### PR TITLE
Add deck management for flashcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ npm start    # startet die gebaute App auf Port 3002
 4. Über das Suchfeld und die Filter sortierst und findest du Aufgaben nach Priorität oder Farbe.
 5. Die Seiten **Kalender** und **Statistiken** bieten dir einen Überblick über anstehende Termine und erledigte Tasks.
 6. Unter **Notizen** kannst du unabhängige Notizen verwalten und per Drag & Drop sortieren.
-7. In **Karten verwalten** legst du eigene Lernkarten an oder bearbeitest sie.
+7. Unter **Decks** legst du Kartendecks an und kannst sie bearbeiten. In der Detailansicht eines Decks fügst du einzelne Karten hinzu.
 8. Der Bereich **Karten** zeigt dir fällige Karten zum Lernen an.
 
 Viel Spaß beim Ausprobieren!

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import Kanban from "./pages/Kanban";
 import NotesPage from "./pages/Notes";
 import FlashcardsPage from "./pages/Flashcards";
 import FlashcardManagerPage from "./pages/FlashcardManager";
+import DeckDetailPage from "./pages/DeckDetail";
 import SettingsPage from "./pages/Settings";
 import NotFound from "./pages/NotFound";
 import PomodoroPage from "./pages/Pomodoro";
@@ -40,6 +41,7 @@ const App = () => (
               <Route path="/calendar" element={<CalendarPage />} />
               <Route path="/kanban" element={<Kanban />} />
               <Route path="/flashcards/manage" element={<FlashcardManagerPage />} />
+              <Route path="/flashcards/deck/:deckId" element={<DeckDetailPage />} />
               <Route path="/flashcards" element={<FlashcardsPage />} />
               <Route path="/notes" element={<NotesPage />} />
               <Route path="/settings" element={<SettingsPage />} />

--- a/src/components/DeckModal.tsx
+++ b/src/components/DeckModal.tsx
@@ -1,0 +1,52 @@
+import React, { useState, useEffect } from 'react';
+import { Deck } from '@/types';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface DeckModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (name: string) => void;
+  deck?: Deck;
+}
+
+const DeckModal: React.FC<DeckModalProps> = ({ isOpen, onClose, onSave, deck }) => {
+  const [name, setName] = useState('');
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setName(deck ? deck.name : '');
+  }, [isOpen, deck]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (name.trim()) {
+      onSave(name);
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{deck ? 'Deck bearbeiten' : 'Neues Deck'}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <Label htmlFor="name">Name *</Label>
+            <Input id="name" value={name} onChange={e => setName(e.target.value)} required />
+          </div>
+          <div className="flex justify-end space-x-2 pt-4">
+            <Button type="button" variant="outline" onClick={onClose}>Abbrechen</Button>
+            <Button type="submit">{deck ? 'Speichern' : 'Erstellen'}</Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default DeckModal;

--- a/src/components/FlashcardModal.tsx
+++ b/src/components/FlashcardModal.tsx
@@ -1,31 +1,32 @@
 import React, { useState, useEffect } from 'react';
-import { Flashcard } from '@/types';
+import { Flashcard, Deck } from '@/types';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 
 interface FlashcardModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSave: (data: Omit<Flashcard, 'id' | 'interval' | 'dueDate'>) => void;
+  decks: Deck[];
   card?: Flashcard;
 }
 
-const FlashcardModal: React.FC<FlashcardModalProps> = ({ isOpen, onClose, onSave, card }) => {
-  const [formData, setFormData] = useState({ front: '', back: '', deck: '' });
+const FlashcardModal: React.FC<FlashcardModalProps> = ({ isOpen, onClose, onSave, decks, card }) => {
+  const [formData, setFormData] = useState({ front: '', back: '', deckId: '' });
 
   useEffect(() => {
     if (!isOpen) return;
     if (card) {
-      setFormData({ front: card.front, back: card.back, deck: card.deck });
+      setFormData({ front: card.front, back: card.back, deckId: card.deckId });
     } else {
-      setFormData({ front: '', back: '', deck: '' });
+      setFormData({ front: '', back: '', deckId: decks[0]?.id || '' });
     }
-  }, [isOpen, card]);
+  }, [isOpen, card, decks]);
 
