### PR TITLE
Update Kanban view to show individual tasks

### DIFF
--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -17,6 +17,10 @@ interface TaskCardProps {
   onToggleComplete: (taskId: string, completed: boolean) => void;
   onViewDetails: (task: Task) => void;
   depth?: number;
+  /** Titles of all parent tasks from root to immediate parent */
+  parentPathTitles?: string[];
+  /** Whether to render subtasks recursively */
+  showSubtasks?: boolean;
 }
 
 const TaskCard: React.FC<TaskCardProps> = ({
@@ -26,7 +30,9 @@ const TaskCard: React.FC<TaskCardProps> = ({
   onAddSubtask,
   onToggleComplete,
   onViewDetails,
-  depth = 0
+  depth = 0,
+  parentPathTitles = [],
+  showSubtasks = true
 }) => {
   const isCompleted = calculateTaskCompletion(task);
   const progress = getTaskProgress(task);
@@ -59,7 +65,7 @@ const TaskCard: React.FC<TaskCardProps> = ({
               />
             )}
             <div className="flex-1 min-w-0">
-              <CardTitle 
+              <CardTitle
                 className={`text-base sm:text-lg font-semibold cursor-pointer hover:text-blue-600 transition-colors ${
                   isCompleted ? 'line-through text-gray-500' : ''
                 } break-words`}
@@ -67,6 +73,11 @@ const TaskCard: React.FC<TaskCardProps> = ({
               >
                 {task.title}
               </CardTitle>
+              {parentPathTitles.length > 0 && (
+                <div className="text-xs text-gray-500 italic mt-1 break-words">
+                  {parentPathTitles.join(' > ')}
+                </div>
+              )}
               <div className="flex items-center space-x-2 mt-2 flex-wrap gap-1">
                 <Badge className={`text-xs px-2 py-1 border ${priorityClasses} flex-shrink-0`}>
                   <span className="hidden sm:inline">{priorityIcon} </span>
@@ -170,13 +181,13 @@ const TaskCard: React.FC<TaskCardProps> = ({
         </div>
       </CardHeader>
       
-      {(task.description || task.subtasks.length > 0) && (
+      {(task.description || (showSubtasks && task.subtasks.length > 0)) && (
         <CardContent className="pt-0">
           {task.description && (
             <p className="text-sm text-gray-600 mb-3 break-words">{task.description}</p>
           )}
-          
-          {task.subtasks.length > 0 && (
+
+          {showSubtasks && task.subtasks.length > 0 && (
             <div className="space-y-3">
               <div className="flex items-center justify-between">
                 <span className="text-xs sm:text-sm font-medium text-gray-700">
@@ -199,6 +210,7 @@ const TaskCard: React.FC<TaskCardProps> = ({
                     onToggleComplete={onToggleComplete}
                     onViewDetails={onViewDetails}
                     depth={depth + 1}
+                    showSubtasks={showSubtasks}
                   />
                 ))}
               </div>

--- a/src/pages/Kanban.tsx
+++ b/src/pages/Kanban.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTaskStore } from '@/hooks/useTaskStore';
 import TaskCard from '@/components/TaskCard';
 import Navbar from '@/components/Navbar';
+import { flattenTasks, FlattenedTask } from '@/utils/taskUtils';
 import {
   DragDropContext,
   Droppable,
@@ -24,18 +25,18 @@ const Kanban: React.FC = () => {
     }
   };
 
-  const tasksByStatus: Record<'todo' | 'inprogress' | 'done', typeof tasks> = {
+  const flattened = flattenTasks(tasks);
+
+  const tasksByStatus: Record<'todo' | 'inprogress' | 'done', FlattenedTask[]> = {
     todo: [],
     inprogress: [],
     done: []
   };
 
-  tasks
-    .filter(t => !t.parentId)
-    .forEach(t => {
-      const status = t.status as 'todo' | 'inprogress' | 'done';
-      tasksByStatus[status].push(t);
-    });
+  flattened.forEach(item => {
+    const status = item.task.status as 'todo' | 'inprogress' | 'done';
+    tasksByStatus[status].push(item);
+  });
 
   const statuses: Array<'todo' | 'inprogress' | 'done'> = [
     'todo',
@@ -67,10 +68,10 @@ const Kanban: React.FC = () => {
                     <h2 className="text-base font-semibold mb-2">
                       {labels[status]}
                     </h2>
-                    {tasksByStatus[status].map((task, index) => (
+                    {tasksByStatus[status].map((item, index) => (
                       <Draggable
-                        key={task.id}
-                        draggableId={task.id}
+                        key={item.task.id}
+                        draggableId={item.task.id}
                         index={index}
                       >
                         {prov => (
@@ -80,7 +81,9 @@ const Kanban: React.FC = () => {
                             {...prov.dragHandleProps}
                           >
                             <TaskCard
-                              task={task}
+                              task={item.task}
+                              parentPathTitles={item.path.map(p => p.title)}
+                              showSubtasks={false}
                               onEdit={() => {}}
                               onDelete={() => {}}
                               onAddSubtask={() => {}}

--- a/src/utils/taskUtils.ts
+++ b/src/utils/taskUtils.ts
@@ -55,3 +55,23 @@ export const getPriorityIcon = (priority: string): string => {
       return '⚪';
   }
 };
+
+export interface FlattenedTask {
+  task: Task;
+  /** Array of parent tasks from root to immediate parent */
+  path: Task[];
+}
+
+export const flattenTasks = (
+  tasks: Task[],
+  parentPath: Task[] = []
+): FlattenedTask[] => {
+  const result: FlattenedTask[] = [];
+  tasks.forEach(t => {
+    result.push({ task: t, path: parentPath });
+    if (t.subtasks.length > 0) {
+      result.push(...flattenTasks(t.subtasks, [...parentPath, t]));
+    }
+  });
+  return result;
+};


### PR DESCRIPTION
## Summary
- expose a utility to flatten the task tree and return parent path information
- extend `TaskCard` to optionally show parent path and disable nested rendering
- render Kanban board using the flattened tasks so each task is draggable by itself

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c5661170832a83c66e927b4115aa