### PR TITLE
Fix recurrence badge layout

### DIFF
--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -77,9 +77,16 @@ const TaskCard: React.FC<TaskCardProps> = ({
                   style={{ backgroundColor: task.color }}
                 />
                 {task.isRecurring && (
-                  <Badge variant="outline" className="text-xs flex-shrink-0">
-                    <span className="hidden sm:inline">Wiederholt </span>
-                    {task.recurrencePattern}
+                  <Badge
+                    variant="outline"
+                    className="text-xs flex-shrink-0 text-center leading-snug"
+                  >
+                    <span className="hidden sm:block">
+                      Wiederholt
+                      <br />
+                      {task.recurrencePattern}
+                    </span>
+                    <span className="sm:hidden">{task.recurrencePattern}</span>
                   </Badge>
                 )}
                 {task.dueDate && (


### PR DESCRIPTION
## Summary
- fix layout of recurrence badge to show line break between "Wiederholt" and recurrence pattern

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840037c5460832a80259ef1c46a81aa