### PR TITLE
Fix random mode card display

### DIFF
--- a/src/pages/Flashcards.tsx
+++ b/src/pages/Flashcards.tsx
@@ -81,7 +81,14 @@ const FlashcardsPage: React.FC = () => {
                 className="text-center text-lg cursor-pointer py-12"
                 onClick={() => setShowBack(b => !b)}
               >
-                {showBack ? current.back : current.front}
+                {showBack ? (
+                  <div className="space-y-2">
+                    <div>{current.front}</div>
+                    <div>{current.back}</div>
+                  </div>
+                ) : (
+                  current.front
+                )}
               </div>
             </CardContent>
             <CardFooter className="flex justify-between">


### PR DESCRIPTION
## Summary
- show front and back together after revealing a flashcard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684718161da0832a987e445ecfae996f