### PR TITLE
Fix random flashcard shuffle

### DIFF
--- a/src/pages/Flashcards.tsx
+++ b/src/pages/Flashcards.tsx
@@ -21,8 +21,14 @@ const FlashcardsPage: React.FC = () => {
     }
   }, [decks, selectedDecks.length]);
 
-  const filtered = flashcards.filter(c => selectedDecks.includes(c.deckId));
-  const dueCards = filtered.filter(c => new Date(c.dueDate) <= new Date());
+  const filtered = useMemo(
+    () => flashcards.filter(c => selectedDecks.includes(c.deckId)),
+    [flashcards, selectedDecks]
+  );
+  const dueCards = useMemo(
+    () => filtered.filter(c => new Date(c.dueDate) <= new Date()),
+    [filtered]
+  );
 
   const cards = useMemo(() => {
     if (randomMode) {


### PR DESCRIPTION
## Summary
- stabilize deck filtering in Flashcards by memoizing filtered lists
- this prevents random mode from reshuffling on every render

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684719864188832a8d3af7e133d9c617