### PR TITLE
Fix flashcards API 404

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -148,7 +148,8 @@ const server = http.createServer((req, res) => {
     }
   }
 
-  if (parsed.pathname === '/api/flashcards') {
+  if (parsed.pathname === '/api/flashcards' ||
+      parsed.pathname === '/api/flashcards/') {
     if (req.method === 'GET') {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify(loadFlashcards()));


### PR DESCRIPTION
## Summary
- accept optional trailing slash for flashcards API route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684699092cf8832a8f891d1db4859e44