### PR TITLE
Filter dashboard stats by selected category

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -115,9 +115,16 @@ const Dashboard: React.FC = () => {
   }, [filteredTasks, sortCriteria]);
 
   // Statistics
-  const totalTasks = tasks.length;
-  const totalCategories = categories.length;
-  const completedTasks = tasks.filter(task => {
+  const totalTasks = selectedCategory
+    ? getTasksByCategory(selectedCategory.id).length
+    : tasks.length;
+
+  const totalCategories = selectedCategory ? 1 : categories.length;
+
+  const completedTasks = (selectedCategory
+    ? getTasksByCategory(selectedCategory.id)
+    : tasks
+  ).filter(task => {
     const hasSubtasks = task.subtasks.length > 0;
     if (hasSubtasks) {
       return task.subtasks.every(subtask => subtask.completed);


### PR DESCRIPTION
## Summary
- show dashboard stats for all tasks on the dashboard
- when a category is selected display stats for tasks within that category

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8bf82874832abfe1f0e2c2cc9a04