### PR TITLE
Fix markdown styling for notes

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -92,5 +92,8 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [
+                require("tailwindcss-animate"),
+                require("@tailwindcss/typography")
+        ],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- enable Tailwind typography plugin for proper markdown styling in notes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build:dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684944502424832a98def3802a013b47