### PR TITLE
Fix pomodoro ticker loop

### DIFF
--- a/src/components/PomodoroTicker.tsx
+++ b/src/components/PomodoroTicker.tsx
@@ -25,7 +25,7 @@ const PomodoroTicker = () => {
       setLastTick(Date.now())
     }, 1000)
     return () => clearInterval(interval)
-  }, [tick, lastTick, setLastTick])
+  }, [tick, setLastTick])
 
   useEffect(() => {
     if (prevMode.current === 'work' && mode === 'break' && startTime) {


### PR DESCRIPTION
## Summary
- prevent `PomodoroTicker` from causing an update loop by removing `lastTick` from effect deps

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68475e58fc08832abcde966c105c99af