### PR TITLE
Implement theme-based colors

### DIFF
--- a/src/components/PomodoroStats.tsx
+++ b/src/components/PomodoroStats.tsx
@@ -15,9 +15,9 @@ const PomodoroStats: React.FC = () => {
           <p className="text-sm">Arbeit: {stats.totalWorkMinutes} min</p>
           <p className="text-sm">Pause: {stats.totalBreakMinutes} min</p>
           <p className="text-sm mb-2">Zyklen: {stats.totalCycles}</p>
-          <div className="w-full h-3 bg-gray-200 rounded overflow-hidden">
+          <div className="w-full h-3 bg-muted rounded overflow-hidden">
             <div
-              className="h-full bg-indigo-500"
+              className="h-full bg-primary"
               style={{ width: `${
                 stats.totalWorkMinutes + stats.totalBreakMinutes === 0
                   ? 0
@@ -26,7 +26,7 @@ const PomodoroStats: React.FC = () => {
               }%` }}
             />
             <div
-              className="h-full bg-green-500"
+              className="h-full bg-accent"
               style={{ width: `${
                 stats.totalWorkMinutes + stats.totalBreakMinutes === 0
                   ? 0
@@ -46,9 +46,9 @@ const PomodoroStats: React.FC = () => {
           <p className="text-sm">Arbeit: {stats.todayTotals.workMinutes} min</p>
           <p className="text-sm">Pause: {stats.todayTotals.breakMinutes} min</p>
           <p className="text-sm mb-2">Zyklen: {stats.todayTotals.cycles}</p>
-          <div className="w-full h-3 bg-gray-200 rounded overflow-hidden mb-4">
+          <div className="w-full h-3 bg-muted rounded overflow-hidden mb-4">
             <div
-              className="h-full bg-indigo-500"
+              className="h-full bg-primary"
               style={{ width: `${
                 stats.todayTotals.workMinutes + stats.todayTotals.breakMinutes === 0
                   ? 0
@@ -57,7 +57,7 @@ const PomodoroStats: React.FC = () => {
               }%` }}
             />
             <div
-              className="h-full bg-green-500"
+              className="h-full bg-accent"
               style={{ width: `${
                 stats.todayTotals.workMinutes + stats.todayTotals.breakMinutes === 0
                   ? 0
@@ -72,8 +72,8 @@ const PomodoroStats: React.FC = () => {
                 <XAxis dataKey="time" fontSize={12} />
                 <YAxis fontSize={12} />
                 <Tooltip />
-                <Bar dataKey="work" stackId="a" fill="#4f46e5" />
-                <Bar dataKey="break" stackId="a" fill="#16a34a" />
+                <Bar dataKey="work" stackId="a" fill="hsl(var(--primary))" />
+                <Bar dataKey="break" stackId="a" fill="hsl(var(--accent))" />
               </BarChart>
             </ResponsiveContainer>
           </div>
@@ -97,7 +97,7 @@ const PomodoroStats: React.FC = () => {
                 <XAxis dataKey="time" fontSize={12} />
                 <YAxis fontSize={12} />
                 <Tooltip />
-                <Bar dataKey="value" fill="#4f46e5" />
+                <Bar dataKey="value" fill="hsl(var(--primary))" />
               </BarChart>
             </ResponsiveContainer>
           </div>
@@ -115,8 +115,8 @@ const PomodoroStats: React.FC = () => {
                 <XAxis dataKey="date" fontSize={12} />
                 <YAxis fontSize={12} />
                 <Tooltip />
-                <Bar dataKey="work" stackId="a" fill="#4f46e5" />
-                <Bar dataKey="break" stackId="a" fill="#16a34a" />
+                <Bar dataKey="work" stackId="a" fill="hsl(var(--primary))" />
+                <Bar dataKey="break" stackId="a" fill="hsl(var(--accent))" />
               </BarChart>
             </ResponsiveContainer>
           </div>
@@ -134,8 +134,8 @@ const PomodoroStats: React.FC = () => {
                 <XAxis dataKey="date" fontSize={12} />
                 <YAxis fontSize={12} />
                 <Tooltip />
-                <Bar dataKey="work" stackId="a" fill="#4f46e5" />
-                <Bar dataKey="break" stackId="a" fill="#16a34a" />
+                <Bar dataKey="work" stackId="a" fill="hsl(var(--primary))" />
+                <Bar dataKey="break" stackId="a" fill="hsl(var(--accent))" />
               </BarChart>
             </ResponsiveContainer>
           </div>
@@ -153,8 +153,8 @@ const PomodoroStats: React.FC = () => {
                 <XAxis dataKey="month" fontSize={12} />
                 <YAxis fontSize={12} />
                 <Tooltip />
-                <Bar dataKey="work" stackId="a" fill="#4f46e5" />
-                <Bar dataKey="break" stackId="a" fill="#16a34a" />
+                <Bar dataKey="work" stackId="a" fill="hsl(var(--primary))" />
+                <Bar dataKey="break" stackId="a" fill="hsl(var(--accent))" />
               </BarChart>
             </ResponsiveContainer>
           </div>

--- a/src/components/PomodoroTimer.tsx
+++ b/src/components/PomodoroTimer.tsx
@@ -283,7 +283,7 @@ const PomodoroTimer: React.FC<PomodoroTimerProps> = ({ compact, size = 80, float
           className="transform -rotate-90"
         >
           <circle
-            stroke="#e5e7eb"
+            stroke="hsl(var(--muted))"
             fill="transparent"
             strokeWidth={stroke}
             r={normalizedRadius}
@@ -291,7 +291,7 @@ const PomodoroTimer: React.FC<PomodoroTimerProps> = ({ compact, size = 80, float
             cy={radius}
           />
           <circle
-            stroke={mode === 'work' ? '#4f46e5' : '#16a34a'}
+            stroke={mode === 'work' ? 'hsl(var(--primary))' : 'hsl(var(--accent))'}
             fill="transparent"
             strokeWidth={stroke}
             strokeLinecap="round"

--- a/src/pages/FlashcardStatistics.tsx
+++ b/src/pages/FlashcardStatistics.tsx
@@ -20,9 +20,21 @@ const FlashcardStatisticsPage: React.FC = () => {
   const stats = useFlashcardStatistics();
 
   const difficultyData = [
-    { name: "Leicht", value: stats.difficultyCounts.easy, color: "#10B981" },
-    { name: "Mittel", value: stats.difficultyCounts.medium, color: "#F59E0B" },
-    { name: "Schwer", value: stats.difficultyCounts.hard, color: "#EF4444" },
+    {
+      name: "Leicht",
+      value: stats.difficultyCounts.easy,
+      color: "hsl(var(--accent))",
+    },
+    {
+      name: "Mittel",
+      value: stats.difficultyCounts.medium,
+      color: "hsl(var(--primary))",
+    },
+    {
+      name: "Schwer",
+      value: stats.difficultyCounts.hard,
+      color: "hsl(var(--destructive))",
+    },
   ];
 
   return (
@@ -130,7 +142,7 @@ const FlashcardStatisticsPage: React.FC = () => {
                     <XAxis dataKey="date" fontSize={12} />
                     <YAxis fontSize={12} />
                     <Tooltip />
-                    <Bar dataKey="count" fill="#3B82F6" name="Karten" />
+                    <Bar dataKey="count" fill="hsl(var(--accent))" name="Karten" />
                   </BarChart>
                 </ResponsiveContainer>
               </div>
@@ -165,14 +177,14 @@ const FlashcardStatisticsPage: React.FC = () => {
                         <tr key={idx} className="border-b">
                           <td className="py-2 font-medium">{deck.deckName}</td>
                           <td className="text-right py-2">{deck.total}</td>
-                          <td className="text-right py-2 text-red-600">
+                          <td className="text-right py-2 text-accent">
                             {deck.due}
                           </td>
                           <td className="text-right py-2">
                             <div className="flex items-center justify-end">
-                              <div className="w-16 sm:w-20 bg-gray-200 rounded-full h-2 mr-2">
+                              <div className="w-16 sm:w-20 bg-muted rounded-full h-2 mr-2">
                                 <div
-                                  className="bg-red-600 h-2 rounded-full"
+                                  className="bg-accent h-2 rounded-full"
                                   style={{ width: `${percent}%` }}
                                 />
                               </div>

--- a/src/pages/Kanban.tsx
+++ b/src/pages/Kanban.tsx
@@ -162,7 +162,7 @@ const Kanban: React.FC = () => {
                   <div
                     ref={provided.innerRef}
                     {...provided.droppableProps}
-                    className="bg-gray-100 rounded-md p-2 space-y-2 min-h-[200px]"
+                    className="bg-muted rounded-md p-2 space-y-2 min-h-[200px]"
                   >
                     <h2 className="text-base font-semibold mb-2">
                       {labels[status]}

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -10,9 +10,21 @@ const Statistics = () => {
   const stats = useStatistics();
 
   const priorityData = [
-    { name: 'Hoch', value: stats.tasksByPriority.high, color: '#EF4444' },
-    { name: 'Mittel', value: stats.tasksByPriority.medium, color: '#F59E0B' },
-    { name: 'Niedrig', value: stats.tasksByPriority.low, color: '#10B981' }
+    {
+      name: 'Hoch',
+      value: stats.tasksByPriority.high,
+      color: 'hsl(var(--destructive))'
+    },
+    {
+      name: 'Mittel',
+      value: stats.tasksByPriority.medium,
+      color: 'hsl(var(--primary))'
+    },
+    {
+      name: 'Niedrig',
+      value: stats.tasksByPriority.low,
+      color: 'hsl(var(--accent))'
+    }
   ];
 
   const categoryData = stats.tasksByCategory.map(cat => ({
@@ -45,10 +57,10 @@ const Statistics = () => {
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-xs sm:text-sm font-medium">Abgeschlossen</CardTitle>
-              <CheckCircle className="h-4 w-4 text-green-600" />
+              <CheckCircle className="h-4 w-4 text-accent" />
             </CardHeader>
             <CardContent>
-              <div className="text-lg sm:text-2xl font-bold text-green-600">{stats.completedTasks}</div>
+              <div className="text-lg sm:text-2xl font-bold text-accent">{stats.completedTasks}</div>
               <p className="text-xs text-muted-foreground">{completionRate}% der Tasks</p>
             </CardContent>
           </Card>
@@ -56,27 +68,27 @@ const Statistics = () => {
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-xs sm:text-sm font-medium">Offen</CardTitle>
-              <Clock className="h-4 w-4 text-yellow-600" />
+              <Clock className="h-4 w-4 text-accent" />
             </CardHeader>
             <CardContent>
-              <div className="text-lg sm:text-2xl font-bold text-yellow-600">{stats.pendingTasks}</div>
+              <div className="text-lg sm:text-2xl font-bold text-accent">{stats.pendingTasks}</div>
             </CardContent>
           </Card>
 
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-xs sm:text-sm font-medium">Überfällig</CardTitle>
-              <Clock className="h-4 w-4 text-red-600" />
+              <Clock className="h-4 w-4 text-accent" />
             </CardHeader>
             <CardContent>
-              <div className="text-lg sm:text-2xl font-bold text-red-600">{stats.overdueTasks}</div>
+              <div className="text-lg sm:text-2xl font-bold text-accent">{stats.overdueTasks}</div>
             </CardContent>
           </Card>
 
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-xs sm:text-sm font-medium">Erledigt 7 Tage</CardTitle>
-              <CheckCircle className="h-4 w-4 text-green-600" />
+              <CheckCircle className="h-4 w-4 text-accent" />
             </CardHeader>
             <CardContent>
               <div className="text-lg sm:text-2xl font-bold">{stats.tasksCompletedLast7Days}</div>
@@ -86,10 +98,10 @@ const Statistics = () => {
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-xs sm:text-sm font-medium">Wiederkehrend</CardTitle>
-              <TrendingUp className="h-4 w-4 text-blue-600" />
+              <TrendingUp className="h-4 w-4 text-accent" />
             </CardHeader>
             <CardContent>
-              <div className="text-lg sm:text-2xl font-bold text-blue-600">{stats.recurringTasks}</div>
+              <div className="text-lg sm:text-2xl font-bold text-accent">{stats.recurringTasks}</div>
             </CardContent>
           </Card>
 
@@ -165,8 +177,12 @@ const Statistics = () => {
                     />
                     <YAxis fontSize={12} />
                     <Tooltip />
-                    <Bar dataKey="completed" fill="#10B981" name="Abgeschlossen" />
-                    <Bar dataKey="total" fill="#E5E7EB" name="Gesamt" />
+                    <Bar
+                      dataKey="completed"
+                      fill="hsl(var(--accent))"
+                      name="Abgeschlossen"
+                    />
+                    <Bar dataKey="total" fill="hsl(var(--muted))" name="Gesamt" />
                   </BarChart>
                 </ResponsiveContainer>
               </div>
@@ -197,17 +213,17 @@ const Statistics = () => {
                     <Tooltip 
                       labelFormatter={(value) => new Date(value).toLocaleDateString('de-DE')}
                     />
-                    <Line 
-                      type="monotone" 
-                      dataKey="completed" 
-                      stroke="#10B981" 
+                    <Line
+                      type="monotone"
+                      dataKey="completed"
+                      stroke="hsl(var(--accent))"
                       strokeWidth={2}
                       name="Abgeschlossen"
                     />
-                    <Line 
-                      type="monotone" 
-                      dataKey="created" 
-                      stroke="#3B82F6" 
+                    <Line
+                      type="monotone"
+                      dataKey="created"
+                      stroke="hsl(var(--primary))"
                       strokeWidth={2}
                       name="Erstellt"
                     />
@@ -239,14 +255,14 @@ const Statistics = () => {
                     <tr key={index} className="border-b">
                       <td className="py-2 font-medium">{category.categoryName}</td>
                       <td className="text-right py-2">{category.count}</td>
-                      <td className="text-right py-2 text-green-600">{category.completed}</td>
+                      <td className="text-right py-2 text-accent">{category.completed}</td>
                       <td className="text-right py-2">
                         <div className="flex items-center justify-end">
-                          <div className="w-16 sm:w-20 bg-gray-200 rounded-full h-2 mr-2">
-                            <div 
-                              className="bg-blue-600 h-2 rounded-full"
-                              style={{ 
-                                width: `${category.count > 0 ? (category.completed / category.count) * 100 : 0}%` 
+                          <div className="w-16 sm:w-20 bg-muted rounded-full h-2 mr-2">
+                            <div
+                              className="bg-accent h-2 rounded-full"
+                              style={{
+                                width: `${category.count > 0 ? (category.completed / category.count) * 100 : 0}%`
                               }}
                             />
                           </div>


### PR DESCRIPTION
## Summary
- apply muted color to Kanban columns
- use CSS variables for priority colors in statistics
- update Flashcard statistics colors to use theme variables
- adjust Pomodoro timer and stats to rely on theme colors

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68496b5c521c832a89fa749ad007c6c0