### PR TITLE
Add deck progress and statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ npm start    # startet die gebaute App auf Port 3002
   - Eingabemodus zum Tippen der Antworten; nach dem Prüfen bewertest du selbst, ob die Karte leicht, mittel oder schwer war
   - Timed-Modus mit 10 Sekunden Countdown pro Karte; der Timer wird einmalig gestartet und kann pausiert werden. Bei Ablauf wird automatisch "schwer" gewertet
 - Statistikseite für Lernkarten
+  - Deck-Statistiken mit Übersicht fälliger Karten
 - Speicherung der Daten auf dem lokalen Server
  - Pomodoro-Timer läuft beim Neuladen der Seite weiter
  - Statistikseite auf der Pomodoro-Seite mit Tages-, Wochen-, Monats- und Jahresübersicht

--- a/src/hooks/useFlashcardStatistics.ts
+++ b/src/hooks/useFlashcardStatistics.ts
@@ -11,10 +11,11 @@ export interface FlashcardStats {
     hard: number;
   };
   upcomingDue: { date: string; count: number }[];
+  deckStats: { deckId: string; deckName: string; total: number; due: number }[];
 }
 
 export const useFlashcardStatistics = (): FlashcardStats => {
-  const { flashcards } = useFlashcardStore();
+  const { flashcards, decks } = useFlashcardStore();
 
   return useMemo(() => {
     const totalCards = flashcards.length;
@@ -48,6 +49,13 @@ export const useFlashcardStatistics = (): FlashcardStats => {
       });
     }
 
-    return { totalCards, dueCards, averageInterval, difficultyCounts, upcomingDue };
-  }, [flashcards]);
+    const deckStats = decks.map(deck => {
+      const cards = flashcards.filter(c => c.deckId === deck.id);
+      const total = cards.length;
+      const due = cards.filter(c => new Date(c.dueDate) <= new Date()).length;
+      return { deckId: deck.id, deckName: deck.name, total, due };
+    });
+
+    return { totalCards, dueCards, averageInterval, difficultyCounts, upcomingDue, deckStats };
+  }, [flashcards, decks]);
 };

--- a/src/hooks/useFlashcardStore.tsx
+++ b/src/hooks/useFlashcardStore.tsx
@@ -122,6 +122,14 @@ const useFlashcardStoreImpl = () => {
     setFlashcards(prev => prev.filter(c => c.deckId !== id));
   };
 
+  const countCardsForDeck = (deckId: string) =>
+    flashcards.filter(c => c.deckId === deckId).length;
+
+  const countDueCardsForDeck = (deckId: string) =>
+    flashcards.filter(
+      c => c.deckId === deckId && new Date(c.dueDate) <= new Date()
+    ).length;
+
   const rateFlashcard = (
     id: string,
     difficulty: 'easy' | 'medium' | 'hard',
@@ -170,7 +178,9 @@ const useFlashcardStoreImpl = () => {
     rateFlashcard,
     addDeck,
     updateDeck,
-    deleteDeck
+    deleteDeck,
+    countCardsForDeck,
+    countDueCardsForDeck
   };
 };
 

