### PR TITLE
Add Markdown support for notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ cd task-tree-dashboard-docked
 
 # Abhängigkeiten installieren
 npm install
+
+Das Projekt nutzt für die Anzeige von Notizen **react-markdown**.
 ```
 
 ## Entwicklung starten
@@ -63,6 +65,7 @@ npm start    # startet die gebaute App auf Port 3002
 - Kalenderansicht mit direkter Task-Erstellung; Tagesaufgaben sind klickbar und bieten alle Task-Optionen
 - Eigene Notizen mit Farbe und Drag & Drop sortierbar
   - Notizen lassen sich anpinnen; die ersten drei angepinnten erscheinen auf der Startseite
+  - Text kann im Markdown-Format geschrieben werden
 - Lernkarten mit Spaced-Repetition-Training und Verwaltung eigener Karten
   - Decks lassen sich beim Lernen ein- oder ausblenden
   - Optionaler Zufallsmodus ohne Bewertung
@@ -89,7 +92,7 @@ npm start    # startet die gebaute App auf Port 3002
 3. Tasks lassen sich per Drag & Drop umsortieren oder in Unteraufgaben aufteilen.
 4. Über das Suchfeld und die Filter sortierst und findest du Aufgaben nach Priorität oder Farbe.
 5. In der **Kalender**-Ansicht klickst du auf ein Datum, um alle bis dahin fälligen Aufgaben zu sehen. Dort kannst du die Tasks direkt öffnen, bearbeiten, Unteraufgaben anlegen oder löschen. Die **Statistiken** geben einen Überblick über erledigte Tasks.
-6. Unter **Notizen** kannst du unabhängige Notizen verwalten und per Drag & Drop sortieren. Gepinnte Notizen erscheinen auf der Startseite.
+6. Unter **Notizen** kannst du unabhängige Notizen verwalten und per Drag & Drop sortieren. Gepinnte Notizen erscheinen auf der Startseite. Deine Inhalte kannst du dabei in Markdown verfassen. Beim Anklicken einer Notiz siehst du zunächst eine Vorschau, die du dort auch bearbeiten kannst.
 7. Unter **Decks** legst du Kartendecks an und kannst sie bearbeiten. In der Detailansicht eines Decks fügst du einzelne Karten hinzu.
 8. Der Bereich **Karten** zeigt dir fällige Karten zum Lernen an. Dort kannst du
    gezielt Decks ein- oder ausblenden, einen Zufallsmodus aktivieren und im

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
     "zod": "^3.23.8",
-    "better-sqlite3": "^9.0.0"
+    "better-sqlite3": "^9.0.0",
+    "react-markdown": "^9.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import Statistics from "./pages/Statistics";
 import CalendarPage from "./pages/Calendar";
 import Kanban from "./pages/Kanban";
 import NotesPage from "./pages/Notes";
+import NoteDetailPage from "./pages/NoteDetail";
 import FlashcardsPage from "./pages/Flashcards";
 import FlashcardManagerPage from "./pages/FlashcardManager";
 import DeckDetailPage from "./pages/DeckDetail";
@@ -51,6 +52,7 @@ const App = () => (
               <Route path="/flashcards" element={<FlashcardsPage />} />
               <Route path="/flashcards/stats" element={<FlashcardStatisticsPage />} />
               <Route path="/notes" element={<NotesPage />} />
+              <Route path="/notes/:id" element={<NoteDetailPage />} />
               <Route path="/settings" element={<SettingsPage />} />
               <Route path="/pomodoro" element={<PomodoroPage />} />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactMarkdown from 'react-markdown';
 import { Note } from '@/types';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Star, StarOff } from 'lucide-react';
@@ -43,7 +44,9 @@ const NoteCard: React.FC<NoteCardProps> = ({ note, onClick }) => {
         </button>
       </CardHeader>
       <CardContent>
-        <p className="text-sm text-gray-600 line-clamp-3">{note.text}</p>
+        <ReactMarkdown className="prose prose-sm text-gray-600 line-clamp-3">
+          {note.text}
+        </ReactMarkdown>
       </CardContent>
     </Card>
   );

--- a/src/components/NoteModal.tsx
+++ b/src/components/NoteModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import ReactMarkdown from 'react-markdown';
 import { Note } from '@/types';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
@@ -66,13 +67,20 @@ const NoteModal: React.FC<NoteModalProps> = ({ isOpen, onClose, onSave, note }) 
             />
           </div>
           <div>
-            <Label htmlFor="text">Text</Label>
+            <Label htmlFor="text">Text (Markdown)</Label>
             <Textarea
               id="text"
               value={formData.text}
               onChange={e => handleChange('text', e.target.value)}
               rows={5}
             />
+            {formData.text && (
+              <div className="mt-2 p-2 border rounded-sm bg-gray-50 max-h-40 overflow-auto">
+                <ReactMarkdown className="prose prose-sm">
+                  {formData.text}
+                </ReactMarkdown>
+              </div>
+            )}
           </div>
           <div>
             <Label>Farbe</Label>

--- a/src/pages/NoteDetail.tsx
+++ b/src/pages/NoteDetail.tsx
@@ -1,0 +1,104 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import Navbar from '@/components/Navbar';
+import { useTaskStore } from '@/hooks/useTaskStore';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import ReactMarkdown from 'react-markdown';
+
+const NoteDetailPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { notes, updateNote, deleteNote } = useTaskStore();
+  const note = notes.find(n => n.id === id);
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [formData, setFormData] = useState({ title: '', text: '', color: '#F59E0B' });
+
+  const colorOptions = [
+    '#3B82F6', '#EF4444', '#10B981', '#F59E0B',
+    '#8B5CF6', '#F97316', '#06B6D4', '#84CC16'
+  ];
+
+  useEffect(() => {
+    if (note) {
+      setFormData({ title: note.title, text: note.text, color: note.color });
+    }
+  }, [note]);
+
+  const handleChange = (field: 'title' | 'text' | 'color', value: string) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+  };
+
+  const handleSave = () => {
+    if (note) {
+      updateNote(note.id, formData);
+      setIsEditing(false);
+    }
+  };
+
+  if (!note) return <div className="p-4">Notiz nicht gefunden.</div>;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navbar title="Notiz" onHomeClick={() => navigate('/notes')} />
+      <div className="max-w-2xl mx-auto py-8 px-4">
+        {isEditing ? (
+          <form className="space-y-4" onSubmit={e => { e.preventDefault(); handleSave(); }}>
+            <div>
+              <Label htmlFor="title">Titel *</Label>
+              <Input id="title" value={formData.title} onChange={e => handleChange('title', e.target.value)} required />
+            </div>
+            <div>
+              <Label htmlFor="text">Text (Markdown)</Label>
+              <Textarea id="text" rows={10} value={formData.text} onChange={e => handleChange('text', e.target.value)} />
+            </div>
+            <div>
+              <Label>Farbe</Label>
+              <div className="flex space-x-2 mt-2">
+                {colorOptions.map(color => (
+                  <button
+                    key={color}
+                    type="button"
+                    className={`w-8 h-8 rounded-full border-2 transition-all ${
+                      formData.color === color ? 'border-gray-800 scale-110' : 'border-gray-300 hover:scale-105'
+                    }`}
+                    style={{ backgroundColor: color }}
+                    onClick={() => handleChange('color', color)}
+                  />
+                ))}
+              </div>
+            </div>
+            <div className="flex justify-end space-x-2 pt-4">
+              <Button type="button" variant="outline" onClick={() => setIsEditing(false)}>
+                Abbrechen
+              </Button>
+              <Button type="submit">Speichern</Button>
+            </div>
+          </form>
+        ) : (
+          <div className="space-y-4">
+            <h1 className="text-2xl font-bold" style={{ color: note.color }}>
+              {note.title}
+            </h1>
+            <ReactMarkdown className="prose">
+              {note.text}
+            </ReactMarkdown>
+            <div className="flex justify-end space-x-2 pt-4">
+              <Button variant="outline" onClick={() => setIsEditing(true)}>
+                Bearbeiten
+              </Button>
+              <Button variant="destructive" onClick={() => { deleteNote(note.id); navigate('/notes'); }}>
+                Löschen
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default NoteDetailPage;

--- a/src/pages/Notes.tsx
+++ b/src/pages/Notes.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Plus } from 'lucide-react';
 import { useTaskStore } from '@/hooks/useTaskStore';
 import NoteModal from '@/components/NoteModal';
@@ -6,34 +6,15 @@ import NoteCard from '@/components/NoteCard';
 import { Button } from '@/components/ui/button';
 import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea/dnd';
 import Navbar from '@/components/Navbar';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 const NotesPage = () => {
-  const { notes, addNote, updateNote, reorderNotes } = useTaskStore();
+  const { notes, addNote, reorderNotes } = useTaskStore();
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [editingNote, setEditingNote] = useState<null | number>(null);
-  const [searchParams, setSearchParams] = useSearchParams();
 
   const handleSave = (data: { title: string; text: string; color: string }) => {
-    if (editingNote !== null) {
-      const note = notes[editingNote];
-      updateNote(note.id, data);
-      setEditingNote(null);
-    } else {
-      addNote(data);
-    }
+    addNote(data);
   };
-
-  useEffect(() => {
-    const id = searchParams.get('noteId');
-    if (id) {
-      const idx = notes.findIndex(n => n.id === id);
-      if (idx !== -1) {
-        setEditingNote(idx);
-        setIsModalOpen(true);
-      }
-    }
-  }, [searchParams, notes]);
 
   const onDragEnd = (result: DropResult) => {
     if (!result.destination) return;
@@ -70,10 +51,7 @@ const NotesPage = () => {
                         >
                           <NoteCard
                             note={note}
-                            onClick={() => {
-                              setEditingNote(index);
-                              setIsModalOpen(true);
-                            }}
+                            onClick={() => navigate(`/notes/${note.id}`)}
                           />
                         </div>
                       )}
@@ -88,17 +66,8 @@ const NotesPage = () => {
       </div>
       <NoteModal
         isOpen={isModalOpen}
-        onClose={() => {
-          setIsModalOpen(false);
-          setEditingNote(null);
-          const params = new URLSearchParams(searchParams);
-          if (params.has('noteId')) {
-            params.delete('noteId');
-            setSearchParams(params, { replace: true });
-          }
-        }}
+        onClose={() => setIsModalOpen(false)}
         onSave={handleSave}
-        note={editingNote !== null ? notes[editingNote] : undefined}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- integrate `react-markdown` to render notes
- show markdown preview while editing and on note cards
- open notes in a new detail page with edit mode
- document markdown usage
- add `react-markdown` dependency

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849410e06b0832a94e310eca60ae452