### PR TITLE
Add flashcard statistics and improved algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ npm start    # startet die gebaute App auf Port 3002
 - Kalenderansicht und Statistikseite
 - Eigene Notizen mit Farbe und Drag & Drop sortierbar
 - Lernkarten mit Spaced-Repetition-Training und Verwaltung eigener Karten
+- Statistikseite für Lernkarten
 - Speicherung der Daten auf dem lokalen Server
 
 ## Verwendung
@@ -77,3 +78,19 @@ npm start    # startet die gebaute App auf Port 3002
 8. Der Bereich **Karten** zeigt dir fällige Karten zum Lernen an.
 
 Viel Spaß beim Ausprobieren!
+
+## Lernkarten-Algorithmus
+
+Beim Bewerten einer Karte merkt sich das System, wie oft sie als **leicht**, **mittel** oder **schwer** eingestuft wurde. Aus diesen Zählen berechnet sich eine Erfolgsquote:
+
+```
+successRate = (easyCount + 0.5 * mediumCount) / (easyCount + mediumCount + hardCount)
+```
+
+Die nächste Wiederholungszeit wird dann wie folgt bestimmt:
+
+1. Basisfaktor je nach aktueller Bewertung (`leicht` = 1.5, `mittel` = 1.2, `schwer` = 0.8)
+2. Der Faktor wird mit `1 + successRate` multipliziert
+3. Das Intervall erhöht sich um `interval * Faktor`
+
+Dadurch fließt sowohl die bisherige Leistung als auch die aktuelle Bewertung in das nächste Fälligkeitsdatum ein.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import NotesPage from "./pages/Notes";
 import FlashcardsPage from "./pages/Flashcards";
 import FlashcardManagerPage from "./pages/FlashcardManager";
 import DeckDetailPage from "./pages/DeckDetail";
+import FlashcardStatisticsPage from "./pages/FlashcardStatistics";
 import SettingsPage from "./pages/Settings";
 import NotFound from "./pages/NotFound";
 import PomodoroPage from "./pages/Pomodoro";
@@ -43,6 +44,7 @@ const App = () => (
               <Route path="/flashcards/manage" element={<FlashcardManagerPage />} />
               <Route path="/flashcards/deck/:deckId" element={<DeckDetailPage />} />
               <Route path="/flashcards" element={<FlashcardsPage />} />
+              <Route path="/flashcards/stats" element={<FlashcardStatisticsPage />} />
               <Route path="/notes" element={<NotesPage />} />
               <Route path="/settings" element={<SettingsPage />} />
               <Route path="/pomodoro" element={<PomodoroPage />} />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -167,6 +167,11 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                     <Pencil className="h-4 w-4 mr-2" /> Decks
                   </Link>
                 </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <Link to="/flashcards/stats" className="flex items-center">
+                    <BarChart3 className="h-4 w-4 mr-2" /> Statistiken
+                  </Link>
+                </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
 
@@ -258,6 +263,12 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                   <Button variant="outline" size="sm" className="w-full">
                     <Pencil className="h-4 w-4 mr-2" />
                     Decks
+                  </Button>
+                </Link>
+                <Link to="/flashcards/stats" className="flex-1">
+                  <Button variant="outline" size="sm" className="w-full">
+                    <BarChart3 className="h-4 w-4 mr-2" />
+                    Statistiken
                   </Button>
                 </Link>
               </div>

--- a/src/hooks/useFlashcardStatistics.ts
+++ b/src/hooks/useFlashcardStatistics.ts
@@ -1,0 +1,53 @@
+import { useMemo } from 'react';
+import { useFlashcardStore } from './useFlashcardStore';
+
+export interface FlashcardStats {
+  totalCards: number;
+  dueCards: number;
+  averageInterval: number;
+  difficultyCounts: {
+    easy: number;
+    medium: number;
+    hard: number;
+  };
+  upcomingDue: { date: string; count: number }[];
+}
+
+export const useFlashcardStatistics = (): FlashcardStats => {
+  const { flashcards } = useFlashcardStore();
+
+  return useMemo(() => {
+    const totalCards = flashcards.length;
+    const dueCards = flashcards.filter(c => new Date(c.dueDate) <= new Date()).length;
+    const averageInterval =
+      totalCards > 0
+        ? flashcards.reduce((sum, c) => sum + c.interval, 0) / totalCards
+        : 0;
+
+    const difficultyCounts = flashcards.reduce(
+      (acc, c) => {
+        acc.easy += c.easyCount;
+        acc.medium += c.mediumCount;
+        acc.hard += c.hardCount;
+        return acc;
+      },
+      { easy: 0, medium: 0, hard: 0 }
+    );
+
+    const upcomingDue: { date: string; count: number }[] = [];
+    for (let i = 0; i < 7; i++) {
+      const d = new Date();
+      d.setDate(d.getDate() + i);
+      const key = d.toISOString().split('T')[0];
+      const count = flashcards.filter(
+        c => c.dueDate.toISOString().split('T')[0] === key
+      ).length;
+      upcomingDue.push({
+        date: d.toLocaleDateString('de-DE', { month: 'short', day: 'numeric' }),
+        count
+      });
+    }
+
+    return { totalCards, dueCards, averageInterval, difficultyCounts, upcomingDue };
+  }, [flashcards]);
+};

--- a/src/hooks/useFlashcardStore.tsx
+++ b/src/hooks/useFlashcardStore.tsx
@@ -17,7 +17,10 @@ const useFlashcardStoreImpl = () => {
           setFlashcards(
             (data || []).map((c: any) => ({
               ...c,
-              dueDate: new Date(c.dueDate)
+              dueDate: new Date(c.dueDate),
+              easyCount: c.easyCount ?? 0,
+              mediumCount: c.mediumCount ?? 0,
+              hardCount: c.hardCount ?? 0
             }))
           );
         }
@@ -82,7 +85,10 @@ const useFlashcardStoreImpl = () => {
       ...data,
       id: Date.now().toString(),
       interval: 1,
-      dueDate: new Date()
+      dueDate: new Date(),
+      easyCount: 0,
+      mediumCount: 0,
+      hardCount: 0
     };
     setFlashcards(prev => [...prev, newCard]);
   };
