### PR TITLE
Add task creation from calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npm start    # startet die gebaute App auf Port 3002
 
 - Aufgaben anlegen, bearbeiten und in Kategorien sortieren
 - Unteraufgaben, Prioritäten und Wiederholungen
-- Kalenderansicht und Statistikseite
+- Kalenderansicht mit direkter Task-Erstellung und Statistikseite
 - Eigene Notizen mit Farbe und Drag & Drop sortierbar
 - Lernkarten mit Spaced-Repetition-Training und Verwaltung eigener Karten
   - Decks lassen sich beim Lernen ein- oder ausblenden
@@ -74,7 +74,7 @@ npm start    # startet die gebaute App auf Port 3002
 2. Wähle eine Kategorie aus, um ihre **Tasks** zu sehen. Über `Task` legst du neue Aufgaben an. Dort kannst du Titel, Beschreibung, Priorität, Farbe, Fälligkeitsdatum und optionale Wiederholung definieren.
 3. Tasks lassen sich per Drag & Drop umsortieren oder in Unteraufgaben aufteilen.
 4. Über das Suchfeld und die Filter sortierst und findest du Aufgaben nach Priorität oder Farbe.
-5. Die Seiten **Kalender** und **Statistiken** bieten dir einen Überblick über anstehende Termine und erledigte Tasks.
+5. In der **Kalender**-Ansicht klickst du auf ein Datum, um alle bis dahin fälligen Aufgaben zu sehen und neue Aufgaben direkt für diesen Tag anzulegen. Die **Statistiken** geben einen Überblick über erledigte Tasks.
 6. Unter **Notizen** kannst du unabhängige Notizen verwalten und per Drag & Drop sortieren.
 7. Unter **Decks** legst du Kartendecks an und kannst sie bearbeiten. In der Detailansicht eines Decks fügst du einzelne Karten hinzu.
 8. Der Bereich **Karten** zeigt dir fällige Karten zum Lernen an. Dort kannst du

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -630,6 +630,7 @@ const Dashboard: React.FC = () => {
         categories={categories}
         parentTask={parentTask || undefined}
         defaultCategoryId={selectedCategory ? selectedCategory.id : undefined}
+        defaultDueDate={undefined}
       />
 
       <CategoryModal

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -22,6 +22,10 @@ interface TaskModalProps {
    * editing an existing task where the category comes from the task itself.
    */
   defaultCategoryId?: string;
+  /**
+   * Default due date when creating a new task. Ignored when editing.
+   */
+  defaultDueDate?: Date;
 }
 
 const TaskModal: React.FC<TaskModalProps> = ({
@@ -31,7 +35,8 @@ const TaskModal: React.FC<TaskModalProps> = ({
   task,
   categories,
   parentTask,
-  defaultCategoryId
+  defaultCategoryId,
+  defaultDueDate
 }) => {
   const [formData, setFormData] = useState<TaskFormData>({
     title: '',
@@ -74,12 +79,12 @@ const TaskModal: React.FC<TaskModalProps> = ({
         categoryId:
           defaultCategoryId || parentTask?.categoryId || categories[0]?.id || '',
         parentId: parentTask?.id,
-        dueDate: undefined,
+        dueDate: defaultDueDate,
         isRecurring: false,
         recurrencePattern: undefined
       });
     }
-  }, [isOpen, task, categories, parentTask, defaultCategoryId]);
+  }, [isOpen, task, categories, parentTask, defaultCategoryId, defaultDueDate]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,13 +1,18 @@
 import React, { useMemo, useState } from 'react';
 import { useTaskStore } from '@/hooks/useTaskStore';
-import { Task } from '@/types';
+import { Task, TaskFormData } from '@/types';
 import { Calendar } from '@/components/ui/calendar';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import Navbar from '@/components/Navbar';
+import TaskModal from '@/components/TaskModal';
+import { useToast } from '@/hooks/use-toast';
 
 const CalendarPage = () => {
-  const { tasks } = useTaskStore();
+  const { tasks, categories, addTask } = useTaskStore();
+  const { toast } = useToast();
   const [selected, setSelected] = useState<Date | undefined>();
+  const [isTaskModalOpen, setIsTaskModalOpen] = useState(false);
 
   const tasksByDate = useMemo(() => {
     const map: Record<string, Task[]> = {};
@@ -27,6 +32,17 @@ const CalendarPage = () => {
   const eventDays = useMemo(() => Object.keys(tasksByDate).map(d => new Date(d)), [tasksByDate]);
   const dayTasks = selected ? tasksByDate[selected.toDateString()] || [] : [];
 
+  const handleCreateTask = (taskData: TaskFormData) => {
+    addTask({
+      ...taskData,
+      completed: false
+    });
+    toast({
+      title: 'Task erstellt',
+      description: `"${taskData.title}" wurde erfolgreich erstellt.`
+    });
+  };
+
   return (
     <div className="min-h-screen bg-gray-50">
       <Navbar title="Kalender" />
@@ -44,6 +60,13 @@ const CalendarPage = () => {
               <CardTitle>
                 Aufgaben am {selected.toLocaleDateString('de-DE')}
               </CardTitle>
+              <Button
+                size="sm"
+                className="mt-2"
+                onClick={() => setIsTaskModalOpen(true)}
+              >
+                Neue Task
+              </Button>
             </CardHeader>
             <CardContent>
               {dayTasks.length === 0 ? (
@@ -65,6 +88,14 @@ const CalendarPage = () => {
           </Card>
         )}
       </div>
+      <TaskModal
+        isOpen={isTaskModalOpen}
+        onClose={() => setIsTaskModalOpen(false)}
+        onSave={handleCreateTask}
+        categories={categories}
+        defaultCategoryId={categories[0]?.id}
+        defaultDueDate={selected}
+      />
     </div>
   );
 };

--- a/src/pages/Kanban.tsx
+++ b/src/pages/Kanban.tsx
@@ -213,6 +213,7 @@ const Kanban: React.FC = () => {
         task={editingTask || undefined}
         categories={categories}
         parentTask={parentTask || undefined}
+        defaultDueDate={undefined}
       />
 
       <TaskDetailModal


### PR DESCRIPTION
## Summary
- support default due date in `TaskModal`
- update Dashboard and Kanban pages for new prop
- allow creating tasks directly from Calendar page
- document calendar task creation in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68471bbaf12c832abf90cd2dddf3bd17