### PR TITLE
Implement dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,10 @@
     <meta property="og:type" content="website" />
 
     <meta name="twitter:card" content="summary_large_image" />
+    <script>
+      const theme = localStorage.getItem('theme');
+      if (theme === 'dark') document.documentElement.classList.add('dark');
+    </script>
   </head>
 
   <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ThemeProvider } from "next-themes";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import SearchBar from "@/components/SearchBar";
 import Index from "./pages/Index";
@@ -14,23 +15,25 @@ import NotFound from "./pages/NotFound";
 const queryClient = new QueryClient();
 
 const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <SearchBar />
-        <Routes>
-          <Route path="/" element={<Index />} />
-          <Route path="/statistics" element={<Statistics />} />
-          <Route path="/calendar" element={<CalendarPage />} />
-          <Route path="/kanban" element={<Kanban />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
-    </TooltipProvider>
-  </QueryClientProvider>
+  <ThemeProvider attribute="class" defaultTheme="light" storageKey="theme">
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <Toaster />
+        <Sonner />
+        <BrowserRouter>
+          <SearchBar />
+          <Routes>
+            <Route path="/" element={<Index />} />
+            <Route path="/statistics" element={<Statistics />} />
+            <Route path="/calendar" element={<CalendarPage />} />
+            <Route path="/kanban" element={<Kanban />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  </ThemeProvider>
 );
 
 export default App;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -3,6 +3,7 @@ import React, { useState, useMemo, useEffect } from 'react';
 import { Task, Category, TaskFormData, CategoryFormData } from '@/types';
 import { useTaskStore } from '@/hooks/useTaskStore';
 import { Button } from '@/components/ui/button';
+import ThemeToggle from './ThemeToggle';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -374,13 +375,15 @@ const Dashboard: React.FC = () => {
                 </Button>
               </Link>
 
-              {/* Kanban Button */}
-              <Link to="/kanban">
-                <Button variant="outline" size="sm">
-                  <Columns className="h-4 w-4 mr-2" />
-                  Kanban
-                </Button>
-              </Link>
+            {/* Kanban Button */}
+            <Link to="/kanban">
+              <Button variant="outline" size="sm">
+                <Columns className="h-4 w-4 mr-2" />
+                Kanban
+              </Button>
+            </Link>
+
+            <ThemeToggle />
 
 
               {/* Action Buttons */}
@@ -431,6 +434,8 @@ const Dashboard: React.FC = () => {
                   Kanban
                 </Button>
               </Link>
+
+              <ThemeToggle variant="outline" size="sm" className="flex-1" />
 
 
                 {viewMode === 'categories' ? (

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,37 @@
+import { useTheme } from 'next-themes'
+import { Button } from '@/components/ui/button'
+import { Sun, Moon } from 'lucide-react'
+import { useState, useEffect } from 'react'
+import { cn } from '@/lib/utils'
+
+interface ThemeToggleProps {
+  className?: string
+  variant?: React.ComponentProps<typeof Button>['variant']
+  size?: React.ComponentProps<typeof Button>['size']
+}
+
+const ThemeToggle = ({ className, variant = 'outline', size = 'icon' }: ThemeToggleProps) => {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) return null
+
+  const isDark = theme === 'dark'
+  return (
+    <Button
+      variant={variant}
+      size={size}
+      className={cn(className)}
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+    >
+      {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+      <span className="sr-only">Theme wechseln</span>
+    </Button>
+  )
+}
+
+export default ThemeToggle

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -6,6 +6,7 @@ import { Task } from '@/types';
 import { Calendar } from '@/components/ui/calendar';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import ThemeToggle from '@/components/ThemeToggle';
 
 const CalendarPage = () => {
   const { tasks } = useTaskStore();
@@ -43,6 +44,7 @@ const CalendarPage = () => {
               </Link>
               <h1 className="text-lg sm:text-2xl font-bold text-gray-900">Kalender</h1>
             </div>
+            <ThemeToggle />
           </div>
         </div>
       </header>

--- a/src/pages/Kanban.tsx
+++ b/src/pages/Kanban.tsx
@@ -4,6 +4,7 @@ import { useTaskStore } from '@/hooks/useTaskStore';
 import TaskCard from '@/components/TaskCard';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft } from 'lucide-react';
+import ThemeToggle from '@/components/ThemeToggle';
 import {
   DragDropContext,
   Droppable,
@@ -65,6 +66,7 @@ const Kanban: React.FC = () => {
               </Link>
               <h1 className="text-lg sm:text-2xl font-bold text-gray-900">Kanban</h1>
             </div>
+            <ThemeToggle />
           </div>
         </div>
       </header>

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell, LineChart, Line } from 'recharts';
 import { ArrowLeft, TrendingUp, CheckCircle, Clock, Target } from 'lucide-react';
+import ThemeToggle from '@/components/ThemeToggle';
 
 const Statistics = () => {
   const stats = useStatistics();
@@ -40,6 +41,7 @@ const Statistics = () => {
               </Link>
               <h1 className="text-lg sm:text-2xl font-bold text-gray-900">Statistiken</h1>
             </div>
+            <ThemeToggle />
           </div>
         </div>
       </header>


### PR DESCRIPTION
## Summary
- add a small script to read the theme from localStorage
- wrap the app with `ThemeProvider`
- create a reusable `ThemeToggle` button
- show the theme toggle in all headers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68422924e628832a812b4d97f189ef6d