### PR TITLE
Enable manual rating for typed flashcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ npm start    # startet die gebaute App auf Port 3002
   - Decks lassen sich beim Lernen ein- oder ausblenden
   - Optionaler Zufallsmodus ohne Bewertung
   - Trainingsmodus direkt auf der Kartenseite mit 5 Karten pro Runde und Fazit
-  - Eingabemodus zum Tippen der Antworten
+  - Eingabemodus zum Tippen der Antworten; nach dem Prüfen bewertest du selbst, ob die Karte leicht, mittel oder schwer war
 - Statistikseite für Lernkarten
 - Speicherung der Daten auf dem lokalen Server
 - Pomodoro-Timer läuft beim Neuladen der Seite weiter
@@ -87,7 +87,8 @@ npm start    # startet die gebaute App auf Port 3002
 7. Unter **Decks** legst du Kartendecks an und kannst sie bearbeiten. In der Detailansicht eines Decks fügst du einzelne Karten hinzu.
 8. Der Bereich **Karten** zeigt dir fällige Karten zum Lernen an. Dort kannst du
    gezielt Decks ein- oder ausblenden, einen Zufallsmodus aktivieren und im
-   Eingabemodus Antworten eintippen.
+   Eingabemodus Antworten eintippen. Nach dem Vergleich der Lösung entscheidest
+   du selbst, wie schwer dir die Karte fiel.
 
 Viel Spaß beim Ausprobieren!
 

--- a/src/pages/Flashcards.tsx
+++ b/src/pages/Flashcards.tsx
@@ -245,12 +245,26 @@ const FlashcardsPage: React.FC = () => {
                     Check
                   </Button>
                 ) : (
-                  <Button
-                    variant="outline"
-                    onClick={() => handleRate(isCorrect ? 'easy' : 'hard')}
-                  >
-                    Next
-                  </Button>
+                  <>
+                    <Button
+                      variant="outline"
+                      onClick={() => handleRate('hard')}
+                    >
+                      Schwer
+                    </Button>
+                    <Button
+                      variant="outline"
+                      onClick={() => handleRate('medium')}
+                    >
+                      Mittel
+                    </Button>
+                    <Button
+                      variant="outline"
+                      onClick={() => handleRate('easy')}
+                    >
+                      Leicht
+                    </Button>
+                  </>
                 )
               ) : randomMode && !trainingMode ? (
                 <Button variant="outline" onClick={() => handleRate('easy')}>


### PR DESCRIPTION
## Summary
- let users rate their own answers in typing mode
- document new workflow for the input mode

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684736df17f0832aa199585c5865e7dd