### PR TITLE
Implement Pomodoro timer feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "recharts": "^2.12.7",
     "react-beautiful-dnd": "^13.1.1",
     "sonner": "^1.5.0",
+    "zustand": "^4.5.2",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,8 @@ import Kanban from "./pages/Kanban";
 import NotesPage from "./pages/Notes";
 import SettingsPage from "./pages/Settings";
 import NotFound from "./pages/NotFound";
+import PomodoroPage from "./pages/Pomodoro";
+import PomodoroTimer from "@/components/PomodoroTimer";
 
 const queryClient = new QueryClient();
 
@@ -35,10 +37,12 @@ const App = () => (
               <Route path="/kanban" element={<Kanban />} />
               <Route path="/notes" element={<NotesPage />} />
               <Route path="/settings" element={<SettingsPage />} />
+              <Route path="/pomodoro" element={<PomodoroPage />} />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
               <Route path="*" element={<NotFound />} />
               </Routes>
             </BrowserRouter>
+            <PomodoroTimer compact />
           </CurrentCategoryProvider>
         </TaskStoreProvider>
       </SettingsProvider>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -36,6 +36,7 @@ import {
   DropResult
 } from 'react-beautiful-dnd';
 import Navbar from './Navbar';
+import { usePomodoroStore } from './PomodoroTimer';
 
 const Dashboard: React.FC = () => {
   const {
@@ -103,6 +104,7 @@ const Dashboard: React.FC = () => {
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [parentTask, setParentTask] = useState<Task | null>(null);
   const [taskDetailStack, setTaskDetailStack] = useState<Task[]>([]);
+  const { start: startPomodoro } = usePomodoroStore();
 
   const colorOptions = useMemo(() => {
     const tasksForColors = selectedCategory
@@ -659,6 +661,7 @@ const Dashboard: React.FC = () => {
         onAddSubtask={handleAddSubtask}
         onToggleComplete={handleToggleTaskComplete}
         onViewDetails={handleViewTaskDetails}
+        onStartPomodoro={task => startPomodoro(task.id)}
         canGoBack={taskDetailStack.length > 0}
         onBack={handleTaskDetailBack}
       />

--- a/src/components/PomodoroTimer.tsx
+++ b/src/components/PomodoroTimer.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { create } from 'zustand';
+
+interface PomodoroState {
+  isRunning: boolean;
+  isPaused: boolean;
+  remainingTime: number;
+  mode: 'work' | 'break';
+  currentTaskId?: string;
+  start: (taskId?: string) => void;
+  pause: () => void;
+  resume: () => void;
+  reset: () => void;
+  tick: () => void;
+}
+
+const WORK_DURATION = 25 * 60; // 25 Minuten
+const BREAK_DURATION = 5 * 60; // 5 Minuten
+
+export const usePomodoroStore = create<PomodoroState>(set => ({
+  isRunning: false,
+  isPaused: false,
+  remainingTime: WORK_DURATION,
+  mode: 'work',
+  currentTaskId: undefined,
+  start: (taskId?: string) =>
+    set(() => ({
+      isRunning: true,
+      isPaused: false,
+      remainingTime: WORK_DURATION,
+      mode: 'work',
+      currentTaskId: taskId
+    })),
+  pause: () => set({ isPaused: true }),
+  resume: () => set({ isPaused: false }),
+  reset: () =>
+    set(() => ({
+      isRunning: false,
+      isPaused: false,
+      remainingTime: WORK_DURATION,
+      mode: 'work',
+      currentTaskId: undefined
+    })),
+  tick: () =>
+    set(state => {
+      if (!state.isRunning || state.isPaused) return state;
+      if (state.remainingTime > 0) {
+        return { remainingTime: state.remainingTime - 1 };
+      }
+      const nextMode = state.mode === 'work' ? 'break' : 'work';
+      return {
+        mode: nextMode,
+        remainingTime: nextMode === 'work' ? WORK_DURATION : BREAK_DURATION
+      };
+    })
+}));
+
+const formatTime = (sec: number) => {
+  const m = Math.floor(sec / 60)
+    .toString()
+    .padStart(2, '0');
+  const s = Math.floor(sec % 60)
+    .toString()
+    .padStart(2, '0');
+  return `${m}:${s}`;
+};
+
+interface PomodoroTimerProps {
+  compact?: boolean;
+}
+
+const PomodoroTimer: React.FC<PomodoroTimerProps> = ({ compact }) => {
+  const { isRunning, isPaused, remainingTime, start, pause, resume, reset, tick } =
+    usePomodoroStore();
+
+  useEffect(() => {
+    const interval = setInterval(() => tick(), 1000);
+    return () => clearInterval(interval);
+  }, [tick]);
+
+  if (compact && !isRunning) return null;
+
+  return (
+    <div
+      className={
+        compact
+          ? 'fixed bottom-4 right-4 bg-white shadow-lg rounded p-3 z-50'
+          : 'flex flex-col items-center space-y-4'
+      }
+    >
+      <div className="text-2xl font-bold">{formatTime(remainingTime)}</div>
+      <div className="flex space-x-2">
+        {!isRunning && <Button onClick={() => start()}>Start</Button>}
+        {isRunning && !isPaused && (
+          <Button onClick={pause} variant="outline">
+            Pause
+          </Button>
+        )}
+        {isRunning && isPaused && (
+          <Button onClick={resume} variant="outline">
+            Weiter
+          </Button>
+        )}
+        {isRunning && (
+          <Button onClick={reset} variant="outline">
+            Reset
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PomodoroTimer;
+

--- a/src/components/TaskDetailModal.tsx
+++ b/src/components/TaskDetailModal.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Edit, Plus, Trash2, ArrowLeft } from 'lucide-react';
+import { Edit, Plus, Trash2, ArrowLeft, Timer } from 'lucide-react';
 import { calculateTaskCompletion, getTaskProgress, getPriorityColor, getPriorityIcon } from '@/utils/taskUtils';
 import TaskCard from './TaskCard';
 
@@ -20,6 +20,7 @@ interface TaskDetailModalProps {
   onAddSubtask: (parentTask: Task) => void;
   onToggleComplete: (taskId: string, completed: boolean) => void;
   onViewDetails: (task: Task) => void;
+  onStartPomodoro: (task: Task) => void;
   /** Display back button when true and trigger onBack on click */
   canGoBack?: boolean;
   onBack?: () => void;
@@ -35,6 +36,7 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
   onAddSubtask,
   onToggleComplete,
   onViewDetails,
+  onStartPomodoro,
   canGoBack,
   onBack
 }) => {
@@ -107,6 +109,14 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
               >
                 <Edit className="h-4 w-4 mr-2" />
                 Bearbeiten
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onStartPomodoro(task)}
+              >
+                <Timer className="h-4 w-4 mr-2" />
+                Pomodoro
               </Button>
               <Button
                 variant="outline"

--- a/src/pages/Kanban.tsx
+++ b/src/pages/Kanban.tsx
@@ -4,6 +4,7 @@ import TaskCard from '@/components/TaskCard';
 import Navbar from '@/components/Navbar';
 import TaskModal from '@/components/TaskModal';
 import TaskDetailModal from '@/components/TaskDetailModal';
+import { usePomodoroStore } from '@/components/PomodoroTimer';
 import { useToast } from '@/hooks/use-toast';
 import { Task, TaskFormData } from '@/types';
 import { flattenTasks, FlattenedTask } from '@/utils/taskUtils';
@@ -31,6 +32,7 @@ const Kanban: React.FC = () => {
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [parentTask, setParentTask] = useState<Task | null>(null);
   const [taskDetailStack, setTaskDetailStack] = useState<Task[]>([]);
+  const { start: startPomodoro } = usePomodoroStore();
 
   const onDragEnd = (result: DropResult) => {
     if (!result.destination) return;
@@ -227,6 +229,7 @@ const Kanban: React.FC = () => {
         onAddSubtask={handleAddSubtask}
         onToggleComplete={handleToggleTaskComplete}
         onViewDetails={handleViewTaskDetails}
+        onStartPomodoro={task => startPomodoro(task.id)}
         canGoBack={taskDetailStack.length > 0}
         onBack={handleTaskDetailBack}
       />

--- a/src/pages/Pomodoro.tsx
+++ b/src/pages/Pomodoro.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Navbar from '@/components/Navbar';
+import PomodoroTimer from '@/components/PomodoroTimer';
+
+const PomodoroPage: React.FC = () => {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navbar title="Pomodoro" />
+      <div className="max-w-md mx-auto py-8 px-4">
+        <PomodoroTimer />
+      </div>
+    </div>
+  );
+};
+
+export default PomodoroPage;


### PR DESCRIPTION
## Summary
- add Pomodoro timer component with Zustand state
- expose timer as floating widget in `App`
- create dedicated Pomodoro page and add route
- allow starting a Pomodoro from task detail
- wire up dashboard and kanban pages to start a Pomodoro
- add zustand dependency

## Testing
- `npm run build:dev` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68468d1b5b6c832a9c386233c56aad4c