### PR TITLE
Implement flashcards feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ npm start    # startet die gebaute App auf Port 3002
 - Unteraufgaben, Prioritäten und Wiederholungen
 - Kalenderansicht und Statistikseite
 - Eigene Notizen mit Farbe und Drag & Drop sortierbar
+- Lernkarten mit Spaced-Repetition-Training
 - Speicherung der Daten auf dem lokalen Server
 
 ## Verwendung

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,12 +7,14 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { TaskStoreProvider } from "@/hooks/useTaskStore";
 import { CurrentCategoryProvider } from "@/hooks/useCurrentCategory";
 import { SettingsProvider } from "@/hooks/useSettings";
+import { FlashcardStoreProvider } from "@/hooks/useFlashcardStore";
 import CommandPalette from "@/components/CommandPalette";
 import Index from "./pages/Index";
 import Statistics from "./pages/Statistics";
 import CalendarPage from "./pages/Calendar";
 import Kanban from "./pages/Kanban";
 import NotesPage from "./pages/Notes";
+import FlashcardsPage from "./pages/Flashcards";
 import SettingsPage from "./pages/Settings";
 import NotFound from "./pages/NotFound";
 import PomodoroPage from "./pages/Pomodoro";
@@ -25,7 +27,8 @@ const App = () => (
     <TooltipProvider>
       <SettingsProvider>
         <TaskStoreProvider>
-          <CurrentCategoryProvider>
+          <FlashcardStoreProvider>
+            <CurrentCategoryProvider>
             <Toaster />
             <Sonner />
             <BrowserRouter>
@@ -35,6 +38,7 @@ const App = () => (
               <Route path="/statistics" element={<Statistics />} />
               <Route path="/calendar" element={<CalendarPage />} />
               <Route path="/kanban" element={<Kanban />} />
+              <Route path="/flashcards" element={<FlashcardsPage />} />
               <Route path="/notes" element={<NotesPage />} />
               <Route path="/settings" element={<SettingsPage />} />
               <Route path="/pomodoro" element={<PomodoroPage />} />
@@ -43,7 +47,8 @@ const App = () => (
               </Routes>
             </BrowserRouter>
             <PomodoroTimer compact />
-          </CurrentCategoryProvider>
+            </CurrentCategoryProvider>
+          </FlashcardStoreProvider>
         </TaskStoreProvider>
       </SettingsProvider>
     </TooltipProvider>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
-import { Menu, BarChart3, Calendar as CalendarIcon, Columns, LayoutGrid, List, Cog, Timer } from 'lucide-react'
+import { Menu, BarChart3, Calendar as CalendarIcon, Columns, LayoutGrid, List, Cog, Timer, BookOpen } from 'lucide-react'
 
 interface NavbarProps {
   title?: string;
@@ -81,6 +81,12 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                 Kanban
               </Button>
             </Link>
+            <Link to="/flashcards">
+              <Button variant="outline" size="sm">
+                <BookOpen className="h-4 w-4 mr-2" />
+                Karten
+              </Button>
+            </Link>
             <Link to="/notes">
               <Button variant="outline" size="sm">
                 <List className="h-4 w-4 mr-2" />
@@ -126,6 +132,12 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                 <Button variant="outline" size="sm" className="w-full">
                   <Columns className="h-4 w-4 mr-2" />
                   Kanban
+                </Button>
+              </Link>
+              <Link to="/flashcards" className="flex-1">
+                <Button variant="outline" size="sm" className="w-full">
+                  <BookOpen className="h-4 w-4 mr-2" />
+                  Karten
                 </Button>
               </Link>
               <Link to="/notes" className="flex-1">

--- a/src/hooks/useFlashcardStore.ts
+++ b/src/hooks/useFlashcardStore.ts
@@ -1,0 +1,104 @@
+import React, { useState, useEffect, createContext, useContext } from 'react';
+import { Flashcard } from '@/types';
+
+const API_URL = '/api/flashcards';
+
+const useFlashcardStoreImpl = () => {
+  const [flashcards, setFlashcards] = useState<Flashcard[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch(API_URL);
+        if (res.ok) {
+          const data = await res.json();
+          setFlashcards(
+            (data || []).map((c: any) => ({
+              ...c,
+              dueDate: new Date(c.dueDate)
+            }))
+          );
+        }
+      } catch (err) {
+        console.error('Fehler beim Laden der Karten', err);
+      }
+    };
+
+    load();
+  }, []);
+
+  useEffect(() => {
+    const save = async () => {
+      try {
+        await fetch(API_URL, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(flashcards)
+        });
+      } catch (err) {
+        console.error('Fehler beim Speichern der Karten', err);
+      }
+    };
+
+    save();
+  }, [flashcards]);
+
+  const addFlashcard = (data: Omit<Flashcard, 'id' | 'interval' | 'dueDate'>) => {
+    const newCard: Flashcard = {
+      ...data,
+      id: Date.now().toString(),
+      interval: 1,
+      dueDate: new Date()
+    };
+    setFlashcards(prev => [...prev, newCard]);
+  };
+
+  const updateFlashcard = (id: string, updates: Partial<Flashcard>) => {
+    setFlashcards(prev =>
+      prev.map(c => (c.id === id ? { ...c, ...updates } : c))
+    );
+  };
+
+  const rateFlashcard = (
+    id: string,
+    difficulty: 'easy' | 'medium' | 'hard'
+  ) => {
+    setFlashcards(prev => {
+      return prev.map(card => {
+        if (card.id !== id) return card;
+        let factor = 1;
+        if (difficulty === 'easy') factor = 2;
+        else if (difficulty === 'medium') factor = 1.5;
+        const interval = Math.max(1, Math.round(card.interval * factor));
+        const dueDate = new Date();
+        dueDate.setDate(dueDate.getDate() + interval);
+        return { ...card, interval, dueDate };
+      });
+    });
+  };
+
+  return { flashcards, addFlashcard, updateFlashcard, rateFlashcard };
+};
+
+type FlashcardStore = ReturnType<typeof useFlashcardStoreImpl>;
+
+const FlashcardStoreContext = createContext<FlashcardStore | null>(null);
+
+export const FlashcardStoreProvider: React.FC<{ children: React.ReactNode }> = ({
+  children
+}) => {
+  const store = useFlashcardStoreImpl();
+  return (
+    <FlashcardStoreContext.Provider value={store}>
+      {children}
+    </FlashcardStoreContext.Provider>
+  );
+};
+
+export const useFlashcardStore = () => {
+  const ctx = useContext(FlashcardStoreContext);
+  if (!ctx) {
+    throw new Error('useFlashcardStore must be used within FlashcardStoreProvider');
+  }
+  return ctx;
+};

