### PR TITLE
Add theme customization

### DIFF
--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from 'react'
 
+
 export type ShortcutKeys = {
   openCommand: string
   newTask: string
@@ -14,6 +15,11 @@ const defaultShortcuts: ShortcutKeys = {
 
 const defaultPomodoro = { workMinutes: 25, breakMinutes: 5 }
 const defaultTaskPriority: 'low' | 'medium' | 'high' = 'medium'
+const defaultTheme = {
+  background: '0 0% 100%',
+  foreground: '222.2 84% 4.9%',
+  accent: '210 40% 96.1%'
+}
 
 interface SettingsContextValue {
   shortcuts: ShortcutKeys
@@ -22,6 +28,8 @@ interface SettingsContextValue {
   updatePomodoro: (key: 'workMinutes' | 'breakMinutes', value: number) => void
   defaultTaskPriority: 'low' | 'medium' | 'high'
   updateDefaultTaskPriority: (value: 'low' | 'medium' | 'high') => void
+  theme: typeof defaultTheme
+  updateTheme: (key: keyof typeof defaultTheme, value: string) => void
 }
 
 const SettingsContext = createContext<SettingsContextValue | undefined>(undefined)
@@ -32,6 +40,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const [priority, setPriority] = useState<'low' | 'medium' | 'high'>(
     defaultTaskPriority
   )
+  const [theme, setTheme] = useState(defaultTheme)
 
   useEffect(() => {
     const load = async () => {
@@ -47,6 +56,9 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
           }
           if (data.defaultTaskPriority) {
             setPriority(data.defaultTaskPriority)
+          }
+          if (data.theme) {
+            setTheme({ ...defaultTheme, ...data.theme })
           }
         }
       } catch (err) {
@@ -65,7 +77,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
           body: JSON.stringify({
             shortcuts,
             pomodoro,
-            defaultTaskPriority: priority
+            defaultTaskPriority: priority,
+            theme
           })
         })
       } catch (err) {
@@ -74,7 +87,13 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     }
 
     save()
-  }, [shortcuts, pomodoro, priority])
+  }, [shortcuts, pomodoro, priority, theme])
+
+  useEffect(() => {
+    Object.entries(theme).forEach(([key, value]) => {
+      document.documentElement.style.setProperty(`--${key}`, value)
+    })
+  }, [theme])
 
   const updateShortcut = (key: keyof ShortcutKeys, value: string) => {
     setShortcuts(prev => ({ ...prev, [key]: value.toLowerCase() }))
@@ -88,6 +107,10 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     setPriority(value)
   }
 
+  const updateTheme = (key: keyof typeof defaultTheme, value: string) => {
+    setTheme(prev => ({ ...prev, [key]: value }))
+  }
+
   return (
     <SettingsContext.Provider
       value={{
@@ -96,7 +119,9 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         pomodoro,
         updatePomodoro,
         defaultTaskPriority: priority,
-        updateDefaultTaskPriority
+        updateDefaultTaskPriority,
+        theme,
+        updateTheme
       }}
     >
       {children}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -4,6 +4,7 @@ import { useSettings } from '@/hooks/useSettings'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
+import { hslToHex, hexToHsl } from '@/utils/color'
 import {
   Select,
   SelectContent,
@@ -19,7 +20,9 @@ const SettingsPage: React.FC = () => {
     pomodoro,
     updatePomodoro,
     defaultTaskPriority,
-    updateDefaultTaskPriority
+    updateDefaultTaskPriority,
+    theme,
+    updateTheme
   } = useSettings()
 
   const download = (data: any, name: string) => {
@@ -252,6 +255,36 @@ const SettingsPage: React.FC = () => {
               <SelectItem value="high">Hoch</SelectItem>
             </SelectContent>
           </Select>
+        </div>
+        <div className="pt-4 border-t space-y-4">
+          <h2 className="font-semibold">Theme</h2>
+          <div className="space-y-2">
+            <Label htmlFor="bgColor">Hintergrund</Label>
+            <Input
+              id="bgColor"
+              type="color"
+              value={hslToHex(theme.background)}
+              onChange={e => updateTheme('background', hexToHsl(e.target.value))}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="fgColor">Vordergrund</Label>
+            <Input
+              id="fgColor"
+              type="color"
+              value={hslToHex(theme.foreground)}
+              onChange={e => updateTheme('foreground', hexToHsl(e.target.value))}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="accentColor">Akzent</Label>
+            <Input
+              id="accentColor"
+              type="color"
+              value={hslToHex(theme.accent)}
+              onChange={e => updateTheme('accent', hexToHsl(e.target.value))}
+            />
+          </div>
         </div>
         <div className="pt-4 border-t space-y-4">
           <h2 className="font-semibold">Datenexport / -import</h2>

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,0 +1,56 @@
+export const hexToHsl = (hex: string): string => {
+  let h = hex.replace('#', '');
+  if (h.length === 3) h = h.split('').map(c => c + c).join('');
+  const r = parseInt(h.slice(0, 2), 16) / 255;
+  const g = parseInt(h.slice(2, 4), 16) / 255;
+  const b = parseInt(h.slice(4, 6), 16) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let hh = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        hh = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        hh = (b - r) / d + 2;
+        break;
+      case b:
+        hh = (r - g) / d + 4;
+        break;
+    }
+    hh /= 6;
+  }
+  return `${Math.round(hh * 360)} ${Math.round(s * 100)}% ${Math.round(l * 100)}%`;
+};
+
+export const hslToHex = (hsl: string): string => {
+  const [hStr, sStr, lStr] = hsl.split(/\s+/);
+  const h = parseFloat(hStr) / 360;
+  const s = parseFloat(sStr) / 100;
+  const l = parseFloat(lStr) / 100;
+  let r: number, g: number, b: number;
+  if (s === 0) {
+    r = g = b = l;
+  } else {
+    const hue2rgb = (p: number, q: number, t: number) => {
+      if (t < 0) t += 1;
+      if (t > 1) t -= 1;
+      if (t < 1 / 6) return p + (q - p) * 6 * t;
+      if (t < 1 / 2) return q;
+      if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+      return p;
+    };
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    r = hue2rgb(p, q, h + 1 / 3);
+    g = hue2rgb(p, q, h);
+    b = hue2rgb(p, q, h - 1 / 3);
+  }
+  const toHex = (x: number) => Math.round(x * 255).toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+};


### PR DESCRIPTION
## Summary
- allow user to change background, foreground and accent colors
- persist theme settings via existing settings API
- apply custom colors system-wide on load
- add utility functions for hex/HSL conversion

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684954e77b60832a9ccc6ca1616be915