### PR TITLE
Fix tasks loading by enabling API access in dev

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -61,8 +61,20 @@ const server = http.createServer((req, res) => {
   const parsed = parse(req.url, true);
 
   if (parsed.pathname === '/api/data') {
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204, {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET,PUT,OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type',
+      });
+      res.end();
+      return;
+    }
     if (req.method === 'GET') {
-      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      });
       res.end(JSON.stringify(loadData()));
       return;
     }
@@ -73,7 +85,10 @@ const server = http.createServer((req, res) => {
         try {
           const data = JSON.parse(body || '{}');
           saveData(data);
-          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.writeHead(200, {
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*',
+          });
           res.end(JSON.stringify({ status: 'ok' }));
         } catch {
           res.writeHead(400);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,12 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "0.0.0.0",
     port: 8080,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3002',
+        changeOrigin: true,
+      },
+    },
   },
   preview: {
     host: "0.0.0.0",


### PR DESCRIPTION
## Summary
- proxy /api requests to the backend when running Vite dev server
- allow cross-origin requests for the data API

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_684222919cd0832ab6a0738c22dcc962