### PR TITLE
Add default priority option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ npm start    # startet die gebaute App auf Port 3002
   sofort aktualisiert.
 - Lern- und Pausendauer frei konfigurierbar (auch direkt im Timer anpassbar)
 - Daten können im Einstellungsbereich exportiert und importiert werden
+- Standard-Priorität für neue Tasks einstellbar
 
 ## Verwendung
 

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -25,7 +25,7 @@ const isMatching = (e: KeyboardEvent, shortcut: string) => {
 
 const CommandPalette: React.FC = () => {
   const { addTask, addNote, tasks } = useTaskStore()
-  const { shortcuts } = useSettings()
+  const { shortcuts, defaultTaskPriority } = useSettings()
   const { toast } = useToast()
   const { currentCategoryId, setCurrentCategoryId } = useCurrentCategory()
   const navigate = useNavigate()
@@ -72,7 +72,7 @@ const CommandPalette: React.FC = () => {
       addTask({
         title,
         description: '',
-        priority: 'medium',
+        priority: defaultTaskPriority,
         color: '#3B82F6',
         categoryId: currentCategoryId || 'default',
         isRecurring: false

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -9,6 +9,7 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { getPriorityColor } from '@/utils/taskUtils';
+import { useSettings } from '@/hooks/useSettings';
 
 interface TaskModalProps {
   isOpen: boolean;
@@ -38,10 +39,11 @@ const TaskModal: React.FC<TaskModalProps> = ({
   defaultCategoryId,
   defaultDueDate
 }) => {
+  const { defaultTaskPriority } = useSettings()
   const [formData, setFormData] = useState<TaskFormData>({
     title: '',
     description: '',
-    priority: 'medium',
+    priority: defaultTaskPriority,
     color: '#3B82F6',
     categoryId: '',
     parentId: parentTask?.id,
@@ -74,7 +76,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
       setFormData({
         title: '',
         description: '',
-        priority: 'medium',
+        priority: defaultTaskPriority,
         color: '#3B82F6',
         categoryId:
           defaultCategoryId || parentTask?.categoryId || categories[0]?.id || '',
@@ -84,7 +86,15 @@ const TaskModal: React.FC<TaskModalProps> = ({
         recurrencePattern: undefined
       });
     }
-  }, [isOpen, task, categories, parentTask, defaultCategoryId, defaultDueDate]);
+  }, [
+    isOpen,
+    task,
+    categories,
+    parentTask,
+    defaultCategoryId,
+    defaultDueDate,
+    defaultTaskPriority
+  ]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -13,12 +13,15 @@ const defaultShortcuts: ShortcutKeys = {
 }
 
 const defaultPomodoro = { workMinutes: 25, breakMinutes: 5 }
+const defaultTaskPriority: 'low' | 'medium' | 'high' = 'medium'
 
 interface SettingsContextValue {
   shortcuts: ShortcutKeys
   updateShortcut: (key: keyof ShortcutKeys, value: string) => void
   pomodoro: { workMinutes: number; breakMinutes: number }
   updatePomodoro: (key: 'workMinutes' | 'breakMinutes', value: number) => void
+  defaultTaskPriority: 'low' | 'medium' | 'high'
+  updateDefaultTaskPriority: (value: 'low' | 'medium' | 'high') => void
 }
 
 const SettingsContext = createContext<SettingsContextValue | undefined>(undefined)
@@ -26,6 +29,9 @@ const SettingsContext = createContext<SettingsContextValue | undefined>(undefine
 export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [shortcuts, setShortcuts] = useState<ShortcutKeys>(defaultShortcuts)
   const [pomodoro, setPomodoro] = useState(defaultPomodoro)
+  const [priority, setPriority] = useState<'low' | 'medium' | 'high'>(
+    defaultTaskPriority
+  )
 
   useEffect(() => {
     const load = async () => {
@@ -38,6 +44,9 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
           }
           if (data.pomodoro) {
             setPomodoro({ ...defaultPomodoro, ...data.pomodoro })
+          }
+          if (data.defaultTaskPriority) {
+            setPriority(data.defaultTaskPriority)
           }
         }
       } catch (err) {
@@ -53,7 +62,11 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         await fetch('/api/settings', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ shortcuts, pomodoro })
+          body: JSON.stringify({
+            shortcuts,
+            pomodoro,
+            defaultTaskPriority: priority
+          })
         })
       } catch (err) {
         console.error('Fehler beim Speichern der Einstellungen', err)
@@ -61,7 +74,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     }
 
     save()
-  }, [shortcuts, pomodoro])
+  }, [shortcuts, pomodoro, priority])
 
   const updateShortcut = (key: keyof ShortcutKeys, value: string) => {
     setShortcuts(prev => ({ ...prev, [key]: value.toLowerCase() }))
@@ -71,9 +84,20 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     setPomodoro(prev => ({ ...prev, [key]: value }))
   }
 
+  const updateDefaultTaskPriority = (value: 'low' | 'medium' | 'high') => {
+    setPriority(value)
+  }
+
   return (
     <SettingsContext.Provider
-      value={{ shortcuts, updateShortcut, pomodoro, updatePomodoro }}
+      value={{
+        shortcuts,
+        updateShortcut,
+        pomodoro,
+        updatePomodoro,
+        defaultTaskPriority: priority,
+        updateDefaultTaskPriority
+      }}
     >
       {children}
     </SettingsContext.Provider>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -4,9 +4,23 @@ import { useSettings } from '@/hooks/useSettings'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
 
 const SettingsPage: React.FC = () => {
-  const { shortcuts, updateShortcut, pomodoro, updatePomodoro } = useSettings()
+  const {
+    shortcuts,
+    updateShortcut,
+    pomodoro,
+    updatePomodoro,
+    defaultTaskPriority,
+    updateDefaultTaskPriority
+  } = useSettings()
 
   const download = (data: any, name: string) => {
     const blob = new Blob([JSON.stringify(data, null, 2)], {
@@ -222,6 +236,22 @@ const SettingsPage: React.FC = () => {
             value={pomodoro.breakMinutes}
             onChange={e => updatePomodoro('breakMinutes', Number(e.target.value))}
           />
+        </div>
+        <div>
+          <Label htmlFor="priority">Standard-Priorität</Label>
+          <Select
+            value={defaultTaskPriority}
+            onValueChange={updateDefaultTaskPriority}
+          >
+            <SelectTrigger id="priority">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="low">Niedrig</SelectItem>
+              <SelectItem value="medium">Mittel</SelectItem>
+              <SelectItem value="high">Hoch</SelectItem>
+            </SelectContent>
+          </Select>
         </div>
         <div className="pt-4 border-t space-y-4">
           <h2 className="font-semibold">Datenexport / -import</h2>


### PR DESCRIPTION
## Summary
- allow setting a default priority in user settings
- expose selector on the settings page
- use this preference when adding tasks via the modal or command palette
- store/retrieve the value via `/api/settings`
- document default priority option

## Testing
- `npm run lint` *(fails: several existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68494ef81504832ab14790e6229a8b65