### PR TITLE
Fix pomodoro history import resolution

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ import NotFound from "./pages/NotFound";
 import PomodoroPage from "./pages/Pomodoro";
 import PomodoroTimer from "@/components/PomodoroTimer";
 import PomodoroTicker from "@/components/PomodoroTicker";
-import { PomodoroHistoryProvider } from "@/hooks/usePomodoroHistory";
+import { PomodoroHistoryProvider } from "@/hooks/usePomodoroHistory.tsx";
 
 const queryClient = new QueryClient();
 

--- a/src/components/PomodoroTicker.tsx
+++ b/src/components/PomodoroTicker.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { usePomodoroStore } from './PomodoroTimer'
-import { usePomodoroHistory } from '@/hooks/usePomodoroHistory'
+import { usePomodoroHistory } from '@/hooks/usePomodoroHistory.tsx'
 
 const PomodoroTicker = () => {
   const tick = usePomodoroStore(state => state.tick)

--- a/src/hooks/usePomodoroStats.ts
+++ b/src/hooks/usePomodoroStats.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { usePomodoroHistory } from './usePomodoroHistory';
+import { usePomodoroHistory } from './usePomodoroHistory.tsx';
 import { PomodoroStats } from '@/types';
 
 export const usePomodoroStats = (): PomodoroStats => {


### PR DESCRIPTION
## Summary
- fix import paths for pomodoro history hook so Vite resolves the correct file

## Testing
- `npm run lint` *(fails: Cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_68472d336f3c832a8d99ca4514a403b1