### PR TITLE
Add notes feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ npm start    # startet die gebaute App auf Port 3002
 - Aufgaben anlegen, bearbeiten und in Kategorien sortieren
 - Unteraufgaben, Prioritäten und Wiederholungen
 - Kalenderansicht und Statistikseite
+- Eigene Notizen mit Farbe und Drag & Drop sortierbar
 - Speicherung der Daten auf dem lokalen Server
 
 ## Verwendung
@@ -70,5 +71,6 @@ npm start    # startet die gebaute App auf Port 3002
 3. Tasks lassen sich per Drag & Drop umsortieren oder in Unteraufgaben aufteilen.
 4. Über das Suchfeld und die Filter sortierst und findest du Aufgaben nach Priorität oder Farbe.
 5. Die Seiten **Kalender** und **Statistiken** bieten dir einen Überblick über anstehende Termine und erledigte Tasks.
+6. Unter **Notizen** kannst du unabhängige Notizen verwalten und per Drag & Drop sortieren.
 
 Viel Spaß beim Ausprobieren!

--- a/server/index.js
+++ b/server/index.js
@@ -24,7 +24,7 @@ function loadData() {
     const raw = fs.readFileSync(DATA_FILE, 'utf8');
     return JSON.parse(raw, dateReviver);
   } catch {
-    return { tasks: [], categories: [] };
+    return { tasks: [], categories: [], notes: [] };
   }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Index from "./pages/Index";
 import Statistics from "./pages/Statistics";
 import CalendarPage from "./pages/Calendar";
 import Kanban from "./pages/Kanban";
