### PR TITLE
Fix missing flashcard store file

### DIFF
--- a/src/hooks/useFlashcardStore.ts
+++ b/src/hooks/useFlashcardStore.ts
@@ -1,0 +1,1 @@
+export * from './useFlashcardStore.tsx';


### PR DESCRIPTION
## Summary
- add TypeScript entry `useFlashcardStore.ts` to resolve 404 error

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68469be7a614832aaecfdb9aeff225c4