### PR TITLE
Add global command palette with shortcuts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,11 +5,14 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { TaskStoreProvider } from "@/hooks/useTaskStore";
+import { SettingsProvider } from "@/hooks/useSettings";
+import CommandPalette from "@/components/CommandPalette";
 import Index from "./pages/Index";
 import Statistics from "./pages/Statistics";
 import CalendarPage from "./pages/Calendar";
 import Kanban from "./pages/Kanban";
 import NotesPage from "./pages/Notes";
+import SettingsPage from "./pages/Settings";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -17,21 +20,25 @@ const queryClient = new QueryClient();
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>
-      <TaskStoreProvider>
-        <Toaster />
-        <Sonner />
-        <BrowserRouter>
-          <Routes>
-            <Route path="/" element={<Index />} />
-            <Route path="/statistics" element={<Statistics />} />
-            <Route path="/calendar" element={<CalendarPage />} />
-            <Route path="/kanban" element={<Kanban />} />
-            <Route path="/notes" element={<NotesPage />} />
-            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-        </BrowserRouter>
-      </TaskStoreProvider>
+      <SettingsProvider>
+        <TaskStoreProvider>
+          <Toaster />
+          <Sonner />
+          <BrowserRouter>
+            <CommandPalette />
+            <Routes>
+              <Route path="/" element={<Index />} />
+              <Route path="/statistics" element={<Statistics />} />
+              <Route path="/calendar" element={<CalendarPage />} />
+              <Route path="/kanban" element={<Kanban />} />
+              <Route path="/notes" element={<NotesPage />} />
+              <Route path="/settings" element={<SettingsPage />} />
+              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </BrowserRouter>
+        </TaskStoreProvider>
+      </SettingsProvider>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react'
+import { CommandDialog, CommandInput } from '@/components/ui/command'
+import { useTaskStore } from '@/hooks/useTaskStore'
+import { useSettings } from '@/hooks/useSettings'
+import { useToast } from '@/hooks/use-toast'
+
+const isMatching = (e: KeyboardEvent, shortcut: string) => {
+  const keys = shortcut.toLowerCase().split('+')
+  const key = keys.pop()!
+  const wanted = {
+    ctrl: keys.includes('ctrl'),
+    shift: keys.includes('shift'),
+    alt: keys.includes('alt'),
+    meta: keys.includes('meta')
+  }
+  if (wanted.ctrl !== e.ctrlKey) return false
+  if (wanted.shift !== e.shiftKey) return false
+  if (wanted.alt !== e.altKey) return false
+  if (wanted.meta !== e.metaKey) return false
+  return e.key.toLowerCase() === key
+}
+
+const CommandPalette: React.FC = () => {
+  const { addTask, addNote } = useTaskStore()
+  const { shortcuts } = useSettings()
+  const { toast } = useToast()
+  const [open, setOpen] = useState(false)
+  const [mode, setMode] = useState<'task' | 'note'>('task')
+  const [value, setValue] = useState('')
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (isMatching(e, shortcuts.openCommand)) {
+        e.preventDefault()
+        setMode('task')
+        setOpen(o => !o)
+      } else if (isMatching(e, shortcuts.newTask)) {
+        e.preventDefault()
+        setMode('task')
+        setOpen(true)
+      } else if (isMatching(e, shortcuts.newNote)) {
+        e.preventDefault()
+        setMode('note')
+        setOpen(true)
+      }
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [shortcuts])
+
+  const create = () => {
+    const title = value.trim()
+    if (!title) return
+    if (mode === 'task') {
+      addTask({
+        title,
+        description: '',
+        priority: 'medium',
+        color: '#3B82F6',
+        categoryId: 'default',
+        isRecurring: false
+      })
+      toast({ description: 'Task erstellt' })
+    } else {
+      addNote({ title, text: '', color: '#F59E0B' })
+      toast({ description: 'Notiz erstellt' })
+    }
+    setValue('')
+    setOpen(false)
+  }
+
+  return (
+    <CommandDialog open={open} onOpenChange={setOpen}>
+      <CommandInput
+        placeholder={mode === 'task' ? 'Task-Titel eingeben...' : 'Notiz-Titel eingeben...'}
+        value={value}
+        onValueChange={setValue}
+        onKeyDown={e => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            create()
+          }
+        }}
+      />
+    </CommandDialog>
+  )
+}
+
+export default CommandPalette

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
-import { Menu, BarChart3, Calendar as CalendarIcon, Columns, LayoutGrid, List } from 'lucide-react'
+import { Menu, BarChart3, Calendar as CalendarIcon, Columns, LayoutGrid, List, Cog } from 'lucide-react'
 
 interface NavbarProps {
   title?: string
@@ -61,6 +61,12 @@ const Navbar: React.FC<NavbarProps> = ({ title }) => {
                 Notizen
               </Button>
             </Link>
+            <Link to="/settings">
+              <Button variant="outline" size="sm">
+                <Cog className="h-4 w-4 mr-2" />
+                Einstellungen
+              </Button>
+            </Link>
           </div>
         </div>
         {showMobileMenu && (
@@ -94,6 +100,12 @@ const Navbar: React.FC<NavbarProps> = ({ title }) => {
                 <Button variant="outline" size="sm" className="w-full">
                   <List className="h-4 w-4 mr-2" />
                   Notizen
+                </Button>
+              </Link>
+              <Link to="/settings" className="flex-1">
+                <Button variant="outline" size="sm" className="w-full">
+                  <Cog className="h-4 w-4 mr-2" />
+                  Einstellungen
                 </Button>
               </Link>
             </div>

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -1,0 +1,47 @@
+import React, { createContext, useContext, useEffect, useState } from 'react'
+
+export type ShortcutKeys = {
+  openCommand: string
+  newTask: string
+  newNote: string
+}
+
+const defaultShortcuts: ShortcutKeys = {
+  openCommand: 'ctrl+k',
+  newTask: 'ctrl+t',
+  newNote: 'ctrl+n'
+}
+
+interface SettingsContextValue {
+  shortcuts: ShortcutKeys
+  updateShortcut: (key: keyof ShortcutKeys, value: string) => void
+}
+
+const SettingsContext = createContext<SettingsContextValue | undefined>(undefined)
+
+export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [shortcuts, setShortcuts] = useState<ShortcutKeys>(() => {
+    const stored = localStorage.getItem('shortcuts')
+    return stored ? { ...defaultShortcuts, ...JSON.parse(stored) } : defaultShortcuts
+  })
+
+  useEffect(() => {
+    localStorage.setItem('shortcuts', JSON.stringify(shortcuts))
+  }, [shortcuts])
+
+  const updateShortcut = (key: keyof ShortcutKeys, value: string) => {
+    setShortcuts(prev => ({ ...prev, [key]: value.toLowerCase() }))
+  }
+
+  return (
+    <SettingsContext.Provider value={{ shortcuts, updateShortcut }}>
+      {children}
+    </SettingsContext.Provider>
+  )
+}
+
+export const useSettings = () => {
+  const ctx = useContext(SettingsContext)
+  if (!ctx) throw new Error('useSettings must be used within SettingsProvider')
+  return ctx
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import Navbar from '@/components/Navbar'
+import { useSettings } from '@/hooks/useSettings'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+const SettingsPage: React.FC = () => {
+  const { shortcuts, updateShortcut } = useSettings()
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navbar title="Einstellungen" />
+      <div className="max-w-2xl mx-auto px-4 py-6 space-y-4">
+        <div>
+          <Label htmlFor="open">Command Palette</Label>
+          <Input
+            id="open"
+            value={shortcuts.openCommand}
+            onChange={e => updateShortcut('openCommand', e.target.value)}
+            placeholder="z.B. ctrl+k"
+          />
+        </div>
+        <div>
+          <Label htmlFor="task">Neue Task</Label>
+          <Input
+            id="task"
+            value={shortcuts.newTask}
+            onChange={e => updateShortcut('newTask', e.target.value)}
+            placeholder="z.B. ctrl+t"
+          />
+        </div>
+        <div>
+          <Label htmlFor="note">Neue Notiz</Label>
+          <Input
+            id="note"
+            value={shortcuts.newNote}
+            onChange={e => updateShortcut('newNote', e.target.value)}
+            placeholder="z.B. ctrl+n"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default SettingsPage


### PR DESCRIPTION
## Summary
- create `CommandPalette` component for quick task/note entry
- add settings context with customizable shortcuts
- add settings page and integrate with navbar
- wire palette and provider into `App`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684680324aa0832a87c55786d738c579