### PR TITLE
Add back button and consistent note sizing

### DIFF
--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -20,7 +20,7 @@ const NoteCard: React.FC<NoteCardProps> = ({ note, onClick }) => {
 
   return (
     <Card
-      className="cursor-pointer hover:shadow-md transition-all"
+      className="cursor-pointer hover:shadow-md transition-all h-full flex flex-col"
       onClick={onClick}
     >
       <CardHeader className="pb-2 flex items-center space-x-2">
@@ -43,7 +43,7 @@ const NoteCard: React.FC<NoteCardProps> = ({ note, onClick }) => {
           )}
         </button>
       </CardHeader>
-      <CardContent>
+      <CardContent className="flex-1">
         <ReactMarkdown className="prose prose-sm text-gray-600 line-clamp-3">
           {note.text}
         </ReactMarkdown>

--- a/src/pages/NoteDetail.tsx
+++ b/src/pages/NoteDetail.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import Navbar from '@/components/Navbar';
 import { useTaskStore } from '@/hooks/useTaskStore';
 import { Button } from '@/components/ui/button';
+import { ArrowLeft } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
@@ -45,6 +46,14 @@ const NoteDetailPage: React.FC = () => {
     <div className="min-h-screen bg-gray-50">
       <Navbar title="Notiz" onHomeClick={() => navigate('/notes')} />
       <div className="max-w-2xl mx-auto py-8 px-4">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => navigate('/notes')}
+          className="mb-4"
+        >
+          <ArrowLeft className="h-4 w-4 mr-2" /> Zurück
+        </Button>
         {isEditing ? (
           <form className="space-y-4" onSubmit={e => { e.preventDefault(); handleSave(); }}>
             <div>

--- a/src/pages/Notes.tsx
+++ b/src/pages/Notes.tsx
@@ -38,7 +38,7 @@ const NotesPage = () => {
             <Droppable droppableId="notes" direction="horizontal">
               {provided => (
                 <div
-                  className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4"
+                  className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 auto-rows-fr"
                   ref={provided.innerRef}
                   {...provided.droppableProps}
                 >
@@ -49,6 +49,7 @@ const NotesPage = () => {
                           ref={prov.innerRef}
                           {...prov.draggableProps}
                           {...prov.dragHandleProps}
+                          className="h-full"
                         >
                           <NoteCard
                             note={note}


### PR DESCRIPTION
## Summary
- keep all note cards at equal height in overview
- allow NoteCard to stretch in a grid
- add a back button to the note detail page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684946176f9c832a81ead7eb80f04bef