### PR TITLE
Enable navigation back to parent tasks

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -44,6 +44,7 @@ const Dashboard: React.FC = () => {
   const [editingCategory, setEditingCategory] = useState<Category | null>(null);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [parentTask, setParentTask] = useState<Task | null>(null);
+  const [taskDetailStack, setTaskDetailStack] = useState<Task[]>([]);
 
   // Filter categories and tasks based on search
   const filteredCategories = categories.filter(category =>
@@ -164,8 +165,23 @@ const Dashboard: React.FC = () => {
   };
 
   const handleViewTaskDetails = (task: Task) => {
+    setTaskDetailStack(prev => (selectedTask ? [...prev, selectedTask] : prev));
     setSelectedTask(task);
     setIsTaskDetailModalOpen(true);
+  };
+
+  const handleTaskDetailBack = () => {
+    setTaskDetailStack(prev => {
+      const stack = [...prev];
+      const parent = stack.pop();
+      if (parent) {
+        setSelectedTask(parent);
+      } else {
+        setIsTaskDetailModalOpen(false);
+        setSelectedTask(null);
+      }
+      return stack;
+    });
   };
 
   const handleBackToCategories = () => {
@@ -467,6 +483,7 @@ const Dashboard: React.FC = () => {
         onClose={() => {
           setIsTaskDetailModalOpen(false);
           setSelectedTask(null);
+          setTaskDetailStack([]);
         }}
         task={selectedTask}
         category={selectedTask ? categories.find(c => c.id === selectedTask.categoryId) || null : null}
@@ -475,6 +492,8 @@ const Dashboard: React.FC = () => {
         onAddSubtask={handleAddSubtask}
         onToggleComplete={handleToggleTaskComplete}
         onViewDetails={handleViewTaskDetails}
+        canGoBack={taskDetailStack.length > 0}
+        onBack={handleTaskDetailBack}
       />
     </div>
   );

--- a/src/components/TaskDetailModal.tsx
+++ b/src/components/TaskDetailModal.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Edit, Plus, Trash2 } from 'lucide-react';
+import { Edit, Plus, Trash2, ArrowLeft } from 'lucide-react';
 import { calculateTaskCompletion, getTaskProgress, getPriorityColor, getPriorityIcon } from '@/utils/taskUtils';
 import TaskCard from './TaskCard';
 
@@ -20,6 +20,9 @@ interface TaskDetailModalProps {
   onAddSubtask: (parentTask: Task) => void;
   onToggleComplete: (taskId: string, completed: boolean) => void;
   onViewDetails: (task: Task) => void;
+  /** Display back button when true and trigger onBack on click */
+  canGoBack?: boolean;
+  onBack?: () => void;
 }
 
 const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
@@ -31,7 +34,9 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
   onDelete,
   onAddSubtask,
   onToggleComplete,
-  onViewDetails
+  onViewDetails,
+  canGoBack,
+  onBack
 }) => {
   if (!task) return null;
 
@@ -53,6 +58,11 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
         <DialogHeader>
           <div className="flex items-start justify-between">
             <div className="flex items-start space-x-3 flex-1">
+              {canGoBack && (
+                <Button variant="ghost" size="icon" onClick={onBack} className="mt-1">
+                  <ArrowLeft className="h-4 w-4" />
+                </Button>
+              )}
               {task.subtasks.length === 0 && (
                 <input
                   type="checkbox"


### PR DESCRIPTION
## Summary
- add arrow button in TaskDetailModal to go up to the parent
- track task detail stack in Dashboard to allow navigating back

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f88d33d40832a9d55e41271c33c21