### PR TITLE
Add extended task statistics

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -132,6 +132,8 @@ const Dashboard: React.FC = () => {
     return task.completed;
   }).length;
 
+  const pendingTasks = totalTasks - completedTasks;
+
   // Handlers
   const handleCreateTask = (taskData: TaskFormData) => {
     addTask({
@@ -400,7 +402,7 @@ const Dashboard: React.FC = () => {
 
       {/* Statistics */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-6">
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6 mb-6 sm:mb-8">
+        <div className="grid grid-cols-1 sm:grid-cols-4 gap-4 sm:gap-6 mb-6 sm:mb-8">
           <Card>
             <CardHeader className="pb-2">
               <CardTitle className="text-sm font-medium text-gray-600">Gesamt Tasks</CardTitle>
@@ -418,6 +420,14 @@ const Dashboard: React.FC = () => {
               <div className="text-xs sm:text-sm text-gray-500">
                 {totalTasks > 0 ? Math.round((completedTasks / totalTasks) * 100) : 0}% erledigt
               </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-gray-600">Offen</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-xl sm:text-2xl font-bold text-yellow-600">{pendingTasks}</div>
             </CardContent>
           </Card>
           <Card>

--- a/src/hooks/useStatistics.ts
+++ b/src/hooks/useStatistics.ts
@@ -23,7 +23,17 @@ export const useStatistics = (): TaskStats => {
 
     const totalTasks = allTasks.length;
     const completedTasks = allTasks.filter(task => task.completed).length;
+    const pendingTasks = allTasks.filter(task => !task.completed).length;
     const recurringTasks = allTasks.filter(task => task.isRecurring).length;
+
+    const weekAgo = new Date();
+    weekAgo.setDate(weekAgo.getDate() - 7);
+    const tasksCompletedLast7Days = allTasks.filter(task => {
+      if (!task.completed) return false;
+      const updated = task.lastCompleted || task.updatedAt;
+      return new Date(updated) >= weekAgo;
+    }).length;
+    const tasksCreatedLast7Days = allTasks.filter(task => new Date(task.createdAt) >= weekAgo).length;
     
 
     const today = new Date();
@@ -76,6 +86,9 @@ export const useStatistics = (): TaskStats => {
     return {
       totalTasks,
       completedTasks,
+      pendingTasks,
+      tasksCompletedLast7Days,
+      tasksCreatedLast7Days,
       overdueTasks,
       tasksByPriority,
       tasksByCategory,

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -46,7 +46,7 @@ const Statistics = () => {
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-8">
         {/* Overview Cards */}
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-6 mb-6 sm:mb-8">
+        <div className="grid grid-cols-2 lg:grid-cols-6 gap-3 sm:gap-6 mb-6 sm:mb-8">
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-xs sm:text-sm font-medium">Gesamt Tasks</CardTitle>
@@ -56,7 +56,7 @@ const Statistics = () => {
               <div className="text-lg sm:text-2xl font-bold">{stats.totalTasks}</div>
             </CardContent>
           </Card>
-          
+
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-xs sm:text-sm font-medium">Abgeschlossen</CardTitle>
@@ -67,7 +67,17 @@ const Statistics = () => {
               <p className="text-xs text-muted-foreground">{completionRate}% der Tasks</p>
             </CardContent>
           </Card>
-          
+
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-xs sm:text-sm font-medium">Offen</CardTitle>
+              <Clock className="h-4 w-4 text-yellow-600" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-lg sm:text-2xl font-bold text-yellow-600">{stats.pendingTasks}</div>
+            </CardContent>
+          </Card>
+
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-xs sm:text-sm font-medium">Überfällig</CardTitle>
@@ -77,7 +87,17 @@ const Statistics = () => {
               <div className="text-lg sm:text-2xl font-bold text-red-600">{stats.overdueTasks}</div>
             </CardContent>
           </Card>
-          
+
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-xs sm:text-sm font-medium">Erledigt 7 Tage</CardTitle>
+              <CheckCircle className="h-4 w-4 text-green-600" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-lg sm:text-2xl font-bold">{stats.tasksCompletedLast7Days}</div>
+            </CardContent>
+          </Card>
+
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-xs sm:text-sm font-medium">Wiederkehrend</CardTitle>
@@ -85,6 +105,16 @@ const Statistics = () => {
             </CardHeader>
             <CardContent>
               <div className="text-lg sm:text-2xl font-bold text-blue-600">{stats.recurringTasks}</div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-xs sm:text-sm font-medium">Erstellt 7 Tage</CardTitle>
+              <Target className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-lg sm:text-2xl font-bold">{stats.tasksCreatedLast7Days}</div>
             </CardContent>
           </Card>
         </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,6 +53,9 @@ export interface CategoryFormData {
 export interface TaskStats {
   totalTasks: number;
   completedTasks: number;
+  pendingTasks: number;
+  tasksCompletedLast7Days: number;
+  tasksCreatedLast7Days: number;
   overdueTasks: number;
   tasksByPriority: {
     high: number;


### PR DESCRIPTION
## Summary
- include open and recent tasks in statistics
- show open task count on dashboard
- calculate new metrics in stats hook

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8d279eac832aa35e4f30de034cff