--- a/src/pages/DeckDetail.tsx
+++ b/src/pages/DeckDetail.tsx
@@ -10,9 +10,19 @@ import { Plus, Pencil, Trash2 } from 'lucide-react';
 const DeckDetailPage: React.FC = () => {
   const { deckId } = useParams<{ deckId: string }>();
   const navigate = useNavigate();
-  const { flashcards, decks, addFlashcard, updateFlashcard, deleteFlashcard } = useFlashcardStore();
+  const {
+    decks,
+    addFlashcard,
+    updateFlashcard,
+    deleteFlashcard,
+    countCardsForDeck,
+    countDueCardsForDeck,
+    flashcards
+  } = useFlashcardStore();
   const deck = decks.find(d => d.id === deckId);
   const cards = flashcards.filter(c => c.deckId === deckId);
+  const totalCount = countCardsForDeck(deckId!);
+  const dueCount = countDueCardsForDeck(deckId!);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
 
@@ -33,7 +43,10 @@ const DeckDetailPage: React.FC = () => {
     <div className="min-h-screen bg-gray-50">
       <Navbar title={deck.name} onHomeClick={() => navigate('/flashcards/manage')} />
       <div className="max-w-2xl mx-auto py-8 px-4 space-y-4">
-        <div className="flex justify-end">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground">
+            {dueCount}/{totalCount} fällig
+          </span>
           <Button size="sm" onClick={() => setIsModalOpen(true)}>
             <Plus className="h-4 w-4 mr-2" /> Neue Karte
           </Button>

--- a/src/pages/FlashcardManager.tsx
+++ b/src/pages/FlashcardManager.tsx
@@ -9,7 +9,14 @@ import { useFlashcardStore } from '@/hooks/useFlashcardStore';
 import { Deck } from '@/types';
 
 const FlashcardManagerPage: React.FC = () => {
-  const { decks, flashcards, addDeck, updateDeck, deleteDeck } = useFlashcardStore();
+  const {
+    decks,
+    addDeck,
+    updateDeck,
+    deleteDeck,
+    countCardsForDeck,
+    countDueCardsForDeck
+  } = useFlashcardStore();
   const navigate = useNavigate();
   const [isDeckModalOpen, setIsDeckModalOpen] = useState(false);
   const [editingDeck, setEditingDeck] = useState<Deck | null>(null);
@@ -37,13 +44,17 @@ const FlashcardManagerPage: React.FC = () => {
         ) : (
           <div className="space-y-4">
             {decks.map(deck => {
-              const count = flashcards.filter(c => c.deckId === deck.id).length;
+              const total = countCardsForDeck(deck.id);
+              const due = countDueCardsForDeck(deck.id);
               return (
                 <Card key={deck.id} onClick={() => navigate(`/flashcards/deck/${deck.id}`)} className="cursor-pointer">
                   <CardHeader>
                     <CardTitle>{deck.name}</CardTitle>
                   </CardHeader>
-                  <CardContent>{count} Karte{count !== 1 ? 'n' : ''}</CardContent>
+                  <CardContent>
+                    {total} Karte{total !== 1 ? 'n' : ''}
+                    <div className="text-sm text-muted-foreground">{due}/{total} fällig</div>
+                  </CardContent>
                   <CardFooter className="flex justify-end space-x-2">
                     <Button variant="outline" size="sm" onClick={e => { e.stopPropagation(); setEditingDeck(deck); setIsDeckModalOpen(true); }}>
                       <Pencil className="h-4 w-4" />

--- a/src/pages/FlashcardStatistics.tsx
+++ b/src/pages/FlashcardStatistics.tsx
@@ -94,7 +94,49 @@ const FlashcardStatisticsPage: React.FC = () => {
                 </ResponsiveContainer>
               </div>
             </CardContent>
-          </Card>
+            </Card>
+          </div>
+          {stats.deckStats.length > 0 && (
+            <Card className="mt-6">
+              <CardHeader>
+                <CardTitle className="text-base sm:text-lg">Decks im Detail</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-xs sm:text-sm">
+                    <thead>
+                      <tr className="border-b">
+                        <th className="text-left py-2 font-medium">Deck</th>
+                        <th className="text-right py-2 font-medium">Gesamt</th>
+                        <th className="text-right py-2 font-medium">Fällig</th>
+                        <th className="text-right py-2 font-medium">Fälligkeitsanteil</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {stats.deckStats.map((deck, idx) => {
+                        const percent = deck.total > 0 ? (deck.due / deck.total) * 100 : 0;
+                        return (
+                          <tr key={idx} className="border-b">
+                            <td className="py-2 font-medium">{deck.deckName}</td>
+                            <td className="text-right py-2">{deck.total}</td>
+                            <td className="text-right py-2 text-red-600">{deck.due}</td>
+                            <td className="text-right py-2">
+                              <div className="flex items-center justify-end">
+                                <div className="w-16 sm:w-20 bg-gray-200 rounded-full h-2 mr-2">
+                                  <div className="bg-red-600 h-2 rounded-full" style={{ width: `${percent}%` }} />
+                                </div>
+                                <span className="text-xs">{Math.round(percent)}%</span>
+                              </div>
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              </CardContent>
+            </Card>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add helper functions in flashcard store to count cards per deck
- display due progress for decks in manager and detail pages
- extend flashcard statistics with deck overview
- document deck stats in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684936eb95b8832ab84e36cc64ba1690