### PR TITLE
Add typing mode to flashcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ npm start    # startet die gebaute App auf Port 3002
   - Decks lassen sich beim Lernen ein- oder ausblenden
   - Optionaler Zufallsmodus ohne Bewertung
   - Trainingsmodus direkt auf der Kartenseite mit 5 Karten pro Runde und Fazit
+  - Eingabemodus zum Tippen der Antworten
 - Statistikseite für Lernkarten
 - Speicherung der Daten auf dem lokalen Server
 - Pomodoro-Timer läuft beim Neuladen der Seite weiter
@@ -82,7 +83,8 @@ npm start    # startet die gebaute App auf Port 3002
 6. Unter **Notizen** kannst du unabhängige Notizen verwalten und per Drag & Drop sortieren.
 7. Unter **Decks** legst du Kartendecks an und kannst sie bearbeiten. In der Detailansicht eines Decks fügst du einzelne Karten hinzu.
 8. Der Bereich **Karten** zeigt dir fällige Karten zum Lernen an. Dort kannst du
-   gezielt Decks ein- oder ausblenden und einen Zufallsmodus aktivieren.
+   gezielt Decks ein- oder ausblenden, einen Zufallsmodus aktivieren und im
+   Eingabemodus Antworten eintippen.
 
 Viel Spaß beim Ausprobieren!
 

--- a/src/hooks/useFlashcardStore.tsx
+++ b/src/hooks/useFlashcardStore.tsx
@@ -20,7 +20,9 @@ const useFlashcardStoreImpl = () => {
               dueDate: new Date(c.dueDate),
               easyCount: c.easyCount ?? 0,
               mediumCount: c.mediumCount ?? 0,
-              hardCount: c.hardCount ?? 0
+              hardCount: c.hardCount ?? 0,
+              typedCorrect: c.typedCorrect ?? 0,
+              typedTotal: c.typedTotal ?? 0
             }))
           );
         }
@@ -88,7 +90,9 @@ const useFlashcardStoreImpl = () => {
       dueDate: new Date(),
       easyCount: 0,
       mediumCount: 0,
-      hardCount: 0
+      hardCount: 0,
+      typedCorrect: 0,
+      typedTotal: 0
     };
     setFlashcards(prev => [...prev, newCard]);
   };
@@ -120,7 +124,8 @@ const useFlashcardStoreImpl = () => {
 
   const rateFlashcard = (
     id: string,
-    difficulty: 'easy' | 'medium' | 'hard'
+    difficulty: 'easy' | 'medium' | 'hard',
+    typedCorrect?: boolean
   ) => {
     setFlashcards(prev => {
       return prev.map(card => {
@@ -143,7 +148,14 @@ const useFlashcardStoreImpl = () => {
           dueDate,
           easyCount: card.easyCount + (difficulty === 'easy' ? 1 : 0),
           mediumCount: card.mediumCount + (difficulty === 'medium' ? 1 : 0),
-          hardCount: card.hardCount + (difficulty === 'hard' ? 1 : 0)
+          hardCount: card.hardCount + (difficulty === 'hard' ? 1 : 0),
+          typedCorrect: typedCorrect !== undefined
+            ? (card.typedCorrect ?? 0) + (typedCorrect ? 1 : 0)
+            : card.typedCorrect,
+          typedTotal:
+            typedCorrect !== undefined
+              ? (card.typedTotal ?? 0) + 1
+              : card.typedTotal
         };
       });
     });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -77,6 +77,8 @@ export interface Flashcard {
   easyCount: number;
   mediumCount: number;
   hardCount: number;
+  typedCorrect?: number;
+  typedTotal?: number;
 }
 
 export interface Deck {


### PR DESCRIPTION
## Summary
- extend Flashcard type with typing statistics
- store typing statistics when rating cards
- add typing mode to flashcard page with input and feedback
- document the new mode in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_684731d625b0832ab0c9e90eab616203