-  const handleChange = (field: 'front' | 'back' | 'deck', value: string) => {
+  const handleChange = (field: 'front' | 'back' | 'deckId', value: string) => {
     setFormData(prev => ({ ...prev, [field]: value }));
   };
 
@@ -46,11 +47,16 @@ const FlashcardModal: React.FC<FlashcardModalProps> = ({ isOpen, onClose, onSave
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <Label htmlFor="deck">Deck</Label>
-            <Input
-              id="deck"
-              value={formData.deck}
-              onChange={e => handleChange('deck', e.target.value)}
-            />
+            <Select value={formData.deckId} onValueChange={v => handleChange('deckId', v)}>
+              <SelectTrigger id="deck">
+                <SelectValue placeholder="Deck wählen" />
+              </SelectTrigger>
+              <SelectContent>
+                {decks.map(d => (
+                  <SelectItem key={d.id} value={d.id}>{d.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
           <div>
             <Label htmlFor="front">Vorderseite *</Label>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -87,12 +87,12 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                 Karten
               </Button>
             </Link>
-            <Link to="/flashcards/manage">
-              <Button variant="outline" size="sm">
-                <Pencil className="h-4 w-4 mr-2" />
-                Verwalten
-              </Button>
-            </Link>
+              <Link to="/flashcards/manage">
+                <Button variant="outline" size="sm">
+                  <Pencil className="h-4 w-4 mr-2" />
+                  Decks
+                </Button>
+              </Link>
             <Link to="/notes">
               <Button variant="outline" size="sm">
                 <List className="h-4 w-4 mr-2" />
@@ -149,7 +149,7 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
               <Link to="/flashcards/manage" className="flex-1">
                 <Button variant="outline" size="sm" className="w-full">
                   <Pencil className="h-4 w-4 mr-2" />
-                  Verwalten
+                  Decks
                 </Button>
               </Link>
               <Link to="/notes" className="flex-1">

--- a/src/pages/DeckDetail.tsx
+++ b/src/pages/DeckDetail.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import Navbar from '@/components/Navbar';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import FlashcardModal from '@/components/FlashcardModal';
+import { useFlashcardStore } from '@/hooks/useFlashcardStore';
+import { Plus, Pencil, Trash2 } from 'lucide-react';
+
+const DeckDetailPage: React.FC = () => {
+  const { deckId } = useParams<{ deckId: string }>();
+  const navigate = useNavigate();
+  const { flashcards, decks, addFlashcard, updateFlashcard, deleteFlashcard } = useFlashcardStore();
+  const deck = decks.find(d => d.id === deckId);
+  const cards = flashcards.filter(c => c.deckId === deckId);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+
+  if (!deck) return <div className="p-4">Deck nicht gefunden.</div>;
+
+  const handleSave = (data: { front: string; back: string; deckId: string }) => {
+    const payload = { ...data, deckId: deckId! };
+    if (editingIndex !== null) {
+      const card = cards[editingIndex];
+      updateFlashcard(card.id, payload);
+      setEditingIndex(null);
+    } else {
+      addFlashcard(payload);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navbar title={deck.name} onHomeClick={() => navigate('/flashcards/manage')} />
+      <div className="max-w-2xl mx-auto py-8 px-4 space-y-4">
+        <div className="flex justify-end">
+          <Button size="sm" onClick={() => setIsModalOpen(true)}>
+            <Plus className="h-4 w-4 mr-2" /> Neue Karte
+          </Button>
+        </div>
+        {cards.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Noch keine Karten vorhanden.</p>
+        ) : (
+          <div className="space-y-4">
+            {cards.map((card, index) => (
+              <Card key={card.id}>
+                <CardHeader>
+                  <CardTitle className="text-sm font-medium">Karte {index + 1}</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                  <div className="font-medium">{card.front}</div>
+                  <div className="text-sm text-gray-600">{card.back}</div>
+                </CardContent>
+                <CardFooter className="flex justify-end space-x-2">
+                  <Button variant="outline" size="sm" onClick={() => { setEditingIndex(index); setIsModalOpen(true); }}>
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <Button variant="destructive" size="sm" onClick={() => deleteFlashcard(card.id)}>
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </CardFooter>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+      <FlashcardModal
+        isOpen={isModalOpen}
+        onClose={() => { setIsModalOpen(false); setEditingIndex(null); }}
+        onSave={handleSave}
+        decks={decks}
+        card={editingIndex !== null ? cards[editingIndex] : undefined}
+      />
+    </div>
+  );
+};
+
+export default DeckDetailPage;

--- a/src/pages/FlashcardManager.tsx
+++ b/src/pages/FlashcardManager.tsx
@@ -1,66 +1,68 @@
 import React, { useState } from 'react';
 import { Plus, Trash2, Pencil } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import Navbar from '@/components/Navbar';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
-import FlashcardModal from '@/components/FlashcardModal';
+import DeckModal from '@/components/DeckModal';
 import { useFlashcardStore } from '@/hooks/useFlashcardStore';
+import { Deck } from '@/types';
 
 const FlashcardManagerPage: React.FC = () => {
-  const { flashcards, addFlashcard, updateFlashcard, deleteFlashcard } = useFlashcardStore();
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const { decks, flashcards, addDeck, updateDeck, deleteDeck } = useFlashcardStore();
+  const navigate = useNavigate();
+  const [isDeckModalOpen, setIsDeckModalOpen] = useState(false);
+  const [editingDeck, setEditingDeck] = useState<Deck | null>(null);
 
-  const handleSave = (data: { front: string; back: string; deck: string }) => {
-    if (editingIndex !== null) {
-      const card = flashcards[editingIndex];
-      updateFlashcard(card.id, data);
-      setEditingIndex(null);
+  const handleSaveDeck = (name: string) => {
+    if (editingDeck) {
+      updateDeck(editingDeck.id, name);
+      setEditingDeck(null);
     } else {
-      addFlashcard(data);
+      addDeck(name);
     }
   };
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Navbar title="Karten verwalten" />
+      <Navbar title="Decks" />
       <div className="max-w-2xl mx-auto py-8 px-4 space-y-4">
         <div className="flex justify-end">
-          <Button size="sm" onClick={() => setIsModalOpen(true)}>
-            <Plus className="h-4 w-4 mr-2" /> Neue Karte
+          <Button size="sm" onClick={() => setIsDeckModalOpen(true)}>
+            <Plus className="h-4 w-4 mr-2" /> Neues Deck
           </Button>
         </div>
-        {flashcards.length === 0 ? (
-          <p className="text-sm text-muted-foreground">Noch keine Karten vorhanden.</p>
+        {decks.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Noch keine Decks vorhanden.</p>
         ) : (
           <div className="space-y-4">
-            {flashcards.map((card, index) => (
-              <Card key={card.id}>
-                <CardHeader>
-                  <CardTitle>{card.deck || 'Allgemein'}</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-2">
-                  <div className="font-medium">{card.front}</div>
-                  <div className="text-sm text-gray-600">{card.back}</div>
-                </CardContent>
-                <CardFooter className="flex justify-end space-x-2">
-                  <Button variant="outline" size="sm" onClick={() => { setEditingIndex(index); setIsModalOpen(true); }}>
-                    <Pencil className="h-4 w-4" />
-                  </Button>
-                  <Button variant="destructive" size="sm" onClick={() => deleteFlashcard(card.id)}>
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                </CardFooter>
-              </Card>
-            ))}
+            {decks.map(deck => {
+              const count = flashcards.filter(c => c.deckId === deck.id).length;
+              return (
+                <Card key={deck.id} onClick={() => navigate(`/flashcards/deck/${deck.id}`)} className="cursor-pointer">
+                  <CardHeader>
+                    <CardTitle>{deck.name}</CardTitle>
+                  </CardHeader>
+                  <CardContent>{count} Karte{count !== 1 ? 'n' : ''}</CardContent>
+                  <CardFooter className="flex justify-end space-x-2">
+                    <Button variant="outline" size="sm" onClick={e => { e.stopPropagation(); setEditingDeck(deck); setIsDeckModalOpen(true); }}>
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button variant="destructive" size="sm" onClick={e => { e.stopPropagation(); deleteDeck(deck.id); }}>
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </CardFooter>
+                </Card>
+              );
+            })}
           </div>
         )}
       </div>
-      <FlashcardModal
-        isOpen={isModalOpen}
-        onClose={() => { setIsModalOpen(false); setEditingIndex(null); }}
-        onSave={handleSave}
-        card={editingIndex !== null ? flashcards[editingIndex] : undefined}
+      <DeckModal
+        isOpen={isDeckModalOpen}
+        onClose={() => { setIsDeckModalOpen(false); setEditingDeck(null); }}
+        onSave={handleSaveDeck}
+        deck={editingDeck || undefined}
       />
     </div>
   );

--- a/src/pages/Flashcards.tsx
+++ b/src/pages/Flashcards.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/componen
 import { useFlashcardStore } from '@/hooks/useFlashcardStore';
 
 const FlashcardsPage: React.FC = () => {
-  const { flashcards, rateFlashcard } = useFlashcardStore();
+  const { flashcards, decks, rateFlashcard } = useFlashcardStore();
   const dueCards = flashcards.filter(c => new Date(c.dueDate) <= new Date());
   const [index, setIndex] = useState(0);
   const [showBack, setShowBack] = useState(false);
@@ -28,7 +28,7 @@ const FlashcardsPage: React.FC = () => {
         ) : (
           <Card>
             <CardHeader>
-              <CardTitle>{current.deck}</CardTitle>
+              <CardTitle>{decks.find(d => d.id === current.deckId)?.name}</CardTitle>
             </CardHeader>
             <CardContent>
               <div

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -71,9 +71,14 @@ export interface Flashcard {
   id: string;
   front: string;
   back: string;
-  deck: string;
+  deckId: string;
   interval: number;
   dueDate: Date;
+}
+
+export interface Deck {
+  id: string;
+  name: string;
 }
 
 export interface TaskStats {


### PR DESCRIPTION
## Summary
- implement decks table and API in server
- extend flashcard store with deck handling
- add deck modal and deck detail page
- update flashcard manager to manage decks
- show deck names when training
- update navigation and README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68470e447e18832ab9729568bce2847b