### PR TITLE
Fix command palette initialization

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { CommandDialog, CommandInput } from '@/components/ui/command'
+import { CommandDialog, CommandInput, CommandList, CommandEmpty } from '@/components/ui/command'
 import { useTaskStore } from '@/hooks/useTaskStore'
 import { useSettings } from '@/hooks/useSettings'
 import { useToast } from '@/hooks/use-toast'
@@ -82,6 +82,9 @@ const CommandPalette: React.FC = () => {
           }
         }}
       />
+      <CommandList>
+        <CommandEmpty>Keine Ergebnisse</CommandEmpty>
+      </CommandList>
     </CommandDialog>
   )
 }

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -27,6 +27,9 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
+        <DialogHeader>
+          <DialogTitle className="sr-only">Command Palette</DialogTitle>
+        </DialogHeader>
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>


### PR DESCRIPTION
## Summary
- add hidden title inside CommandDialog to satisfy Radix requirements
- add empty list container to CommandPalette so cmdk doesn't crash

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846858c86d8832aa0de76e02ed792cf