### PR TITLE
Add flashcard manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npm start    # startet die gebaute App auf Port 3002
 - Unteraufgaben, Prioritäten und Wiederholungen
 - Kalenderansicht und Statistikseite
 - Eigene Notizen mit Farbe und Drag & Drop sortierbar
-- Lernkarten mit Spaced-Repetition-Training
+- Lernkarten mit Spaced-Repetition-Training und Verwaltung eigener Karten
 - Speicherung der Daten auf dem lokalen Server
 
 ## Verwendung
@@ -73,5 +73,7 @@ npm start    # startet die gebaute App auf Port 3002
 4. Über das Suchfeld und die Filter sortierst und findest du Aufgaben nach Priorität oder Farbe.
 5. Die Seiten **Kalender** und **Statistiken** bieten dir einen Überblick über anstehende Termine und erledigte Tasks.
 6. Unter **Notizen** kannst du unabhängige Notizen verwalten und per Drag & Drop sortieren.
+7. In **Karten verwalten** legst du eigene Lernkarten an oder bearbeitest sie.
+8. Der Bereich **Karten** zeigt dir fällige Karten zum Lernen an.
 
 Viel Spaß beim Ausprobieren!

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import CalendarPage from "./pages/Calendar";
 import Kanban from "./pages/Kanban";
 import NotesPage from "./pages/Notes";
 import FlashcardsPage from "./pages/Flashcards";
+import FlashcardManagerPage from "./pages/FlashcardManager";
 import SettingsPage from "./pages/Settings";
 import NotFound from "./pages/NotFound";
 import PomodoroPage from "./pages/Pomodoro";
@@ -38,6 +39,7 @@ const App = () => (
               <Route path="/statistics" element={<Statistics />} />
               <Route path="/calendar" element={<CalendarPage />} />
               <Route path="/kanban" element={<Kanban />} />
+              <Route path="/flashcards/manage" element={<FlashcardManagerPage />} />
               <Route path="/flashcards" element={<FlashcardsPage />} />
               <Route path="/notes" element={<NotesPage />} />
               <Route path="/settings" element={<SettingsPage />} />

--- a/src/components/FlashcardModal.tsx
+++ b/src/components/FlashcardModal.tsx
@@ -1,0 +1,87 @@
+import React, { useState, useEffect } from 'react';
+import { Flashcard } from '@/types';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+
+interface FlashcardModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (data: Omit<Flashcard, 'id' | 'interval' | 'dueDate'>) => void;
+  card?: Flashcard;
+}
+
+const FlashcardModal: React.FC<FlashcardModalProps> = ({ isOpen, onClose, onSave, card }) => {
+  const [formData, setFormData] = useState({ front: '', back: '', deck: '' });
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (card) {
+      setFormData({ front: card.front, back: card.back, deck: card.deck });
+    } else {
+      setFormData({ front: '', back: '', deck: '' });
+    }
+  }, [isOpen, card]);
+
+  const handleChange = (field: 'front' | 'back' | 'deck', value: string) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (formData.front.trim() && formData.back.trim()) {
+      onSave(formData);
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{card ? 'Karte bearbeiten' : 'Neue Karte'}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <Label htmlFor="deck">Deck</Label>
+            <Input
+              id="deck"
+              value={formData.deck}
+              onChange={e => handleChange('deck', e.target.value)}
+            />
+          </div>
+          <div>
+            <Label htmlFor="front">Vorderseite *</Label>
+            <Textarea
+              id="front"
+              value={formData.front}
+              onChange={e => handleChange('front', e.target.value)}
+              rows={3}
+              required
+            />
+          </div>
+          <div>
+            <Label htmlFor="back">Rückseite *</Label>
+            <Textarea
+              id="back"
+              value={formData.back}
+              onChange={e => handleChange('back', e.target.value)}
+              rows={3}
+              required
+            />
+          </div>
+          <div className="flex justify-end space-x-2 pt-4">
+            <Button type="button" variant="outline" onClick={onClose}>
+              Abbrechen
+            </Button>
+            <Button type="submit">{card ? 'Speichern' : 'Erstellen'}</Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default FlashcardModal;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
-import { Menu, BarChart3, Calendar as CalendarIcon, Columns, LayoutGrid, List, Cog, Timer, BookOpen } from 'lucide-react'
+import { Menu, BarChart3, Calendar as CalendarIcon, Columns, LayoutGrid, List, Cog, Timer, BookOpen, Pencil } from 'lucide-react'
 
 interface NavbarProps {
   title?: string;
@@ -87,6 +87,12 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                 Karten
               </Button>
             </Link>
+            <Link to="/flashcards/manage">
+              <Button variant="outline" size="sm">
+                <Pencil className="h-4 w-4 mr-2" />
+                Verwalten
+              </Button>
+            </Link>
             <Link to="/notes">
               <Button variant="outline" size="sm">
                 <List className="h-4 w-4 mr-2" />
@@ -138,6 +144,12 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                 <Button variant="outline" size="sm" className="w-full">
                   <BookOpen className="h-4 w-4 mr-2" />
                   Karten
+                </Button>
+              </Link>
+              <Link to="/flashcards/manage" className="flex-1">
+                <Button variant="outline" size="sm" className="w-full">
+                  <Pencil className="h-4 w-4 mr-2" />
+                  Verwalten
                 </Button>
               </Link>
               <Link to="/notes" className="flex-1">

--- a/src/hooks/useFlashcardStore.tsx
+++ b/src/hooks/useFlashcardStore.tsx
@@ -59,6 +59,10 @@ const useFlashcardStoreImpl = () => {
     );
   };
 
+  const deleteFlashcard = (id: string) => {
+    setFlashcards(prev => prev.filter(c => c.id !== id));
+  };
+
   const rateFlashcard = (
     id: string,
     difficulty: 'easy' | 'medium' | 'hard'
@@ -77,7 +81,7 @@ const useFlashcardStoreImpl = () => {
     });
   };
 
