### PR TITLE
Fix lost tasks when switching pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { TaskStoreProvider } from "@/hooks/useTaskStore";
 import Index from "./pages/Index";
 import Statistics from "./pages/Statistics";
 import CalendarPage from "./pages/Calendar";
@@ -16,19 +17,21 @@ const queryClient = new QueryClient();
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          <Route path="/statistics" element={<Statistics />} />
-          <Route path="/calendar" element={<CalendarPage />} />
-          <Route path="/kanban" element={<Kanban />} />
-          <Route path="/notes" element={<NotesPage />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
+      <TaskStoreProvider>
+        <Toaster />
+        <Sonner />
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Index />} />
+            <Route path="/statistics" element={<Statistics />} />
+            <Route path="/calendar" element={<CalendarPage />} />
+            <Route path="/kanban" element={<Kanban />} />
+            <Route path="/notes" element={<NotesPage />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      </TaskStoreProvider>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/src/hooks/useTaskStore.tsx
+++ b/src/hooks/useTaskStore.tsx
@@ -1,9 +1,9 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect, createContext, useContext } from 'react';
 import { Task, Category, Note } from '@/types';
 
 const API_URL = '/api/data';
 
-export const useTaskStore = () => {
+const useTaskStoreImpl = () => {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [notes, setNotes] = useState<Note[]>([]);
@@ -408,4 +408,23 @@ export const useTaskStore = () => {
     deleteNote,
     reorderNotes
   };
+};
+
+type TaskStore = ReturnType<typeof useTaskStoreImpl>;
+
+const TaskStoreContext = createContext<TaskStore | null>(null);
+
+export const TaskStoreProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const store = useTaskStoreImpl();
+  return (
+    <TaskStoreContext.Provider value={store}>{children}</TaskStoreContext.Provider>
+  );
+};
+
+export const useTaskStore = () => {
+  const ctx = useContext(TaskStoreContext);
+  if (!ctx) {
+    throw new Error('useTaskStore must be used within TaskStoreProvider');
+  }
+  return ctx;
 };


### PR DESCRIPTION
## Summary
- provide global TaskStore context to persist tasks across routes
- wrap application in `TaskStoreProvider`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6845d01860c4832aa05f8d78402460d9