+import NotesPage from "./pages/Notes";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -23,6 +24,7 @@ const App = () => (
           <Route path="/statistics" element={<Statistics />} />
           <Route path="/calendar" element={<CalendarPage />} />
           <Route path="/kanban" element={<Kanban />} />
+          <Route path="/notes" element={<NotesPage />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -382,6 +382,14 @@ const Dashboard: React.FC = () => {
                 </Button>
               </Link>
 
+              {/* Notes Button */}
+              <Link to="/notes">
+                <Button variant="outline" size="sm">
+                  <List className="h-4 w-4 mr-2" />
+                  Notizen
+                </Button>
+              </Link>
+
 
               {/* Action Buttons */}
               {viewMode === 'categories' ? (
@@ -429,6 +437,13 @@ const Dashboard: React.FC = () => {
                 <Button variant="outline" size="sm" className="w-full">
                   <Columns className="h-4 w-4 mr-2" />
                   Kanban
+                </Button>
+              </Link>
+
+              <Link to="/notes" className="flex-1">
+                <Button variant="outline" size="sm" className="w-full">
+                  <List className="h-4 w-4 mr-2" />
+                  Notizen
                 </Button>
               </Link>
 

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Note } from '@/types';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface NoteCardProps {
+  note: Note;
+  onClick: () => void;
+}
+
+const NoteCard: React.FC<NoteCardProps> = ({ note, onClick }) => {
+  return (
+    <Card
+      className="cursor-pointer hover:shadow-md transition-all"
+      onClick={onClick}
+    >
+      <CardHeader className="pb-2 flex items-center space-x-2">
+        <div
+          className="w-4 h-4 rounded-full flex-shrink-0"
+          style={{ backgroundColor: note.color }}
+        />
+        <CardTitle className="text-base font-medium truncate">
+          {note.title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-gray-600 line-clamp-3">
+          {note.text}
+        </p>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default NoteCard;

--- a/src/components/NoteModal.tsx
+++ b/src/components/NoteModal.tsx
@@ -1,0 +1,103 @@
+import React, { useState, useEffect } from 'react';
+import { Note } from '@/types';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+
+interface NoteModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (data: Omit<Note, 'id' | 'createdAt' | 'updatedAt' | 'order'>) => void;
+  note?: Note;
+}
+
+const NoteModal: React.FC<NoteModalProps> = ({ isOpen, onClose, onSave, note }) => {
+  const [formData, setFormData] = useState({
+    title: '',
+    text: '',
+    color: '#F59E0B'
+  });
+
+  const colorOptions = [
+    '#3B82F6', '#EF4444', '#10B981', '#F59E0B',
+    '#8B5CF6', '#F97316', '#06B6D4', '#84CC16'
+  ];
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (note) {
+      setFormData({ title: note.title, text: note.text, color: note.color });
+    } else {
+      setFormData({ title: '', text: '', color: '#F59E0B' });
+    }
+  }, [isOpen, note]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (formData.title.trim()) {
+      onSave(formData);
+      onClose();
+    }
+  };
+
+  const handleChange = (field: 'title' | 'text' | 'color', value: string) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{note ? 'Notiz bearbeiten' : 'Neue Notiz'}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <Label htmlFor="title">Titel *</Label>
+            <Input
+              id="title"
+              value={formData.title}
+              onChange={e => handleChange('title', e.target.value)}
+              required
+              autoFocus
+            />
+          </div>
+          <div>
+            <Label htmlFor="text">Text</Label>
+            <Textarea
+              id="text"
+              value={formData.text}
+              onChange={e => handleChange('text', e.target.value)}
+              rows={5}
+            />
+          </div>
+          <div>
+            <Label>Farbe</Label>
+            <div className="flex space-x-2 mt-2">
+              {colorOptions.map(color => (
+                <button
+                  key={color}
+                  type="button"
+                  className={`w-8 h-8 rounded-full border-2 transition-all ${
+                    formData.color === color ? 'border-gray-800 scale-110' : 'border-gray-300 hover:scale-105'
+                  }`}
+                  style={{ backgroundColor: color }}
+                  onClick={() => handleChange('color', color)}
+                />
+              ))}
+            </div>
+          </div>
+          <div className="flex justify-end space-x-2 pt-4">
+            <Button type="button" variant="outline" onClick={onClose}>
+              Abbrechen
+            </Button>
+            <Button type="submit">{note ? 'Speichern' : 'Erstellen'}</Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default NoteModal;

--- a/src/pages/Notes.tsx
+++ b/src/pages/Notes.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowLeft, Plus } from 'lucide-react';
+import { useTaskStore } from '@/hooks/useTaskStore';
+import NoteModal from '@/components/NoteModal';
+import NoteCard from '@/components/NoteCard';
+import { Button } from '@/components/ui/button';
+import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
+
+const NotesPage = () => {
+  const { notes, addNote, updateNote, reorderNotes } = useTaskStore();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingNote, setEditingNote] = useState<null | number>(null);
+
+  const handleSave = (data: { title: string; text: string; color: string }) => {
+    if (editingNote !== null) {
+      const note = notes[editingNote];
+      updateNote(note.id, data);
+      setEditingNote(null);
+    } else {
+      addNote(data);
+    }
+  };
+
+  const onDragEnd = (result: DropResult) => {
+    if (!result.destination) return;
+    reorderNotes(result.source.index, result.destination.index);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white shadow-sm border-b sticky top-0 z-40">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between h-14 sm:h-16">
+            <div className="flex items-center space-x-2 sm:space-x-4">
+              <Link to="/">
+                <Button variant="ghost" size="sm">
+                  <ArrowLeft className="h-4 w-4 mr-2" />
+                  <span className="hidden sm:inline">Zurück</span>
+                </Button>
+              </Link>
+              <h1 className="text-lg sm:text-2xl font-bold text-gray-900">Notizen</h1>
+            </div>
+            <Button size="sm" onClick={() => setIsModalOpen(true)}>
+              <Plus className="h-4 w-4 mr-2" /> Neue Notiz
+            </Button>
+          </div>
+        </div>
+      </header>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-8">
+        {notes.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Keine Notizen vorhanden.</p>
+        ) : (
+          <DragDropContext onDragEnd={onDragEnd}>
+            <Droppable droppableId="notes" direction="horizontal">
+              {provided => (
+                <div
+                  className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4"
+                  ref={provided.innerRef}
+                  {...provided.droppableProps}
+                >
+                  {notes.map((note, index) => (
+                    <Draggable key={note.id} draggableId={note.id} index={index}>
+                      {prov => (
+                        <div
+                          ref={prov.innerRef}
+                          {...prov.draggableProps}
+                          {...prov.dragHandleProps}
+                        >
+                          <NoteCard
+                            note={note}
+                            onClick={() => {
+                              setEditingNote(index);
+                              setIsModalOpen(true);
+                            }}
+                          />
+                        </div>
+                      )}
+                    </Draggable>
+                  ))}
+                  {provided.placeholder}
+                </div>
+              )}
+            </Droppable>
+          </DragDropContext>
+        )}
+      </div>
+      <NoteModal
+        isOpen={isModalOpen}
+        onClose={() => {
+          setIsModalOpen(false);
+          setEditingNote(null);
+        }}
+        onSave={handleSave}
+        note={editingNote !== null ? notes[editingNote] : undefined}
+      />
+    </div>
+  );
+};
+
+export default NotesPage;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -56,6 +56,17 @@ export interface CategoryFormData {
   color: string;
 }
 
+export interface Note {
+  id: string;
+  title: string;
+  text: string;
+  color: string;
+  createdAt: Date;
+  updatedAt: Date;
+  /** Sort order within the notes list */
+  order: number;
+}
+
 export interface TaskStats {
   totalTasks: number;
   completedTasks: number;


### PR DESCRIPTION
## Summary
- introduce Note type
- support storing notes on the server
- extend data store to load/save notes and provide CRUD helpers
- add NoteModal and NoteCard components
- implement /notes page with drag & drop sorting
- link new page from dashboard and router
- document notes feature in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6843335656cc832a85a3c60d6aa4a436