### PR TITLE
Fix Pomodoro timer not persisting

### DIFF
--- a/src/components/PomodoroTimer.tsx
+++ b/src/components/PomodoroTimer.tsx
@@ -74,10 +74,7 @@ export const usePomodoroStore = create<PomodoroState>()(
         set(state => ({
           workDuration: work,
           breakDuration: brk,
-          remainingTime:
-            !state.isRunning || state.mode === 'work'
-              ? work
-              : state.remainingTime
+          remainingTime: !state.isRunning ? work : state.remainingTime
         }))
     }),
     { name: 'pomodoro' }


### PR DESCRIPTION
## Summary
- prevent timer reset when opening Pomodoro page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68472f962150832a900e30fe6f3e63fb