-  return { flashcards, addFlashcard, updateFlashcard, rateFlashcard };
+  return { flashcards, addFlashcard, updateFlashcard, deleteFlashcard, rateFlashcard };
 };
 
 type FlashcardStore = ReturnType<typeof useFlashcardStoreImpl>;

--- a/src/pages/FlashcardManager.tsx
+++ b/src/pages/FlashcardManager.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { Plus, Trash2, Pencil } from 'lucide-react';
+import Navbar from '@/components/Navbar';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import FlashcardModal from '@/components/FlashcardModal';
+import { useFlashcardStore } from '@/hooks/useFlashcardStore';
+
+const FlashcardManagerPage: React.FC = () => {
+  const { flashcards, addFlashcard, updateFlashcard, deleteFlashcard } = useFlashcardStore();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+
+  const handleSave = (data: { front: string; back: string; deck: string }) => {
+    if (editingIndex !== null) {
+      const card = flashcards[editingIndex];
+      updateFlashcard(card.id, data);
+      setEditingIndex(null);
+    } else {
+      addFlashcard(data);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navbar title="Karten verwalten" />
+      <div className="max-w-2xl mx-auto py-8 px-4 space-y-4">
+        <div className="flex justify-end">
+          <Button size="sm" onClick={() => setIsModalOpen(true)}>
+            <Plus className="h-4 w-4 mr-2" /> Neue Karte
+          </Button>
+        </div>
+        {flashcards.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Noch keine Karten vorhanden.</p>
+        ) : (
+          <div className="space-y-4">
+            {flashcards.map((card, index) => (
+              <Card key={card.id}>
+                <CardHeader>
+                  <CardTitle>{card.deck || 'Allgemein'}</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                  <div className="font-medium">{card.front}</div>
+                  <div className="text-sm text-gray-600">{card.back}</div>
+                </CardContent>
+                <CardFooter className="flex justify-end space-x-2">
+                  <Button variant="outline" size="sm" onClick={() => { setEditingIndex(index); setIsModalOpen(true); }}>
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <Button variant="destructive" size="sm" onClick={() => deleteFlashcard(card.id)}>
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </CardFooter>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+      <FlashcardModal
+        isOpen={isModalOpen}
+        onClose={() => { setIsModalOpen(false); setEditingIndex(null); }}
+        onSave={handleSave}
+        card={editingIndex !== null ? flashcards[editingIndex] : undefined}
+      />
+    </div>
+  );
+};
+
+export default FlashcardManagerPage;


### PR DESCRIPTION
## Summary
- allow creating, editing and deleting flashcards
- add page to manage flashcards
- add modal for editing flashcards
- expose flashcard management routes in the app and navbar
- document flashcard management in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68469d09ed24832a80665546ab9e8da5