### PR TITLE
Add undo for category deletion

### DIFF
--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -76,6 +76,7 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
                   e.stopPropagation();
                   onDelete(category.id);
                 }}
+                title="Löschen (rückgängig möglich)"
                 className="h-8 w-8 p-0 text-red-600 hover:text-red-800"
               >
                 <Trash2 className="h-4 w-4" />
@@ -102,12 +103,12 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
                   Bearbeiten
                 </DropdownMenuItem>
                 {category.id !== 'default' && (
-                  <DropdownMenuItem 
+                  <DropdownMenuItem
                     onClick={() => onDelete(category.id)}
                     className="text-red-600"
                   >
                     <Trash2 className="h-4 w-4 mr-2" />
-                    Löschen
+                    Löschen (Undo möglich)
                   </DropdownMenuItem>
                 )}
               </DropdownMenuContent>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -21,6 +21,7 @@ import TaskModal from './TaskModal';
 import CategoryModal from './CategoryModal';
 import TaskDetailModal from './TaskDetailModal';
 import { useToast } from '@/hooks/use-toast';
+import { ToastAction } from '@/components/ui/toast';
 import {
   DragDropContext,
   Droppable,
@@ -41,7 +42,8 @@ const Dashboard: React.FC = () => {
     getTasksByCategory,
     findTaskById,
     reorderCategories,
-    reorderTasks
+    reorderTasks,
+    undoDeleteCategory
   } = useTaskStore();
 
   const { toast } = useToast();
@@ -234,11 +236,24 @@ const Dashboard: React.FC = () => {
 
   const handleDeleteCategory = (categoryId: string) => {
     const category = categories.find(c => c.id === categoryId);
-    if (category && window.confirm(`Sind Sie sicher, dass Sie "${category.name}" löschen möchten?`)) {
+    if (!category) return;
+
+    const nonDefaultCount = categories.filter(c => c.id !== 'default').length;
+    const confirmText =
+      nonDefaultCount === 1 && category.id !== 'default'
+        ? `Sie sind dabei, die letzte verbleibende Kategorie zu löschen. "${category.name}" wirklich löschen?`
+        : `Sind Sie sicher, dass Sie "${category.name}" löschen möchten?`;
+
+    if (window.confirm(confirmText)) {
       deleteCategory(categoryId);
       toast({
         title: 'Kategorie gelöscht',
-        description: 'Die Kategorie wurde erfolgreich gelöscht.'
+        description: 'Die Kategorie wurde erfolgreich gelöscht.',
+        action: (
+          <ToastAction altText="Undo" onClick={() => undoDeleteCategory(categoryId)}>
+            Rückgängig
+          </ToastAction>
+        )
       });
     }
   };


### PR DESCRIPTION
## Summary
- add recentlyDeletedCategories and undoDeleteCategory in task store
- recreate default category if all removed
- show undo toast on category deletion and warn when last non-default
- note undo option in CategoryCard actions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841f30f90f8832a8227c9820d9d2c19