### PR TITLE
Add search bar and task search

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import SearchBar from "@/components/SearchBar";
 import Index from "./pages/Index";
 import Statistics from "./pages/Statistics";
 import CalendarPage from "./pages/Calendar";
@@ -18,6 +19,7 @@ const App = () => (
       <Toaster />
       <Sonner />
       <BrowserRouter>
+        <SearchBar />
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/statistics" element={<Statistics />} />

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,56 @@
+import React, { useState, useEffect } from 'react';
+import {
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandItem,
+} from '@/components/ui/command';
+import { useTaskStore } from '@/hooks/useTaskStore';
+import { useNavigate } from 'react-router-dom';
+
+const SearchBar: React.FC = () => {
+  const { searchTasks } = useTaskStore();
+  const [open, setOpen] = useState(false);
+  const [term, setTerm] = useState('');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() === 'k' && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        setOpen(prev => !prev);
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+
+  const results = term ? searchTasks(term) : [];
+
+  const handleSelect = (id: string) => {
+    setOpen(false);
+    navigate(`/?task=${id}`); // navigate to dashboard with query
+  };
+
+  return (
+    <CommandDialog open={open} onOpenChange={setOpen}>
+      <CommandInput
+        placeholder="Task suchen..."
+        value={term}
+        onValueChange={setTerm}
+        autoFocus
+      />
+      <CommandList>
+        <CommandEmpty>Keine Ergebnisse.</CommandEmpty>
+        {results.map(task => (
+          <CommandItem key={task.id} onSelect={() => handleSelect(task.id)}>
+            {task.title}
+          </CommandItem>
+        ))}
+      </CommandList>
+    </CommandDialog>
+  );
+};
+
+export default SearchBar;

--- a/src/hooks/useTaskStore.ts
+++ b/src/hooks/useTaskStore.ts
@@ -339,6 +339,23 @@ export const useTaskStore = () => {
     return null;
   };
 
+  const searchTasks = (term: string, list: Task[] = tasks): Task[] => {
+    const lower = term.toLowerCase();
+    const result: Task[] = [];
+    for (const task of list) {
+      if (
+        task.title.toLowerCase().includes(lower) ||
+        task.description.toLowerCase().includes(lower)
+      ) {
+        result.push(task);
+      }
+      if (task.subtasks.length > 0) {
+        result.push(...searchTasks(term, task.subtasks));
+      }
+    }
+    return result;
+  };
+
   return {
     tasks,
     categories,
@@ -352,6 +369,7 @@ export const useTaskStore = () => {
     undoDeleteCategory,
     getTasksByCategory,
     findTaskById,
+    searchTasks,
     reorderCategories,
     reorderTasks
   };


### PR DESCRIPTION
## Summary
- add a `SearchBar` component using shadcn `CommandDialog`
- expose `searchTasks` helper in `useTaskStore` to find tasks recursively
- include search bar globally in `App`

## Testing
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_684227e05160832abc9ff8bc72d42836