### PR TITLE
Fix notes export and merge imports

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -333,7 +333,7 @@ const server = http.createServer((req, res) => {
     }
   }
 
-  if (parsed.pathname === '/api/notes') {
+  if (parsed.pathname === '/api/notes' || parsed.pathname === '/api/notes/') {
     if (req.method === 'GET') {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify(loadNotes()));


### PR DESCRIPTION
## Summary
- accept trailing slash for notes API
- skip duplicates when importing tasks, notes, decks and full exports

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx -y tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_684741ef48e0832aaf88d13f745cde29