### PR TITLE
Add dashboard link to header

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -181,7 +181,9 @@ const Dashboard: React.FC = () => {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-14 sm:h-16">
             <div className="flex items-center space-x-2 sm:space-x-4 min-w-0 flex-1">
-              <h1 className="text-lg sm:text-2xl font-bold text-gray-900 truncate">Task Tracker</h1>
+              <Link to="/" onClick={handleBackToCategories} className="text-lg sm:text-2xl font-bold text-gray-900 truncate">
+                Task Tracker
+              </Link>
               {selectedCategory && (
                 <div className="hidden sm:flex items-center space-x-2">
                   <span className="text-gray-500">/</span>


### PR DESCRIPTION
## Summary
- make `Task Tracker` in the navbar clickable so it links back to `/`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f85fb9154832a87698708942c4094