### PR TITLE
Fix floating pomodoro window styles

### DIFF
--- a/src/components/PomodoroTimer.tsx
+++ b/src/components/PomodoroTimer.tsx
@@ -182,10 +182,15 @@ const PomodoroTimer: React.FC<PomodoroTimerProps> = ({ compact, size = 80, float
       if (!pip) return;
       pipWindowRef.current = pip;
       if (!pip.document.body) {
-        pip.document.write('<!DOCTYPE html><html><body></body></html>');
+        pip.document.write('<!DOCTYPE html><html><head></head><body></body></html>');
         pip.document.close();
       }
       pip.document.title = 'Pomodoro';
+      pip.document.documentElement.className = document.documentElement.className;
+      document.querySelectorAll('style, link[rel="stylesheet"]').forEach(el => {
+        const clone = el.cloneNode(true) as HTMLElement;
+        pip.document.head.appendChild(clone);
+      });
       pip.document.body.style.margin = '0';
       const container = pip.document.createElement('div');
       pip.document.body.appendChild(container);


### PR DESCRIPTION
## Summary
- ensure floating pomodoro window includes Tailwind styles and dark mode class

## Testing
- `npm run lint` *(fails: react-hooks/exhaustive-deps, @typescript-eslint/no-explicit-any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684949d31838832aa5604db8fe426e9c