### PR TITLE
Reorganize tasks and add home hub

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,8 @@ import { CurrentCategoryProvider } from "@/hooks/useCurrentCategory";
 import { SettingsProvider } from "@/hooks/useSettings";
 import { FlashcardStoreProvider } from "@/hooks/useFlashcardStore";
 import CommandPalette from "@/components/CommandPalette";
-import Index from "./pages/Index";
+import Home from "./pages/Home";
+import TasksPage from "./pages/Tasks";
 import Statistics from "./pages/Statistics";
 import CalendarPage from "./pages/Calendar";
 import Kanban from "./pages/Kanban";
@@ -40,7 +41,8 @@ const App = () => (
             <BrowserRouter>
               <CommandPalette />
               <Routes>
-              <Route path="/" element={<Index />} />
+              <Route path="/" element={<Home />} />
+              <Route path="/tasks" element={<TasksPage />} />
               <Route path="/statistics" element={<Statistics />} />
               <Route path="/calendar" element={<CalendarPage />} />
               <Route path="/kanban" element={<Kanban />} />

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -107,7 +107,7 @@ const CommandPalette: React.FC = () => {
               setCurrentCategoryId(item.task.categoryId)
               setOpen(false)
               setValue('')
-              navigate(`/?taskId=${item.task.id}`)
+              navigate(`/tasks?taskId=${item.task.id}`)
             }}
           >
             {item.path.length > 0

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -70,56 +70,34 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
           </div>
           <div className="hidden sm:flex items-center space-x-4">
             <DropdownMenu
-              open={openMenu === 'dashboard'}
-              onOpenChange={(open) => setOpenMenu(open ? 'dashboard' : null)}
+              open={openMenu === 'tasks'}
+              onOpenChange={(open) => setOpenMenu(open ? 'tasks' : null)}
             >
               <DropdownMenuTrigger asChild>
                 <Button
                   variant="outline"
                   size="sm"
-                  onMouseEnter={() => setOpenMenu('dashboard')}
+                  onMouseEnter={() => setOpenMenu('tasks')}
                   onMouseLeave={() => setOpenMenu(null)}
                 >
-                  Dashboard
+                  Tasks
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent
                 className="bg-white z-50"
-                onMouseEnter={() => setOpenMenu('dashboard')}
+                onMouseEnter={() => setOpenMenu('tasks')}
                 onMouseLeave={() => setOpenMenu(null)}
               >
                 <DropdownMenuItem asChild>
-                  <Link to="/" className="flex items-center">
+                  <Link to="/tasks" className="flex items-center">
                     <LayoutGrid className="h-4 w-4 mr-2" /> Übersicht
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
-                  <Link to="/statistics" className="flex items-center">
-                    <BarChart3 className="h-4 w-4 mr-2" /> Statistiken
+                  <Link to="/kanban" className="flex items-center">
+                    <Columns className="h-4 w-4 mr-2" /> Kanban
                   </Link>
                 </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-
-            <DropdownMenu
-              open={openMenu === 'planning'}
-              onOpenChange={(open) => setOpenMenu(open ? 'planning' : null)}
-            >
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onMouseEnter={() => setOpenMenu('planning')}
-                  onMouseLeave={() => setOpenMenu(null)}
-                >
-                  Planung
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent
-                className="bg-white z-50"
-                onMouseEnter={() => setOpenMenu('planning')}
-                onMouseLeave={() => setOpenMenu(null)}
-              >
                 <DropdownMenuItem asChild>
                   <Link to="/calendar" className="flex items-center">
                     <CalendarIcon className="h-4 w-4 mr-2" /> Kalender
@@ -131,8 +109,8 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
-                  <Link to="/kanban" className="flex items-center">
-                    <Columns className="h-4 w-4 mr-2" /> Kanban
+                  <Link to="/statistics" className="flex items-center">
+                    <BarChart3 className="h-4 w-4 mr-2" /> Statistiken
                   </Link>
                 </DropdownMenuItem>
               </DropdownMenuContent>
@@ -175,61 +153,35 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
               </DropdownMenuContent>
             </DropdownMenu>
 
-            <DropdownMenu
-              open={openMenu === 'more'}
-              onOpenChange={(open) => setOpenMenu(open ? 'more' : null)}
-            >
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onMouseEnter={() => setOpenMenu('more')}
-                  onMouseLeave={() => setOpenMenu(null)}
-                >
-                  Mehr
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent
-                className="bg-white z-50"
-                onMouseEnter={() => setOpenMenu('more')}
-                onMouseLeave={() => setOpenMenu(null)}
-              >
-                <DropdownMenuItem asChild>
-                  <Link to="/notes" className="flex items-center">
-                    <List className="h-4 w-4 mr-2" /> Notizen
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem asChild>
-                  <Link to="/settings" className="flex items-center">
-                    <Cog className="h-4 w-4 mr-2" /> Einstellungen
-                  </Link>
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <Link to="/notes">
+              <Button variant="outline" size="sm">
+                <List className="h-4 w-4 mr-2" /> Notizen
+              </Button>
+            </Link>
+            <Link to="/settings">
+              <Button variant="outline" size="sm">
+                <Cog className="h-4 w-4 mr-2" /> Einstellungen
+              </Button>
+            </Link>
           </div>
         </div>
         {showMobileMenu && (
           <div className="sm:hidden pb-4 space-y-4">
             <div className="space-y-2">
-              <p className="text-xs font-semibold text-gray-500">Dashboard</p>
+              <p className="text-xs font-semibold text-gray-500">Tasks</p>
               <div className="flex flex-wrap gap-2">
-                <Link to="/" className="flex-1">
+                <Link to="/tasks" className="flex-1">
                   <Button variant="outline" size="sm" className="w-full">
                     <LayoutGrid className="h-4 w-4 mr-2" />
                     Übersicht
                   </Button>
                 </Link>
-                <Link to="/statistics" className="flex-1">
+                <Link to="/kanban" className="flex-1">
                   <Button variant="outline" size="sm" className="w-full">
-                    <BarChart3 className="h-4 w-4 mr-2" />
-                    Statistiken
+                    <Columns className="h-4 w-4 mr-2" />
+                    Kanban
                   </Button>
                 </Link>
-              </div>
-            </div>
-            <div className="space-y-2">
-              <p className="text-xs font-semibold text-gray-500">Planung</p>
-              <div className="flex flex-wrap gap-2">
                 <Link to="/calendar" className="flex-1">
                   <Button variant="outline" size="sm" className="w-full">
                     <CalendarIcon className="h-4 w-4 mr-2" />
@@ -242,10 +194,10 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                     Pomodoro
                   </Button>
                 </Link>
-                <Link to="/kanban" className="flex-1">
+                <Link to="/statistics" className="flex-1">
                   <Button variant="outline" size="sm" className="w-full">
-                    <Columns className="h-4 w-4 mr-2" />
-                    Kanban
+                    <BarChart3 className="h-4 w-4 mr-2" />
+                    Statistiken
                   </Button>
                 </Link>
               </div>
@@ -274,7 +226,7 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
               </div>
             </div>
             <div className="space-y-2">
-              <p className="text-xs font-semibold text-gray-500">Mehr</p>
+              <p className="text-xs font-semibold text-gray-500">Notizen</p>
               <div className="flex flex-wrap gap-2">
                 <Link to="/notes" className="flex-1">
                   <Button variant="outline" size="sm" className="w-full">
@@ -282,6 +234,11 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                     Notizen
                   </Button>
                 </Link>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <p className="text-xs font-semibold text-gray-500">Einstellungen</p>
+              <div className="flex flex-wrap gap-2">
                 <Link to="/settings" className="flex-1">
                   <Button variant="outline" size="sm" className="w-full">
                     <Cog className="h-4 w-4 mr-2" />

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import Navbar from '@/components/Navbar';
+import { Card, CardContent, CardTitle } from '@/components/ui/card';
+import { LayoutGrid, BookOpen, List } from 'lucide-react';
+
+const Home: React.FC = () => (
+  <div className="min-h-screen bg-gray-50">
+    <Navbar />
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <Link to="/tasks">
+          <Card className="hover:shadow-md transition-all text-center">
+            <CardContent className="py-8">
+              <LayoutGrid className="h-8 w-8 mx-auto mb-2" />
+              <CardTitle>Tasks</CardTitle>
+            </CardContent>
+          </Card>
+        </Link>
+        <Link to="/flashcards">
+          <Card className="hover:shadow-md transition-all text-center">
+            <CardContent className="py-8">
+              <BookOpen className="h-8 w-8 mx-auto mb-2" />
+              <CardTitle>Flashcards</CardTitle>
+            </CardContent>
+          </Card>
+        </Link>
+        <Link to="/notes">
+          <Card className="hover:shadow-md transition-all text-center">
+            <CardContent className="py-8">
+              <List className="h-8 w-8 mx-auto mb-2" />
+              <CardTitle>Notizen</CardTitle>
+            </CardContent>
+          </Card>
+        </Link>
+      </div>
+    </div>
+  </div>
+);
+
+export default Home;

--- a/src/pages/Tasks.tsx
+++ b/src/pages/Tasks.tsx
@@ -1,8 +1,8 @@
 
 import Dashboard from '@/components/Dashboard';
 
-const Index = () => {
+const TasksPage = () => {
   return <Dashboard />;
 };
 
-export default Index;
+export default TasksPage;


### PR DESCRIPTION
## Summary
- add new `Home` page as global hub
- move dashboard to `/tasks`
- update navbar with dedicated *Tasks* section and direct links for Notes and Settings
- adjust command palette and routes for new task location

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684880d982f8832abc1ec7b013e84f2d