### PR TITLE
Enable task actions in Kanban view

### DIFF
--- a/src/pages/Kanban.tsx
+++ b/src/pages/Kanban.tsx
@@ -1,7 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useTaskStore } from '@/hooks/useTaskStore';
 import TaskCard from '@/components/TaskCard';
 import Navbar from '@/components/Navbar';
+import TaskModal from '@/components/TaskModal';
+import TaskDetailModal from '@/components/TaskDetailModal';
+import { useToast } from '@/hooks/use-toast';
+import { Task, TaskFormData } from '@/types';
 import { flattenTasks, FlattenedTask } from '@/utils/taskUtils';
 import {
   DragDropContext,
@@ -11,7 +15,22 @@ import {
 } from 'react-beautiful-dnd';
 
 const Kanban: React.FC = () => {
-  const { tasks, updateTask } = useTaskStore();
+  const {
+    tasks,
+    categories,
+    addTask,
+    updateTask,
+    deleteTask,
+    findTaskById
+  } = useTaskStore();
+  const { toast } = useToast();
+
+  const [isTaskModalOpen, setIsTaskModalOpen] = useState(false);
+  const [isTaskDetailModalOpen, setIsTaskDetailModalOpen] = useState(false);
+  const [editingTask, setEditingTask] = useState<Task | null>(null);
+  const [selectedTask, setSelectedTask] = useState<Task | null>(null);
+  const [parentTask, setParentTask] = useState<Task | null>(null);
+  const [taskDetailStack, setTaskDetailStack] = useState<Task[]>([]);
 
   const onDragEnd = (result: DropResult) => {
     if (!result.destination) return;
@@ -23,6 +42,84 @@ const Kanban: React.FC = () => {
         completed: newStatus === 'done'
       });
     }
+  };
+
+  const handleCreateTask = (taskData: TaskFormData) => {
+    addTask({
+      ...taskData,
+      completed: false
+    });
+    toast({
+      title: 'Task erstellt',
+      description: `"${taskData.title}" wurde erfolgreich erstellt.`
+    });
+    setParentTask(null);
+  };
+
+  const handleUpdateTask = (taskData: TaskFormData) => {
+    if (editingTask) {
+      updateTask(editingTask.id, {
+        ...taskData,
+        completed: editingTask.completed
+      });
+      toast({
+        title: 'Task aktualisiert',
+        description: `"${taskData.title}" wurde erfolgreich aktualisiert.`
+      });
+      setEditingTask(null);
+    }
+  };
+
+  const handleDeleteTask = (taskId: string) => {
+    const task = findTaskById(taskId);
+    if (task && window.confirm(`Sind Sie sicher, dass Sie "${task.title}" löschen möchten?`)) {
+      deleteTask(taskId);
+      toast({
+        title: 'Task gelöscht',
+        description: 'Die Task wurde erfolgreich gelöscht.'
+      });
+    }
+  };
+
+  const handleToggleTaskComplete = (taskId: string, completed: boolean) => {
+    updateTask(taskId, { completed });
+    const task = findTaskById(taskId);
+    toast({
+      title: completed ? 'Task abgeschlossen' : 'Task reaktiviert',
+      description: `"${task?.title}" wurde ${completed ? 'als erledigt markiert' : 'reaktiviert'}.`
+    });
+  };
+
+  const handleAddSubtask = (parent: Task) => {
+    setParentTask(parent);
+    setEditingTask(null);
+    setIsTaskModalOpen(true);
+  };
+
+  const handleEditTask = (task: Task) => {
+    setEditingTask(task);
+    setParentTask(null);
+    setIsTaskModalOpen(true);
+  };
+
+  const handleViewTaskDetails = (task: Task) => {
+    setTaskDetailStack(prev => (selectedTask ? [...prev, selectedTask] : prev));
+    setSelectedTask(task);
+    setIsTaskDetailModalOpen(true);
+  };
+
+  const handleTaskDetailBack = () => {
+    setTaskDetailStack(prev => {
+      const stack = [...prev];
+      const parent = stack.pop();
+      if (parent) {
+        setSelectedTask(parent);
+      } else {
+        setIsTaskDetailModalOpen(false);
+        setSelectedTask(null);
+      }
+      return stack;
+    });
   };
 
   const flattened = flattenTasks(tasks);
@@ -84,11 +181,11 @@ const Kanban: React.FC = () => {
                               task={item.task}
                               parentPathTitles={item.path.map(p => p.title)}
                               showSubtasks={false}
-                              onEdit={() => {}}
-                              onDelete={() => {}}
-                              onAddSubtask={() => {}}
-                              onToggleComplete={() => {}}
-                              onViewDetails={() => {}}
+                              onEdit={handleEditTask}
+                              onDelete={handleDeleteTask}
+                              onAddSubtask={handleAddSubtask}
+                              onToggleComplete={handleToggleTaskComplete}
+                              onViewDetails={handleViewTaskDetails}
                             />
                           </div>
                         )}
@@ -102,6 +199,37 @@ const Kanban: React.FC = () => {
           </div>
         </DragDropContext>
       </div>
+
+      <TaskModal
+        isOpen={isTaskModalOpen}
+        onClose={() => {
+          setIsTaskModalOpen(false);
+          setEditingTask(null);
+          setParentTask(null);
+        }}
+        onSave={editingTask ? handleUpdateTask : handleCreateTask}
+        task={editingTask || undefined}
+        categories={categories}
+        parentTask={parentTask || undefined}
+      />
+
+      <TaskDetailModal
+        isOpen={isTaskDetailModalOpen}
+        onClose={() => {
+          setIsTaskDetailModalOpen(false);
+          setSelectedTask(null);
+          setTaskDetailStack([]);
+        }}
+        task={selectedTask}
+        category={selectedTask ? categories.find(c => c.id === selectedTask.categoryId) || null : null}
+        onEdit={handleEditTask}
+        onDelete={handleDeleteTask}
+        onAddSubtask={handleAddSubtask}
+        onToggleComplete={handleToggleTaskComplete}
+        onViewDetails={handleViewTaskDetails}
+        canGoBack={taskDetailStack.length > 0}
+        onBack={handleTaskDetailBack}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- wire up TaskCard actions in the Kanban board
- include task and detail modals in Kanban view

## Testing
- `npm run lint` *(fails: cannot find package `@eslint/js`)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_684680654720832a87849a3e57ffcd30