### PR TITLE
Fix pomodoro timer mode

### DIFF
--- a/src/components/PomodoroTimer.tsx
+++ b/src/components/PomodoroTimer.tsx
@@ -71,8 +71,17 @@ interface PomodoroTimerProps {
 }
 
 const PomodoroTimer: React.FC<PomodoroTimerProps> = ({ compact }) => {
-  const { isRunning, isPaused, remainingTime, start, pause, resume, reset, tick } =
-    usePomodoroStore();
+  const {
+    isRunning,
+    isPaused,
+    remainingTime,
+    mode,
+    start,
+    pause,
+    resume,
+    reset,
+    tick
+  } = usePomodoroStore();
 
   useEffect(() => {
     const interval = setInterval(() => tick(), 1000);


### PR DESCRIPTION
## Summary
- fetch `mode` from store in PomodoroTimer

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68471881dd7c832ab1c734945c7e3cdb