### PR TITLE
Add Kanban board

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import Statistics from "./pages/Statistics";
 import CalendarPage from "./pages/Calendar";
+import Kanban from "./pages/Kanban";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -21,6 +22,7 @@ const App = () => (
           <Route path="/" element={<Index />} />
           <Route path="/statistics" element={<Statistics />} />
           <Route path="/calendar" element={<CalendarPage />} />
+          <Route path="/kanban" element={<Kanban />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/hooks/useTaskStore.ts
+++ b/src/hooks/useTaskStore.ts
@@ -25,7 +25,8 @@ export const useTaskStore = () => {
               lastCompleted: task.lastCompleted ? new Date(task.lastCompleted) : undefined,
               nextDue: task.nextDue ? new Date(task.nextDue) : undefined,
               order: typeof task.order === 'number' ? task.order : idx,
-              dueDate: task.dueDate ? new Date(task.dueDate) : undefined
+              completed: task.completed ?? false,
+              status: task.status ?? (task.completed ? 'done' : 'todo')
             }))
           );
         }
@@ -77,18 +78,19 @@ export const useTaskStore = () => {
   }, [tasks, categories]);
 
   const addTask = (taskData: Omit<Task, 'id' | 'createdAt' | 'updatedAt' | 'subtasks'>) => {
-    const newTask: Task = {
-      ...taskData,
-      id: Date.now().toString(),
-      subtasks: [],
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      dueDate: taskData.dueDate,
-      nextDue: taskData.isRecurring ? calculateNextDue(taskData.recurrencePattern) : undefined,
-      lastCompleted: undefined,
-      dueDate: taskData.dueDate ? new Date(taskData.dueDate) : undefined,
-      order: 0
-    };
+  const newTask: Task = {
+    ...taskData,
+    id: Date.now().toString(),
+    subtasks: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    dueDate: taskData.dueDate,
+    nextDue: taskData.isRecurring ? calculateNextDue(taskData.recurrencePattern) : undefined,
+    lastCompleted: undefined,
+    dueDate: taskData.dueDate ? new Date(taskData.dueDate) : undefined,
+    status: 'todo',
+    order: 0
+  };
     
     if (taskData.parentId) {
       // Add as subtask

--- a/src/pages/Kanban.tsx
+++ b/src/pages/Kanban.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useTaskStore } from '@/hooks/useTaskStore';
+import TaskCard from '@/components/TaskCard';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft } from 'lucide-react';
+import {
+  DragDropContext,
+  Droppable,
+  Draggable,
+  DropResult
+} from 'react-beautiful-dnd';
+
+const Kanban: React.FC = () => {
+  const { tasks, updateTask } = useTaskStore();
+
+  const onDragEnd = (result: DropResult) => {
+    if (!result.destination) return;
+    const { draggableId, destination, source } = result;
+    const newStatus = destination.droppableId as 'todo' | 'inprogress' | 'done';
+    if (destination.droppableId !== source.droppableId) {
+      updateTask(draggableId, {
+        status: newStatus,
+        completed: newStatus === 'done'
+      });
+    }
+  };
+
+  const tasksByStatus: Record<'todo' | 'inprogress' | 'done', typeof tasks> = {
+    todo: [],
+    inprogress: [],
+    done: []
+  };
+
+  tasks
+    .filter(t => !t.parentId)
+    .forEach(t => {
+      const status = t.status as 'todo' | 'inprogress' | 'done';
+      tasksByStatus[status].push(t);
+    });
+
+  const statuses: Array<'todo' | 'inprogress' | 'done'> = [
+    'todo',
+    'inprogress',
+    'done'
+  ];
+
+  const labels: Record<'todo' | 'inprogress' | 'done', string> = {
+    todo: 'To Do',
+    inprogress: 'In Bearbeitung',
+    done: 'Erledigt'
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white shadow-sm border-b sticky top-0 z-40">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between h-14 sm:h-16">
+            <div className="flex items-center space-x-2 sm:space-x-4">
+              <Link to="/">
+                <Button variant="ghost" size="sm">
+                  <ArrowLeft className="h-4 w-4 mr-2" />
+                  <span className="hidden sm:inline">Zurück</span>
+                </Button>
+              </Link>
+              <h1 className="text-lg sm:text-2xl font-bold text-gray-900">Kanban</h1>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-8">
+        <DragDropContext onDragEnd={onDragEnd}>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {statuses.map(status => (
+              <Droppable droppableId={status} key={status}>
+                {provided => (
+                  <div
+                    ref={provided.innerRef}
+                    {...provided.droppableProps}
+                    className="bg-gray-100 rounded-md p-2 space-y-2 min-h-[200px]"
+                  >
+                    <h2 className="text-base font-semibold mb-2">
+                      {labels[status]}
+                    </h2>
+                    {tasksByStatus[status].map((task, index) => (
+                      <Draggable
+                        key={task.id}
+                        draggableId={task.id}
+                        index={index}
+                      >
+                        {prov => (
+                          <div
+                            ref={prov.innerRef}
+                            {...prov.draggableProps}
+                            {...prov.dragHandleProps}
+                          >
+                            <TaskCard
+                              task={task}
+                              onEdit={() => {}}
+                              onDelete={() => {}}
+                              onAddSubtask={() => {}}
+                              onToggleComplete={() => {}}
+                              onViewDetails={() => {}}
+                            />
+                          </div>
+                        )}
+                      </Draggable>
+                    ))}
+                    {provided.placeholder}
+                  </div>
+                )}
+              </Droppable>
+            ))}
+          </div>
+        </DragDropContext>
+      </div>
+    </div>
+  );
+};
+
+export default Kanban;
+

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,8 @@ export interface Task {
   priority: 'low' | 'medium' | 'high';
   color: string;
   completed: boolean;
+  /** Status for kanban workflow */
+  status: 'todo' | 'inprogress' | 'done';
   categoryId: string;
   parentId?: string;
   subtasks: Task[];


### PR DESCRIPTION
## Summary
- add status field to Task type
- keep backward compatibility when loading tasks
- add Kanban page with drag-n-drop columns
- hook `/kanban` route

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841f96efd58832abd9b25f85e3a7e4c