### PR TITLE
Add time-of-day statistics to Pomodoro

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,12 @@ npm start    # startet die gebaute App auf Port 3002
   - Eingabemodus zum Tippen der Antworten
 - Statistikseite für Lernkarten
 - Speicherung der Daten auf dem lokalen Server
-- Pomodoro-Timer läuft beim Neuladen der Seite weiter
-- Statistikseite auf der Pomodoro-Seite mit Tages-, Wochen-, Monats- und Jahresübersicht
-- Minuten für Arbeit und Pause werden separat gezählt und als gestapelter Balken
-  dargestellt. Beim Pausieren oder Zurücksetzen des Timers werden die Werte
+ - Pomodoro-Timer läuft beim Neuladen der Seite weiter
+ - Statistikseite auf der Pomodoro-Seite mit Tages-, Wochen-, Monats- und Jahresübersicht
+   - Auswertung nach Tageszeiten (Morgen, Mittag, Abend, Nacht)
+   - Zusätzliche Anzeige für den aktuellen Tag
+ - Minuten für Arbeit und Pause werden separat gezählt und als gestapelter Balken
+    dargestellt. Beim Pausieren oder Zurücksetzen des Timers werden die Werte
   sofort aktualisiert.
 - Lern- und Pausendauer frei konfigurierbar (auch direkt im Timer anpassbar)
 

--- a/src/components/PomodoroStats.tsx
+++ b/src/components/PomodoroStats.tsx
@@ -43,6 +43,29 @@ const PomodoroStats: React.FC = () => {
           <CardTitle className="text-base">Heute</CardTitle>
         </CardHeader>
         <CardContent>
+          <p className="text-sm">Arbeit: {stats.todayTotals.workMinutes} min</p>
+          <p className="text-sm">Pause: {stats.todayTotals.breakMinutes} min</p>
+          <p className="text-sm mb-2">Zyklen: {stats.todayTotals.cycles}</p>
+          <div className="w-full h-3 bg-gray-200 rounded overflow-hidden mb-4">
+            <div
+              className="h-full bg-indigo-500"
+              style={{ width: `${
+                stats.todayTotals.workMinutes + stats.todayTotals.breakMinutes === 0
+                  ? 0
+                  : (stats.todayTotals.workMinutes /
+                      (stats.todayTotals.workMinutes + stats.todayTotals.breakMinutes)) * 100
+              }%` }}
+            />
+            <div
+              className="h-full bg-green-500"
+              style={{ width: `${
+                stats.todayTotals.workMinutes + stats.todayTotals.breakMinutes === 0
+                  ? 0
+                  : (stats.todayTotals.breakMinutes /
+                      (stats.todayTotals.workMinutes + stats.todayTotals.breakMinutes)) * 100
+              }%` }}
+            />
+          </div>
           <div className="h-40">
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={stats.today} margin={{ top: 10, right: 20, left: 0, bottom: 20 }}>
@@ -51,6 +74,30 @@ const PomodoroStats: React.FC = () => {
                 <Tooltip />
                 <Bar dataKey="work" stackId="a" fill="#4f46e5" />
                 <Bar dataKey="break" stackId="a" fill="#16a34a" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Tageszeiten (Gesamt)</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-40">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={[
+                  { time: 'Morgen', value: stats.timeOfDay.morning },
+                  { time: 'Mittag', value: stats.timeOfDay.afternoon },
+                  { time: 'Abend', value: stats.timeOfDay.evening },
+                  { time: 'Nacht', value: stats.timeOfDay.night }
+                ]}
+                margin={{ top: 10, right: 20, left: 0, bottom: 20 }}>
+                <XAxis dataKey="time" fontSize={12} />
+                <YAxis fontSize={12} />
+                <Tooltip />
+                <Bar dataKey="value" fill="#4f46e5" />
               </BarChart>
             </ResponsiveContainer>
           </div>

--- a/src/hooks/usePomodoroStats.ts
+++ b/src/hooks/usePomodoroStats.ts
@@ -68,16 +68,61 @@ export const usePomodoroStats = (): PomodoroStats => {
       return Object.keys(data).map(key => ({ date: key, ...data[key] }));
     };
 
-    const weekData = aggregateBy(week, d => d.toLocaleDateString('de-DE', { weekday: 'short' }), 7, 'day');
+    const weekData = aggregateBy(
+      week,
+      d => d.toLocaleDateString('de-DE', { weekday: 'short' }),
+      7,
+      'day'
+    );
     const daysInMonth = new Date().getDate();
-    const monthData = aggregateBy(month, d => d.getDate().toString(), daysInMonth, 'day');
-    const yearData = aggregateBy(year, d => d.toLocaleDateString('de-DE', { month: 'short' }), 12, 'month');
+    const monthData = aggregateBy(
+      month,
+      d => d.getDate().toString(),
+      daysInMonth,
+      'day'
+    );
+    const yearData = aggregateBy(
+      year,
+      d => d.toLocaleDateString('de-DE', { month: 'short' }),
+      12,
+      'month'
+    );
+
+    const todayTotals = {
+      workMinutes: today.reduce(
+        (sum, s) => sum + minutes(s.start, s.end),
+        0
+      ),
+      breakMinutes: today.reduce(
+        (sum, s) => sum + minutes(s.end, s.breakEnd ?? s.end),
+        0
+      ),
+      cycles: today.length
+    };
+
+    const timeOfDay = {
+      morning: 0,
+      afternoon: 0,
+      evening: 0,
+      night: 0
+    };
+    sessions.forEach(s => {
+      const start = new Date(s.start);
+      const h = start.getHours();
+      const m = minutes(s.start, s.end);
+      if (h >= 6 && h < 12) timeOfDay.morning += m;
+      else if (h >= 12 && h < 18) timeOfDay.afternoon += m;
+      else if (h >= 18 && h < 24) timeOfDay.evening += m;
+      else timeOfDay.night += m;
+    });
 
     return {
       totalWorkMinutes,
       totalBreakMinutes,
       totalCycles,
+      todayTotals,
       today: todayData,
+      timeOfDay,
       week: weekData,
       month: monthData,
       year: yearData

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -122,7 +122,18 @@ export interface PomodoroStats {
   totalWorkMinutes: number;
   totalBreakMinutes: number;
   totalCycles: number;
+  todayTotals: {
+    workMinutes: number;
+    breakMinutes: number;
+    cycles: number;
+  };
   today: { time: string; work: number; break: number }[];
+  timeOfDay: {
+    morning: number;
+    afternoon: number;
+    evening: number;
+    night: number;
+  };
   week: { date: string; work: number; break: number }[];
   month: { date: string; work: number; break: number }[];
   year: { month: string; work: number; break: number }[];


### PR DESCRIPTION
## Summary
- show totals for today in Pomodoro statistics
- add new time-of-day analysis (morning, afternoon, evening, night)
- update README with new statistics features

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_684737778aa8832a871fc741ec464fbf