### PR TITLE
Enable card color customization

### DIFF
--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -18,7 +18,9 @@ const defaultTaskPriority: 'low' | 'medium' | 'high' = 'medium'
 const defaultTheme = {
   background: '0 0% 100%',
   foreground: '222.2 84% 4.9%',
-  accent: '210 40% 96.1%'
+  accent: '210 40% 96.1%',
+  card: '0 0% 100%',
+  'card-foreground': '222.2 84% 4.9%'
 }
 
 interface SettingsContextValue {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -276,16 +276,36 @@ const SettingsPage: React.FC = () => {
               onChange={e => updateTheme('foreground', hexToHsl(e.target.value))}
             />
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="accentColor">Akzent</Label>
-            <Input
-              id="accentColor"
-              type="color"
-              value={hslToHex(theme.accent)}
-              onChange={e => updateTheme('accent', hexToHsl(e.target.value))}
-            />
-          </div>
+        <div className="space-y-2">
+          <Label htmlFor="accentColor">Akzent</Label>
+          <Input
+            id="accentColor"
+            type="color"
+            value={hslToHex(theme.accent)}
+            onChange={e => updateTheme('accent', hexToHsl(e.target.value))}
+          />
         </div>
+        <div className="space-y-2">
+          <Label htmlFor="cardBgColor">Karten-Hintergrund</Label>
+          <Input
+            id="cardBgColor"
+            type="color"
+            value={hslToHex(theme.card)}
+            onChange={e => updateTheme('card', hexToHsl(e.target.value))}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="cardFgColor">Karten-Vordergrund</Label>
+          <Input
+            id="cardFgColor"
+            type="color"
+            value={hslToHex(theme['card-foreground'])}
+            onChange={e =>
+              updateTheme('card-foreground', hexToHsl(e.target.value))
+            }
+          />
+        </div>
+      </div>
         <div className="pt-4 border-t space-y-4">
           <h2 className="font-semibold">Datenexport / -import</h2>
           <div className="space-y-2">


### PR DESCRIPTION
## Summary
- allow saving card colors in settings
- add color pickers for card background and foreground

## Testing
- `npm run lint`
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_684969044498832a910618132957bcb2