### PR TITLE
Fix modal reset

### DIFF
--- a/src/components/CategoryModal.tsx
+++ b/src/components/CategoryModal.tsx
@@ -32,6 +32,8 @@ const CategoryModal: React.FC<CategoryModalProps> = ({
   ];
 
   useEffect(() => {
+    if (!isOpen) return;
+
     if (category) {
       setFormData({
         name: category.name,
@@ -45,7 +47,7 @@ const CategoryModal: React.FC<CategoryModalProps> = ({
         color: '#3B82F6'
       });
     }
-  }, [category]);
+  }, [category, isOpen]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -44,6 +44,8 @@ const TaskModal: React.FC<TaskModalProps> = ({
   ];
 
   useEffect(() => {
+    if (!isOpen) return;
+
     if (task) {
       setFormData({
         title: task.title,
@@ -67,7 +69,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
         recurrencePattern: undefined
       });
     }
-  }, [task, categories, parentTask]);
+  }, [isOpen, task, categories, parentTask]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- ensure new category modal resets when reopened
- ensure new task modal resets when reopened

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f85b3b748832aa11c175417f2b633