### PR TITLE
Fix notes navigation

### DIFF
--- a/src/pages/Notes.tsx
+++ b/src/pages/Notes.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from 'react-router-dom';
 
 const NotesPage = () => {
   const { notes, addNote, reorderNotes } = useTaskStore();
+  const navigate = useNavigate();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const handleSave = (data: { title: string; text: string; color: string }) => {


### PR DESCRIPTION
## Summary
- connect note list entries to the detail page by adding `navigate`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849432c82b0832abea3058fd05827e8