### PR TITLE
Improve pomodoro timer layout

### DIFF
--- a/src/components/PomodoroTimer.tsx
+++ b/src/components/PomodoroTimer.tsx
@@ -74,9 +74,11 @@ const formatTime = (sec: number) => {
 
 interface PomodoroTimerProps {
   compact?: boolean;
+  /** Radius of the timer circle */
+  size?: number;
 }
 
-const PomodoroTimer: React.FC<PomodoroTimerProps> = ({ compact }) => {
+const PomodoroTimer: React.FC<PomodoroTimerProps> = ({ compact, size = 80 }) => {
   const {
     isRunning,
     isPaused,
@@ -99,7 +101,7 @@ const PomodoroTimer: React.FC<PomodoroTimerProps> = ({ compact }) => {
   const duration = mode === 'work' ? WORK_DURATION : BREAK_DURATION;
   const progress = remainingTime / duration;
 
-  const radius = 80;
+  const radius = size;
   const stroke = 8;
   const normalizedRadius = radius - stroke / 2;
   const circumference = normalizedRadius * 2 * Math.PI;
@@ -140,7 +142,11 @@ const PomodoroTimer: React.FC<PomodoroTimerProps> = ({ compact }) => {
           />
         </svg>
         <div className="absolute inset-0 flex items-center justify-center">
-          <div className="text-2xl font-bold">{formatTime(remainingTime)}</div>
+          <div
+            className={size > 100 ? 'text-4xl font-bold' : 'text-2xl font-bold'}
+          >
+            {formatTime(remainingTime)}
+          </div>
         </div>
       </div>
       <div className="flex space-x-2 mt-4">

--- a/src/pages/Pomodoro.tsx
+++ b/src/pages/Pomodoro.tsx
@@ -4,10 +4,10 @@ import PomodoroTimer from '@/components/PomodoroTimer';
 
 const PomodoroPage: React.FC = () => {
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 flex flex-col">
       <Navbar title="Pomodoro" />
-      <div className="max-w-md mx-auto py-8 px-4">
-        <PomodoroTimer />
+      <div className="flex-grow flex items-center justify-center p-4">
+        <PomodoroTimer size={150} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- enlarge the pomodoro timer when it is shown on its own page
- allow `PomodoroTimer` to accept a size prop
- center the timer on the page and make it bigger

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68471d9243c0832a834bfd2dfd038008