### PR TITLE
Fix kanban done status

### DIFF
--- a/src/utils/taskUtils.ts
+++ b/src/utils/taskUtils.ts
@@ -5,7 +5,11 @@ export const calculateTaskCompletion = (task: Task): boolean => {
   if (task.subtasks.length === 0) {
     return task.completed;
   }
-  
+
+  if (task.completed) {
+    return true;
+  }
+
   return task.subtasks.every(subtask => calculateTaskCompletion(subtask));
 };
 


### PR DESCRIPTION
## Summary
- fix `calculateTaskCompletion` to respect explicit completion

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684329799dd0832a93916a8397e593e1