### PR TITLE
Remove pinned notes from dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npm start    # startet die gebaute App auf Port 3002
 - Unteraufgaben, Prioritäten und Wiederholungen
 - Kalenderansicht mit direkter Task-Erstellung; Tagesaufgaben sind klickbar und bieten alle Task-Optionen
 - Eigene Notizen mit Farbe und Drag & Drop sortierbar
-  - Notizen lassen sich anpinnen; die ersten drei angepinnten erscheinen auf dem Dashboard und der Startseite
+  - Notizen lassen sich anpinnen; die ersten drei angepinnten erscheinen auf der Startseite
 - Lernkarten mit Spaced-Repetition-Training und Verwaltung eigener Karten
   - Decks lassen sich beim Lernen ein- oder ausblenden
   - Optionaler Zufallsmodus ohne Bewertung
@@ -89,7 +89,7 @@ npm start    # startet die gebaute App auf Port 3002
 3. Tasks lassen sich per Drag & Drop umsortieren oder in Unteraufgaben aufteilen.
 4. Über das Suchfeld und die Filter sortierst und findest du Aufgaben nach Priorität oder Farbe.
 5. In der **Kalender**-Ansicht klickst du auf ein Datum, um alle bis dahin fälligen Aufgaben zu sehen. Dort kannst du die Tasks direkt öffnen, bearbeiten, Unteraufgaben anlegen oder löschen. Die **Statistiken** geben einen Überblick über erledigte Tasks.
-6. Unter **Notizen** kannst du unabhängige Notizen verwalten und per Drag & Drop sortieren. Gepinnte Notizen werden auf dem Dashboard und der Startseite angezeigt.
+6. Unter **Notizen** kannst du unabhängige Notizen verwalten und per Drag & Drop sortieren. Gepinnte Notizen erscheinen auf der Startseite.
 7. Unter **Decks** legst du Kartendecks an und kannst sie bearbeiten. In der Detailansicht eines Decks fügst du einzelne Karten hinzu.
 8. Der Bereich **Karten** zeigt dir fällige Karten zum Lernen an. Dort kannst du
    gezielt Decks ein- oder ausblenden, einen Zufallsmodus aktivieren und im

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -38,7 +38,6 @@ import {
 } from '@hello-pangea/dnd';
 import Navbar from './Navbar';
 import { usePomodoroStore } from './PomodoroTimer';
-import NoteCard from './NoteCard';
 
 const Dashboard: React.FC = () => {
   const {
@@ -118,10 +117,6 @@ const Dashboard: React.FC = () => {
     return Array.from(colors);
   }, [selectedCategory, tasks]);
 
-  const pinnedNotes = useMemo(
-    () => notes.filter(n => n.pinned).sort((a, b) => a.order - b.order).slice(0, 3),
-    [notes]
-  );
 
   // Filter categories and tasks based on search
   const filteredCategories = categories
@@ -399,24 +394,6 @@ const Dashboard: React.FC = () => {
           </Card>
         </div>
 
-        {pinnedNotes.length > 0 && (
-          <div className="mb-6 sm:mb-8">
-            <h2 className="text-lg sm:text-xl font-semibold text-gray-900 mb-3">
-              Gepinnte Notizen
-            </h2>
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-              {pinnedNotes.map(note => (
-                <Link
-                  key={note.id}
-                  to={`/notes?noteId=${note.id}`}
-                  className="block"
-                >
-                  <NoteCard note={note} onClick={() => {}} />
-                </Link>
-              ))}
-            </div>
-          </div>
-        )}
 
         {/* Content */}
         {viewMode === 'categories' ? (


### PR DESCRIPTION
## Summary
- keep pinned notes only on the homepage
- update README accordingly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68493eaa38c4832a96a4392d3200b720