### PR TITLE
Unify navbar across pages

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
+import { Menu, BarChart3, Calendar as CalendarIcon, Columns } from 'lucide-react'
+
+interface NavbarProps {
+  title?: string
+}
+
+const Navbar: React.FC<NavbarProps> = ({ title }) => {
+  const [showMobileMenu, setShowMobileMenu] = React.useState(false)
+  return (
+    <header className="bg-white shadow-sm border-b sticky top-0 z-40">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between h-14 sm:h-16">
+          <div className="flex items-center space-x-2 sm:space-x-4">
+            <Link to="/" className="text-lg sm:text-2xl font-bold text-gray-900">
+              Task Tracker
+            </Link>
+            {title && (
+              <span className="hidden sm:inline text-gray-500">/ {title}</span>
+            )}
+          </div>
+          <div className="sm:hidden">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowMobileMenu(!showMobileMenu)}
+            >
+              <Menu className="h-5 w-5" />
+            </Button>
+          </div>
+          <div className="hidden sm:flex items-center space-x-4">
+            <Link to="/statistics">
+              <Button variant="outline" size="sm">
+                <BarChart3 className="h-4 w-4 mr-2" />
+                Statistiken
+              </Button>
+            </Link>
+            <Link to="/calendar">
+              <Button variant="outline" size="sm">
+                <CalendarIcon className="h-4 w-4 mr-2" />
+                Kalender
+              </Button>
+            </Link>
+            <Link to="/kanban">
+              <Button variant="outline" size="sm">
+                <Columns className="h-4 w-4 mr-2" />
+                Kanban
+              </Button>
+            </Link>
+          </div>
+        </div>
+        {showMobileMenu && (
+          <div className="sm:hidden pb-4 space-y-3">
+            <div className="flex flex-wrap gap-2">
+              <Link to="/statistics" className="flex-1">
+                <Button variant="outline" size="sm" className="w-full">
+                  <BarChart3 className="h-4 w-4 mr-2" />
+                  Statistiken
+                </Button>
+              </Link>
+              <Link to="/calendar" className="flex-1">
+                <Button variant="outline" size="sm" className="w-full">
+                  <CalendarIcon className="h-4 w-4 mr-2" />
+                  Kalender
+                </Button>
+              </Link>
+              <Link to="/kanban" className="flex-1">
+                <Button variant="outline" size="sm" className="w-full">
+                  <Columns className="h-4 w-4 mr-2" />
+                  Kanban
+                </Button>
+              </Link>
+            </div>
+          </div>
+        )}
+      </div>
+    </header>
+  )
+}
+
+export default Navbar

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,11 +1,9 @@
 import React, { useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
-import { ArrowLeft } from 'lucide-react';
 import { useTaskStore } from '@/hooks/useTaskStore';
 import { Task } from '@/types';
 import { Calendar } from '@/components/ui/calendar';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
+import Navbar from '@/components/Navbar';
 
 const CalendarPage = () => {
   const { tasks } = useTaskStore();
@@ -31,21 +29,7 @@ const CalendarPage = () => {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <header className="bg-white shadow-sm border-b sticky top-0 z-40">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-14 sm:h-16">
-            <div className="flex items-center space-x-2 sm:space-x-4">
-              <Link to="/">
-                <Button variant="ghost" size="sm">
-                  <ArrowLeft className="h-4 w-4 mr-2" />
-                  <span className="hidden sm:inline">Zurück</span>
-                </Button>
-              </Link>
-              <h1 className="text-lg sm:text-2xl font-bold text-gray-900">Kalender</h1>
-            </div>
-          </div>
-        </div>
-      </header>
+      <Navbar title="Kalender" />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-8">
         <Calendar
           mode="single"

--- a/src/pages/Kanban.tsx
+++ b/src/pages/Kanban.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { useTaskStore } from '@/hooks/useTaskStore';
 import TaskCard from '@/components/TaskCard';
-import { Button } from '@/components/ui/button';
-import { ArrowLeft } from 'lucide-react';
+import Navbar from '@/components/Navbar';
 import {
   DragDropContext,
   Droppable,
@@ -53,21 +51,7 @@ const Kanban: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <header className="bg-white shadow-sm border-b sticky top-0 z-40">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-14 sm:h-16">
-            <div className="flex items-center space-x-2 sm:space-x-4">
-              <Link to="/">
-                <Button variant="ghost" size="sm">
-                  <ArrowLeft className="h-4 w-4 mr-2" />
-                  <span className="hidden sm:inline">Zurück</span>
-                </Button>
-              </Link>
-              <h1 className="text-lg sm:text-2xl font-bold text-gray-900">Kanban</h1>
-            </div>
-          </div>
-        </div>
-      </header>
+      <Navbar title="Kanban" />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-8">
         <DragDropContext onDragEnd={onDragEnd}>

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -1,11 +1,10 @@
 
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { useStatistics } from '@/hooks/useStatistics';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell, LineChart, Line } from 'recharts';
-import { ArrowLeft, TrendingUp, CheckCircle, Clock, Target } from 'lucide-react';
+import { TrendingUp, CheckCircle, Clock, Target } from 'lucide-react';
+import Navbar from '@/components/Navbar';
 
 const Statistics = () => {
   const stats = useStatistics();
@@ -28,21 +27,7 @@ const Statistics = () => {
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
-      <header className="bg-white shadow-sm border-b sticky top-0 z-40">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-14 sm:h-16">
-            <div className="flex items-center space-x-2 sm:space-x-4">
-              <Link to="/">
-                <Button variant="ghost" size="sm">
-                  <ArrowLeft className="h-4 w-4 mr-2" />
-                  <span className="hidden sm:inline">Zurück</span>
-                </Button>
-              </Link>
-              <h1 className="text-lg sm:text-2xl font-bold text-gray-900">Statistiken</h1>
-            </div>
-          </div>
-        </div>
-      </header>
+      <Navbar title="Statistiken" />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-8">
         {/* Overview Cards */}


### PR DESCRIPTION
## Summary
- add reusable `Navbar` component
- use `Navbar` in Kanban, Calendar and Statistics pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68432f0b9720832a9131540fcee8530d