### PR TITLE
Add overdue task calculation

### DIFF
--- a/src/hooks/useStatistics.ts
+++ b/src/hooks/useStatistics.ts
@@ -25,8 +25,21 @@ export const useStatistics = (): TaskStats => {
     const completedTasks = allTasks.filter(task => task.completed).length;
     const recurringTasks = allTasks.filter(task => task.isRecurring).length;
     
-    // Calculate overdue tasks (for now, just incomplete tasks)
-    const overdueTasks = allTasks.filter(task => !task.completed).length;
+    // Calculate overdue tasks based on due dates
+    const now = new Date();
+    const overdueTasks = allTasks.filter(task => {
+      if (task.completed) return false;
+
+      if (task.isRecurring) {
+        if (!task.nextDue) return false;
+        const nextDueDate = new Date(task.nextDue);
+        const lastCompleted = task.lastCompleted ? new Date(task.lastCompleted) : undefined;
+        return nextDueDate < now && (!lastCompleted || lastCompleted < nextDueDate);
+      }
+
+      if (!task.dueDate) return false;
+      return new Date(task.dueDate) < now;
+    }).length;
 
     // Tasks by priority
     const tasksByPriority = {

--- a/src/hooks/useTaskStore.ts
+++ b/src/hooks/useTaskStore.ts
@@ -22,6 +22,7 @@ export const useTaskStore = () => {
             updatedAt: new Date(task.updatedAt),
             lastCompleted: task.lastCompleted ? new Date(task.lastCompleted) : undefined,
             nextDue: task.nextDue ? new Date(task.nextDue) : undefined,
+            dueDate: task.dueDate ? new Date(task.dueDate) : undefined,
           })));
         }
 
@@ -77,6 +78,7 @@ export const useTaskStore = () => {
       updatedAt: new Date(),
       nextDue: taskData.isRecurring ? calculateNextDue(taskData.recurrencePattern) : undefined,
       lastCompleted: undefined,
+      dueDate: taskData.dueDate ? new Date(taskData.dueDate) : undefined,
     };
     
     if (taskData.parentId) {
@@ -142,12 +144,14 @@ export const useTaskStore = () => {
               updatedAt: new Date(),
               lastCompleted: new Date(),
               nextDue: calculateNextDue(task.recurrencePattern),
+              dueDate: task.dueDate,
             };
           }
           return {
             ...task,
             ...updates,
-            updatedAt: new Date()
+            updatedAt: new Date(),
+            dueDate: updates.dueDate ? new Date(updates.dueDate) : task.dueDate
           };
         }
         if (task.subtasks.length > 0) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,8 @@ export interface Task {
   subtasks: Task[];
   createdAt: Date;
   updatedAt: Date;
+  /** Optional due date for one-time tasks */
+  dueDate?: Date;
   isRecurring: boolean;
   recurrencePattern?: 'daily' | 'weekly' | 'monthly' | 'yearly';
   lastCompleted?: Date;
@@ -33,6 +35,8 @@ export interface TaskFormData {
   color: string;
   categoryId: string;
   parentId?: string;
+  /** Optional due date when creating/editing a task */
+  dueDate?: Date;
   isRecurring: boolean;
   recurrencePattern?: 'daily' | 'weekly' | 'monthly' | 'yearly';
 }


### PR DESCRIPTION
## Summary
- parse optional `dueDate` for tasks
- include `dueDate` field in task data types
- persist `dueDate` on creation and updates
- count overdue tasks using `dueDate`, `nextDue`, and `lastCompleted`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f884c1164832aa1064c3f4a146e8f