### PR TITLE
Add theme color sliders and replace hardcoded styles

### DIFF
--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -44,7 +44,7 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
               style={{ backgroundColor: category.color }}
             />
             <div className="flex-1 min-w-0">
-              <CardTitle className="text-base sm:text-lg font-semibold group-hover:text-blue-600 transition-colors break-words">
+              <CardTitle className="text-base sm:text-lg font-semibold group-hover:text-primary transition-colors break-words">
                 {category.name}
               </CardTitle>
               {category.description && (
@@ -77,7 +77,7 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
                   onDelete(category.id);
                 }}
                 title="Löschen (rückgängig möglich)"
-                className="h-8 w-8 p-0 text-red-600 hover:text-red-800"
+                className="h-8 w-8 p-0 text-destructive hover:text-destructive/80"
               >
                 <Trash2 className="h-4 w-4" />
               </Button>
@@ -105,7 +105,7 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
                 {category.id !== 'default' && (
                   <DropdownMenuItem
                     onClick={() => onDelete(category.id)}
-                    className="text-red-600"
+                    className="text-destructive"
                   >
                     <Trash2 className="h-4 w-4 mr-2" />
                     Löschen (Undo möglich)

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -370,7 +370,7 @@ const Dashboard: React.FC = () => {
               <CardTitle className="text-sm font-medium text-gray-600">Abgeschlossen</CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="text-xl sm:text-2xl font-bold text-green-600">{completedTasks}</div>
+              <div className="text-xl sm:text-2xl font-bold text-accent">{completedTasks}</div>
               <div className="text-xs sm:text-sm text-gray-500">
                 {totalTasks > 0 ? Math.round((completedTasks / totalTasks) * 100) : 0}% erledigt
               </div>
@@ -381,7 +381,7 @@ const Dashboard: React.FC = () => {
               <CardTitle className="text-sm font-medium text-gray-600">Offen</CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="text-xl sm:text-2xl font-bold text-yellow-600">{pendingTasks}</div>
+              <div className="text-xl sm:text-2xl font-bold text-primary">{pendingTasks}</div>
             </CardContent>
           </Card>
           <Card>
@@ -389,7 +389,7 @@ const Dashboard: React.FC = () => {
               <CardTitle className="text-sm font-medium text-gray-600">Kategorien</CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="text-xl sm:text-2xl font-bold text-blue-600">{totalCategories}</div>
+              <div className="text-xl sm:text-2xl font-bold text-primary">{totalCategories}</div>
             </CardContent>
           </Card>
         </div>

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -34,7 +34,7 @@ const NoteCard: React.FC<NoteCardProps> = ({ note, onClick }) => {
         <button
           type="button"
           onClick={handleToggle}
-          className="text-yellow-500 hover:text-yellow-600"
+          className="text-accent-foreground hover:text-accent"
         >
           {note.pinned ? (
             <Star className="w-4 h-4 fill-current" />

--- a/src/components/PomodoroTimer.tsx
+++ b/src/components/PomodoroTimer.tsx
@@ -291,7 +291,11 @@ const PomodoroTimer: React.FC<PomodoroTimerProps> = ({ compact, size = 80, float
             cy={radius}
           />
           <circle
-            stroke={mode === 'work' ? 'hsl(var(--primary))' : 'hsl(var(--accent))'}
+            stroke={
+              mode === 'work'
+                ? 'hsl(var(--pomodoro-work-ring))'
+                : 'hsl(var(--pomodoro-break-ring))'
+            }
             fill="transparent"
             strokeWidth={stroke}
             strokeLinecap="round"

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -61,12 +61,12 @@ const TaskCard: React.FC<TaskCardProps> = ({
                 type="checkbox"
                 checked={task.completed}
                 onChange={handleToggleComplete}
-                className="mt-1 h-4 w-4 text-blue-600 rounded border-gray-300 focus:ring-blue-500 flex-shrink-0"
+                className="mt-1 h-4 w-4 text-primary rounded border-gray-300 focus:ring-primary flex-shrink-0"
               />
             )}
             <div className="flex-1 min-w-0">
               <CardTitle
-                className={`text-base sm:text-lg font-semibold cursor-pointer hover:text-blue-600 transition-colors ${
+                className={`text-base sm:text-lg font-semibold cursor-pointer hover:text-primary transition-colors ${
                   isCompleted ? 'line-through text-gray-500' : ''
                 } break-words`}
                 onClick={() => onViewDetails(task)}
@@ -102,7 +102,11 @@ const TaskCard: React.FC<TaskCardProps> = ({
                 )}
                 {task.dueDate && (
                   <span
-                    className={`text-xs flex-shrink-0 ${new Date(task.dueDate) < new Date() && !task.completed ? 'text-red-600' : 'text-gray-500'}`}
+                    className={`text-xs flex-shrink-0 ${
+                      new Date(task.dueDate) < new Date() && !task.completed
+                        ? 'text-destructive'
+                        : 'text-muted-foreground'
+                    }`}
                   >
                     Fällig am {new Date(task.dueDate).toLocaleDateString('de-DE')}
                   </span>
@@ -141,7 +145,7 @@ const TaskCard: React.FC<TaskCardProps> = ({
               variant="ghost"
               size="sm"
               onClick={() => onDelete(task.id)}
-              className="h-8 w-8 p-0 text-red-600 hover:text-red-800"
+              className="h-8 w-8 p-0 text-destructive hover:text-destructive/80"
             >
               <Trash2 className="h-4 w-4" />
             </Button>
@@ -168,9 +172,9 @@ const TaskCard: React.FC<TaskCardProps> = ({
                   <Edit className="h-4 w-4 mr-2" />
                   Bearbeiten
                 </DropdownMenuItem>
-                <DropdownMenuItem 
+                <DropdownMenuItem
                   onClick={() => onDelete(task.id)}
-                  className="text-red-600"
+                  className="text-destructive"
                 >
                   <Trash2 className="h-4 w-4 mr-2" />
                   Löschen

--- a/src/components/TaskDetailModal.tsx
+++ b/src/components/TaskDetailModal.tsx
@@ -70,7 +70,7 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
                   type="checkbox"
                   checked={task.completed}
                   onChange={handleToggleComplete}
-                  className="mt-1 h-5 w-5 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
+                  className="mt-1 h-5 w-5 text-primary rounded border-gray-300 focus:ring-primary"
                 />
               )}
               <div className="flex-1">
@@ -125,7 +125,7 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
                   onDelete(task.id);
                   onClose();
                 }}
-                className="text-red-600 hover:text-red-800"
+                className="text-destructive hover:text-destructive/80"
               >
                 <Trash2 className="h-4 w-4 mr-2" />
                 Löschen

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -20,7 +20,14 @@ const defaultTheme = {
   foreground: '222.2 84% 4.9%',
   accent: '210 40% 96.1%',
   card: '0 0% 100%',
-  'card-foreground': '222.2 84% 4.9%'
+  'card-foreground': '222.2 84% 4.9%',
+  'stat-bar-primary': '210 40% 96.1%',
+  'stat-bar-secondary': '214.3 31.8% 91.4%',
+  'kanban-todo': '210 40% 96.1%',
+  'kanban-inprogress': '214.3 31.8% 91.4%',
+  'kanban-done': '140 40% 96.1%',
+  'pomodoro-work-ring': '222.2 47.4% 11.2%',
+  'pomodoro-break-ring': '210 40% 96.1%'
 }
 
 interface SettingsContextValue {

--- a/src/index.css
+++ b/src/index.css
@@ -10,7 +10,7 @@
     --card: 0 0% 100%;
     --card-foreground: 222.2 84% 4.9%;
 
-    --popover: 0 0% 100%;
+    --popover: 0 0% 98%;
     --popover-foreground: 222.2 84% 4.9%;
 
     --primary: 222.2 47.4% 11.2%;
@@ -49,6 +49,14 @@
     --sidebar-border: 220 13% 91%;
 
     --sidebar-ring: 217.2 91.2% 59.8%;
+
+    --stat-bar-primary: var(--accent);
+    --stat-bar-secondary: var(--muted);
+    --kanban-todo: var(--muted);
+    --kanban-inprogress: var(--secondary);
+    --kanban-done: var(--accent);
+    --pomodoro-work-ring: var(--primary);
+    --pomodoro-break-ring: var(--accent);
   }
 
   .dark {
@@ -58,7 +66,7 @@
     --card: 222.2 84% 4.9%;
     --card-foreground: 210 40% 98%;
 
-    --popover: 222.2 84% 4.9%;
+    --popover: 217.2 32.6% 17.5%;
     --popover-foreground: 210 40% 98%;
 
     --primary: 210 40% 98%;
@@ -87,6 +95,14 @@
     --sidebar-accent-foreground: 240 4.8% 95.9%;
     --sidebar-border: 240 3.7% 15.9%;
     --sidebar-ring: 217.2 91.2% 59.8%;
+
+    --stat-bar-primary: var(--accent);
+    --stat-bar-secondary: var(--muted);
+    --kanban-todo: var(--muted);
+    --kanban-inprogress: var(--secondary);
+    --kanban-done: var(--accent);
+    --pomodoro-work-ring: var(--primary);
+    --pomodoro-break-ring: var(--accent);
   }
 }
 

--- a/src/pages/FlashcardStatistics.tsx
+++ b/src/pages/FlashcardStatistics.tsx
@@ -60,10 +60,10 @@ const FlashcardStatisticsPage: React.FC = () => {
               <CardTitle className="text-xs sm:text-sm font-medium">
                 Fällig
               </CardTitle>
-              <Clock className="h-4 w-4 text-red-600" />
+              <Clock className="h-4 w-4 text-destructive" />
             </CardHeader>
             <CardContent>
-              <div className="text-lg sm:text-2xl font-bold text-red-600">
+              <div className="text-lg sm:text-2xl font-bold text-destructive">
                 {stats.dueCards}
               </div>
             </CardContent>
@@ -73,10 +73,10 @@ const FlashcardStatisticsPage: React.FC = () => {
               <CardTitle className="text-xs sm:text-sm font-medium">
                 Ø Intervall
               </CardTitle>
-              <TrendingUp className="h-4 w-4 text-blue-600" />
+              <TrendingUp className="h-4 w-4 text-primary" />
             </CardHeader>
             <CardContent>
-              <div className="text-lg sm:text-2xl font-bold text-blue-600">
+              <div className="text-lg sm:text-2xl font-bold text-primary">
                 {Math.round(stats.averageInterval * 10) / 10} Tage
               </div>
             </CardContent>
@@ -142,7 +142,11 @@ const FlashcardStatisticsPage: React.FC = () => {
                     <XAxis dataKey="date" fontSize={12} />
                     <YAxis fontSize={12} />
                     <Tooltip />
-                    <Bar dataKey="count" fill="hsl(var(--accent))" name="Karten" />
+                    <Bar
+                      dataKey="count"
+                      fill="hsl(var(--stat-bar-primary))"
+                      name="Karten"
+                    />
                   </BarChart>
                 </ResponsiveContainer>
               </div>

--- a/src/pages/Flashcards.tsx
+++ b/src/pages/Flashcards.tsx
@@ -278,7 +278,7 @@ const FlashcardsPage: React.FC = () => {
             <CardContent>
               {timedMode && timerStarted && (
                 <div className="flex justify-center items-center space-x-2 mb-4">
-                  <div className="text-2xl font-bold text-red-600 text-center">
+                  <div className="text-2xl font-bold text-destructive text-center">
                     {Math.max(timeLeft, 0)}
                   </div>
                   {timerPaused ? (
@@ -299,7 +299,7 @@ const FlashcardsPage: React.FC = () => {
                     <>
                       <div className="text-center">{current.back}</div>
                       <div
-                        className={`text-sm text-center ${isCorrect ? 'text-green-600' : 'text-red-600'}`}
+                        className={`text-sm text-center ${isCorrect ? 'text-accent' : 'text-destructive'}`}
                       >
                         {isCorrect ? 'Richtig!' : 'Falsch'}
                       </div>

--- a/src/pages/Kanban.tsx
+++ b/src/pages/Kanban.tsx
@@ -162,7 +162,8 @@ const Kanban: React.FC = () => {
                   <div
                     ref={provided.innerRef}
                     {...provided.droppableProps}
-                    className="bg-muted rounded-md p-2 space-y-2 min-h-[200px]"
+                    className="rounded-md p-2 space-y-2 min-h-[200px]"
+                    style={{ backgroundColor: `hsl(var(--kanban-${status}))` }}
                   >
                     <h2 className="text-base font-semibold mb-2">
                       {labels[status]}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -305,6 +305,79 @@ const SettingsPage: React.FC = () => {
             }
           />
         </div>
+        <div className="space-y-2">
+          <Label htmlFor="statBarPrimary">Statistik Balken 1</Label>
+          <Input
+            id="statBarPrimary"
+            type="color"
+            value={hslToHex(theme['stat-bar-primary'])}
+            onChange={e =>
+              updateTheme('stat-bar-primary', hexToHsl(e.target.value))
+            }
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="statBarSecondary">Statistik Balken 2</Label>
+          <Input
+            id="statBarSecondary"
+            type="color"
+            value={hslToHex(theme['stat-bar-secondary'])}
+            onChange={e =>
+              updateTheme('stat-bar-secondary', hexToHsl(e.target.value))
+            }
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="kanbanTodo">Kanban ToDo</Label>
+          <Input
+            id="kanbanTodo"
+            type="color"
+            value={hslToHex(theme['kanban-todo'])}
+            onChange={e => updateTheme('kanban-todo', hexToHsl(e.target.value))}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="kanbanInprogress">Kanban In Arbeit</Label>
+          <Input
+            id="kanbanInprogress"
+            type="color"
+            value={hslToHex(theme['kanban-inprogress'])}
+            onChange={e =>
+              updateTheme('kanban-inprogress', hexToHsl(e.target.value))
+            }
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="kanbanDone">Kanban Done</Label>
+          <Input
+            id="kanbanDone"
+            type="color"
+            value={hslToHex(theme['kanban-done'])}
+            onChange={e => updateTheme('kanban-done', hexToHsl(e.target.value))}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="workRing">Pomodoro Arbeit</Label>
+          <Input
+            id="workRing"
+            type="color"
+            value={hslToHex(theme['pomodoro-work-ring'])}
+            onChange={e =>
+              updateTheme('pomodoro-work-ring', hexToHsl(e.target.value))
+            }
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="breakRing">Pomodoro Pause</Label>
+          <Input
+            id="breakRing"
+            type="color"
+            value={hslToHex(theme['pomodoro-break-ring'])}
+            onChange={e =>
+              updateTheme('pomodoro-break-ring', hexToHsl(e.target.value))
+            }
+          />
+        </div>
       </div>
         <div className="pt-4 border-t space-y-4">
           <h2 className="font-semibold">Datenexport / -import</h2>

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -179,10 +179,14 @@ const Statistics = () => {
                     <Tooltip />
                     <Bar
                       dataKey="completed"
-                      fill="hsl(var(--accent))"
+                      fill="hsl(var(--stat-bar-primary))"
                       name="Abgeschlossen"
                     />
-                    <Bar dataKey="total" fill="hsl(var(--muted))" name="Gesamt" />
+                    <Bar
+                      dataKey="total"
+                      fill="hsl(var(--stat-bar-secondary))"
+                      name="Gesamt"
+                    />
                   </BarChart>
                 </ResponsiveContainer>
               </div>

--- a/src/utils/taskUtils.ts
+++ b/src/utils/taskUtils.ts
@@ -33,11 +33,11 @@ export const getTaskProgress = (task: Task): { completed: number; total: number 
 export const getPriorityColor = (priority: string): string => {
   switch (priority) {
     case 'high':
-      return 'text-red-600 bg-red-50 border-red-200';
+      return 'text-destructive bg-destructive/10 border-destructive/30';
     case 'medium':
-      return 'text-yellow-600 bg-yellow-50 border-yellow-200';
+      return 'text-primary bg-primary/10 border-primary/30';
     case 'low':
-      return 'text-green-600 bg-green-50 border-green-200';
+      return 'text-accent bg-accent/10 border-accent/30';
     default:
       return 'text-gray-600 bg-background border-gray-200';
   }


### PR DESCRIPTION
## Summary
- allow customizing bar, kanban and pomodoro colors via settings sliders
- lighten navbar dropdown background
- use theme colors in kanban, statistics and flashcards
- replace hard coded status colors with theme variables

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68496e243628832ab30168852d69ad3f