### PR TITLE
Add theme toggle

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -21,6 +21,7 @@ import TaskModal from './TaskModal';
 import CategoryModal from './CategoryModal';
 import TaskDetailModal from './TaskDetailModal';
 import { useToast } from '@/hooks/use-toast';
+import ThemeToggle from './ThemeToggle';
 import {
   DragDropContext,
   Droppable,
@@ -334,6 +335,8 @@ const Dashboard: React.FC = () => {
             {/* Desktop Actions */}
             <div className="hidden sm:flex items-center space-x-4">
 
+              <ThemeToggle />
+
               {/* Statistics Button */}
               <Link to="/statistics">
                 <Button variant="outline" size="sm">
@@ -371,6 +374,7 @@ const Dashboard: React.FC = () => {
 
               {/* Mobile Actions */}
               <div className="flex flex-wrap gap-2">
+              <ThemeToggle className="flex-1" />
               <Link to="/statistics" className="flex-1">
                 <Button variant="outline" size="sm" className="w-full">
                   <BarChart3 className="h-4 w-4 mr-2" />

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react'
+import { useTheme } from 'next-themes'
+import { Button } from '@/components/ui/button'
+import { Sun, Moon } from 'lucide-react'
+
+type Props = {
+  className?: string
+}
+
+const ThemeToggle = ({ className }: Props) => {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) return null
+
+  const toggle = () => {
+    setTheme(theme === 'dark' ? 'light' : 'dark')
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggle}
+      aria-label="Toggle Theme"
+      className={className}
+    >
+      {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </Button>
+  )
+}
+
+export default ThemeToggle

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { ThemeProvider } from 'next-themes'
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <ThemeProvider attribute="class" defaultTheme="light">
+    <App />
+  </ThemeProvider>
+)


### PR DESCRIPTION
## Summary
- integrate ThemeProvider from next-themes
- add ThemeToggle component
- expose toggle button in dashboard header for desktop and mobile

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841f61d74f8832a8e86898a04b19982