### PR TITLE
Fix pomodoro timer and persist settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,8 @@ import SettingsPage from "./pages/Settings";
 import NotFound from "./pages/NotFound";
 import PomodoroPage from "./pages/Pomodoro";
 import PomodoroTimer from "@/components/PomodoroTimer";
+import PomodoroTicker from "@/components/PomodoroTicker";
+import { PomodoroHistoryProvider } from "@/hooks/usePomodoroHistory";
 
 const queryClient = new QueryClient();
 
@@ -29,9 +31,10 @@ const App = () => (
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>
       <SettingsProvider>
-        <TaskStoreProvider>
-          <FlashcardStoreProvider>
-            <CurrentCategoryProvider>
+        <PomodoroHistoryProvider>
+          <TaskStoreProvider>
+            <FlashcardStoreProvider>
+              <CurrentCategoryProvider>
             <Toaster />
             <Sonner />
             <BrowserRouter>
@@ -53,9 +56,11 @@ const App = () => (
               </Routes>
             </BrowserRouter>
             <PomodoroTimer compact />
+            <PomodoroTicker />
             </CurrentCategoryProvider>
           </FlashcardStoreProvider>
         </TaskStoreProvider>
+        </PomodoroHistoryProvider>
       </SettingsProvider>
     </TooltipProvider>
   </QueryClientProvider>

--- a/src/components/PomodoroStats.tsx
+++ b/src/components/PomodoroStats.tsx
@@ -6,7 +6,7 @@ import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from 'recha
 const PomodoroStats: React.FC = () => {
   const stats = usePomodoroStats();
   return (
-    <div className="space-y-4">
+    <div className="w-full grid gap-4 md:grid-cols-2">
       <Card>
         <CardHeader>
           <CardTitle className="text-base">Gesamt</CardTitle>

--- a/src/components/PomodoroTicker.tsx
+++ b/src/components/PomodoroTicker.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react'
+import { usePomodoroStore } from './PomodoroTimer'
+import { usePomodoroHistory } from '@/hooks/usePomodoroHistory'
+
+const PomodoroTicker = () => {
+  const tick = usePomodoroStore(state => state.tick)
+  const mode = usePomodoroStore(state => state.mode)
+  const setStartTime = usePomodoroStore(state => state.setStartTime)
+  const startTime = usePomodoroStore(state => state.startTime)
+  const addSession = usePomodoroHistory().addSession
+  const prevMode = useRef(mode)
+
+  useEffect(() => {
+    const interval = setInterval(() => tick(), 1000)
+    return () => clearInterval(interval)
+  }, [tick])
+
+  useEffect(() => {
+    if (prevMode.current === 'work' && mode === 'break' && startTime) {
+      addSession(startTime, Date.now())
+      setStartTime(undefined)
+    }
+    if (prevMode.current === 'break' && mode === 'work') {
+      setStartTime(Date.now())
+    }
+    prevMode.current = mode
+  }, [mode, startTime, addSession, setStartTime])
+
+  return null
+}
+
+export default PomodoroTicker

--- a/src/hooks/usePomodoroHistory.ts
+++ b/src/hooks/usePomodoroHistory.ts
@@ -1,19 +1,63 @@
-import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
-import { PomodoroSession } from '@/types';
+import React, { createContext, useContext, useEffect, useState } from 'react'
+import { PomodoroSession } from '@/types'
 
-interface PomodoroHistoryState {
-  sessions: PomodoroSession[];
-  addSession: (start: number, end: number) => void;
+const API_URL = '/api/pomodoro-sessions'
+
+const usePomodoroHistoryImpl = () => {
+  const [sessions, setSessions] = useState<PomodoroSession[]>([])
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch(API_URL)
+        if (res.ok) {
+          const data = await res.json()
+          setSessions(data || [])
+        }
+      } catch (err) {
+        console.error('Fehler beim Laden der Pomodoro-Sessions', err)
+      }
+    }
+    load()
+  }, [])
+
+  useEffect(() => {
+    const save = async () => {
+      try {
+        await fetch(API_URL, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(sessions)
+        })
+      } catch (err) {
+        console.error('Fehler beim Speichern der Pomodoro-Sessions', err)
+      }
+    }
+    save()
+  }, [sessions])
+
+  const addSession = (start: number, end: number) => {
+    setSessions(prev => [...prev, { start, end }])
+  }
+
+  return { sessions, addSession }
 }
 
-export const usePomodoroHistory = create<PomodoroHistoryState>()(
-  persist(
-    set => ({
-      sessions: [],
-      addSession: (start, end) =>
-        set(state => ({ sessions: [...state.sessions, { start, end }] }))
-    }),
-    { name: 'pomodoro-history' }
+type Store = ReturnType<typeof usePomodoroHistoryImpl>
+
+const PomodoroHistoryContext = createContext<Store | null>(null)
+
+export const PomodoroHistoryProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const store = usePomodoroHistoryImpl()
+  return (
+    <PomodoroHistoryContext.Provider value={store}>
+      {children}
+    </PomodoroHistoryContext.Provider>
   )
-);
+}
+
+export const usePomodoroHistory = () => {
+  const ctx = useContext(PomodoroHistoryContext)
+  if (!ctx) throw new Error('usePomodoroHistory must be used within PomodoroHistoryProvider')
+  return ctx
+}

--- a/src/hooks/usePomodoroStats.ts
+++ b/src/hooks/usePomodoroStats.ts
@@ -3,7 +3,7 @@ import { usePomodoroHistory } from './usePomodoroHistory';
 import { PomodoroStats } from '@/types';
 
 export const usePomodoroStats = (): PomodoroStats => {
-  const sessions = usePomodoroHistory(state => state.sessions);
+  const { sessions } = usePomodoroHistory();
 
   return useMemo(() => {
     const minutes = (start: number, end: number) => Math.round((end - start) / 60000);

--- a/src/pages/Pomodoro.tsx
+++ b/src/pages/Pomodoro.tsx
@@ -9,7 +9,7 @@ const PomodoroPage: React.FC = () => {
       <Navbar title="Pomodoro" />
       <div className="flex-grow p-4 space-y-6 flex flex-col items-center">
         <PomodoroTimer size={150} />
-        <PomodoroStats />
+        <div className="w-full max-w-4xl"><PomodoroStats /></div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- store pomodoro settings and history in the database
- add API endpoints for settings and pomodoro sessions
- remove duplicate timer interval with new `PomodoroTicker`
- update stats layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684729e4e064832a931f8a4d61338973