### PR TITLE
Fix drag-and-drop deprecation warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
         "react": "^18.3.1",
-        "react-beautiful-dnd": "^13.1.1",
+        "@hello-pangea/dnd": "^14.0.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
@@ -6363,26 +6363,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-beautiful-dnd": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz",
-      "integrity": "sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==",
-      "deprecated": "react-beautiful-dnd is now deprecated. Context and options: https://github.com/atlassian/react-beautiful-dnd/issues/2672",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2",
-        "css-box-model": "^1.2.0",
-        "memoize-one": "^5.1.1",
-        "raf-schd": "^4.0.2",
-        "react-redux": "^7.2.0",
-        "redux": "^4.0.4",
-        "use-memo-one": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.5 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.5 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-day-picker": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
     "recharts": "^2.12.7",
-    "react-beautiful-dnd": "^13.1.1",
+    "@hello-pangea/dnd": "^14.0.1",
     "sonner": "^1.5.0",
     "zustand": "^4.5.2",
     "tailwind-merge": "^2.5.2",

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -34,7 +34,7 @@ import {
   Droppable,
   Draggable,
   DropResult
-} from 'react-beautiful-dnd';
+} from '@hello-pangea/dnd';
 import Navbar from './Navbar';
 import { usePomodoroStore } from './PomodoroTimer';
 

--- a/src/pages/Kanban.tsx
+++ b/src/pages/Kanban.tsx
@@ -13,7 +13,7 @@ import {
   Droppable,
   Draggable,
   DropResult
-} from 'react-beautiful-dnd';
+} from '@hello-pangea/dnd';
 
 const Kanban: React.FC = () => {
   const {

--- a/src/pages/Notes.tsx
+++ b/src/pages/Notes.tsx
@@ -4,7 +4,7 @@ import { useTaskStore } from '@/hooks/useTaskStore';
 import NoteModal from '@/components/NoteModal';
 import NoteCard from '@/components/NoteCard';
 import { Button } from '@/components/ui/button';
-import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
+import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea/dnd';
 import Navbar from '@/components/Navbar';
 
 const NotesPage = () => {


### PR DESCRIPTION
## Summary
- replace deprecated `react-beautiful-dnd` with `@hello-pangea/dnd`
- update imports in Dashboard, Notes, and Kanban
- update dependency lists

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68475ffb6274832aae2fd698c22337e8