--- a/src/pages/Flashcards.tsx
+++ b/src/pages/Flashcards.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import Navbar from '@/components/Navbar';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { useFlashcardStore } from '@/hooks/useFlashcardStore';
+
+const FlashcardsPage: React.FC = () => {
+  const { flashcards, rateFlashcard } = useFlashcardStore();
+  const dueCards = flashcards.filter(c => new Date(c.dueDate) <= new Date());
+  const [index, setIndex] = useState(0);
+  const [showBack, setShowBack] = useState(false);
+
+  const current = dueCards[index];
+
+  const handleRate = (d: 'easy' | 'medium' | 'hard') => {
+    if (!current) return;
+    rateFlashcard(current.id, d);
+    setShowBack(false);
+    setIndex(i => i + 1);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navbar title="Karteikarten" />
+      <div className="max-w-md mx-auto py-8 px-4">
+        {dueCards.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Keine fälligen Karten.</p>
+        ) : (
+          <Card>
+            <CardHeader>
+              <CardTitle>{current.deck}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div
+                className="text-center text-lg cursor-pointer py-12"
+                onClick={() => setShowBack(b => !b)}
+              >
+                {showBack ? current.back : current.front}
+              </div>
+            </CardContent>
+            <CardFooter className="flex justify-between">
+              <Button variant="outline" onClick={() => handleRate('hard')}>
+                Schwer
+              </Button>
+              <Button variant="outline" onClick={() => handleRate('medium')}>
+                Mittel
+              </Button>
+              <Button variant="outline" onClick={() => handleRate('easy')}>
+                Leicht
+              </Button>
+            </CardFooter>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default FlashcardsPage;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -67,6 +67,15 @@ export interface Note {
   order: number;
 }
 
+export interface Flashcard {
+  id: string;
+  front: string;
+  back: string;
+  deck: string;
+  interval: number;
+  dueDate: Date;
+}
+
 export interface TaskStats {
   totalTasks: number;
   completedTasks: number;


### PR DESCRIPTION
## Summary
- introduce `Flashcard` type
- store flashcards on the server with `/api/flashcards`
- add hook `useFlashcardStore` to manage flashcards and spaced repetition
- create `Flashcards` page with rating buttons
- wire up provider and route
- link the new page in the navbar
- document flashcards in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68469586ba30832aacd236f654c72458