@@ -119,13 +125,26 @@ const useFlashcardStoreImpl = () => {
     setFlashcards(prev => {
       return prev.map(card => {
         if (card.id !== id) return card;
-        let factor = 1;
-        if (difficulty === 'easy') factor = 2;
-        else if (difficulty === 'medium') factor = 1.5;
+        const total = card.easyCount + card.mediumCount + card.hardCount;
+        const successRate =
+          total > 0
+            ? (card.easyCount + 0.5 * card.mediumCount) / total
+            : 0.5;
+        let base = 0.8;
+        if (difficulty === 'easy') base = 1.5;
+        else if (difficulty === 'medium') base = 1.2;
+        const factor = base * (1 + successRate);
         const interval = Math.max(1, Math.round(card.interval * factor));
         const dueDate = new Date();
         dueDate.setDate(dueDate.getDate() + interval);
-        return { ...card, interval, dueDate };
+        return {
+          ...card,
+          interval,
+          dueDate,
+          easyCount: card.easyCount + (difficulty === 'easy' ? 1 : 0),
+          mediumCount: card.mediumCount + (difficulty === 'medium' ? 1 : 0),
+          hardCount: card.hardCount + (difficulty === 'hard' ? 1 : 0)
+        };
       });
     });
   };

--- a/src/pages/FlashcardStatistics.tsx
+++ b/src/pages/FlashcardStatistics.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import Navbar from '@/components/Navbar';
+import { useFlashcardStatistics } from '@/hooks/useFlashcardStatistics';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip, BarChart, Bar, XAxis, YAxis, CartesianGrid } from 'recharts';
+import { BookOpen, Clock, TrendingUp } from 'lucide-react';
+
+const FlashcardStatisticsPage: React.FC = () => {
+  const stats = useFlashcardStatistics();
+
+  const difficultyData = [
+    { name: 'Leicht', value: stats.difficultyCounts.easy, color: '#10B981' },
+    { name: 'Mittel', value: stats.difficultyCounts.medium, color: '#F59E0B' },
+    { name: 'Schwer', value: stats.difficultyCounts.hard, color: '#EF4444' }
+  ];
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navbar title="Karten Statistiken" />
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-8">
+        <div className="grid grid-cols-2 lg:grid-cols-6 gap-3 sm:gap-6 mb-6 sm:mb-8">
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-xs sm:text-sm font-medium">Gesamt Karten</CardTitle>
+              <BookOpen className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-lg sm:text-2xl font-bold">{stats.totalCards}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-xs sm:text-sm font-medium">Fällig</CardTitle>
+              <Clock className="h-4 w-4 text-red-600" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-lg sm:text-2xl font-bold text-red-600">{stats.dueCards}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-xs sm:text-sm font-medium">Ø Intervall</CardTitle>
+              <TrendingUp className="h-4 w-4 text-blue-600" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-lg sm:text-2xl font-bold text-blue-600">
+                {Math.round(stats.averageInterval * 10) / 10} Tage
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base sm:text-lg">Schwierigkeiten</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="h-48 sm:h-64">
+                <ResponsiveContainer width="100%" height="100%">
+                  <PieChart>
+                    <Pie data={difficultyData} cx="50%" cy="50%" innerRadius={30} outerRadius={60} paddingAngle={5} dataKey="value">
+                      {difficultyData.map((entry, index) => (
+                        <Cell key={`cell-${index}`} fill={entry.color} />
+                      ))}
+                    </Pie>
+                    <Tooltip />
+                  </PieChart>
+                </ResponsiveContainer>
+              </div>
+              <div className="flex justify-center space-x-4 mt-4">
+                {difficultyData.map((item, index) => (
+                  <div key={index} className="flex items-center">
+                    <div className="w-3 h-3 rounded-full mr-2" style={{ backgroundColor: item.color }} />
+                    <span className="text-xs sm:text-sm">{item.name}: {item.value}</span>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base sm:text-lg">Fälligkeit nächste 7 Tage</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="h-48 sm:h-64">
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={stats.upcomingDue} margin={{ top: 20, right: 30, left: 20, bottom: 20 }}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="date" fontSize={12} />
+                    <YAxis fontSize={12} />
+                    <Tooltip />
+                    <Bar dataKey="count" fill="#3B82F6" name="Karten" />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FlashcardStatisticsPage;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -74,6 +74,9 @@ export interface Flashcard {
   deckId: string;
   interval: number;
   dueDate: Date;
+  easyCount: number;
+  mediumCount: number;
+  hardCount: number;
 }
 
 export interface Deck {


### PR DESCRIPTION
## Summary
- track review counts for each flashcard
- compute next interval using past results
- provide hook and page for flashcard statistics
- expose stats page via router and navbar
- document flashcard algorithm in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684712ce0990832a9f12a54aa9252d63