### PR TITLE
Fix crash when cycling through flashcards

### DIFF
--- a/src/pages/Flashcards.tsx
+++ b/src/pages/Flashcards.tsx
@@ -23,7 +23,7 @@ const FlashcardsPage: React.FC = () => {
     <div className="min-h-screen bg-gray-50">
       <Navbar title="Karteikarten" />
       <div className="max-w-md mx-auto py-8 px-4">
-        {dueCards.length === 0 ? (
+        {!current ? (
           <p className="text-sm text-muted-foreground">Keine fälligen Karten.</p>
         ) : (
           <Card>


### PR DESCRIPTION
## Summary
- avoid reading `deckId` when no flashcard is available

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684714e54be4832a9515fc8533ed03fc