### PR TITLE
Add deck selection and random mode for flashcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ npm start    # startet die gebaute App auf Port 3002
 - Kalenderansicht und Statistikseite
 - Eigene Notizen mit Farbe und Drag & Drop sortierbar
 - Lernkarten mit Spaced-Repetition-Training und Verwaltung eigener Karten
+  - Decks lassen sich beim Lernen ein- oder ausblenden
+  - Optionaler Zufallsmodus ohne Bewertung
 - Statistikseite für Lernkarten
 - Speicherung der Daten auf dem lokalen Server
 
@@ -75,7 +77,8 @@ npm start    # startet die gebaute App auf Port 3002
 5. Die Seiten **Kalender** und **Statistiken** bieten dir einen Überblick über anstehende Termine und erledigte Tasks.
 6. Unter **Notizen** kannst du unabhängige Notizen verwalten und per Drag & Drop sortieren.
 7. Unter **Decks** legst du Kartendecks an und kannst sie bearbeiten. In der Detailansicht eines Decks fügst du einzelne Karten hinzu.
-8. Der Bereich **Karten** zeigt dir fällige Karten zum Lernen an.
+8. Der Bereich **Karten** zeigt dir fällige Karten zum Lernen an. Dort kannst du
+   gezielt Decks ein- oder ausblenden und einen Zufallsmodus aktivieren.
 
 Viel Spaß beim Ausprobieren!
 

--- a/src/utils/shuffle.ts
+++ b/src/utils/shuffle.ts
@@ -1,0 +1,8 @@
+export function shuffleArray<T>(arr: T[]): T[] {
+  const copy = [...arr];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}


### PR DESCRIPTION
## Summary
- enable selecting decks during flashcard study
- add optional random study mode independent from SRS
- document new flashcard features in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68471677dff4832ab9051851cc76fd51