### PR TITLE
Implement theme presets with custom option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ npm start    # startet die gebaute App auf Port 3002
 - Lern- und Pausendauer frei konfigurierbar (auch direkt im Timer anpassbar)
 - Daten können im Einstellungsbereich exportiert und importiert werden
 - Standard-Priorität für neue Tasks einstellbar
+- Mehrere Theme-Voreinstellungen (light, dark, ocean) und ein eigenes
+  "Custom"-Theme wählbar
 
 ## Verwendung
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import Navbar from '@/components/Navbar'
-import { useSettings } from '@/hooks/useSettings'
+import { useSettings, themePresets } from '@/hooks/useSettings'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
@@ -28,7 +28,9 @@ const SettingsPage: React.FC = () => {
     defaultTaskPriority,
     updateDefaultTaskPriority,
     theme,
-    updateTheme
+    updateTheme,
+    themeName,
+    updateThemeName
   } = useSettings()
 
   const download = (data: any, name: string) => {
@@ -274,6 +276,22 @@ const SettingsPage: React.FC = () => {
             </div>
           </TabsContent>
           <TabsContent value="theme" className="space-y-4">
+            <div>
+              <Label htmlFor="themePreset">Voreinstellung</Label>
+              <Select value={themeName} onValueChange={updateThemeName}>
+                <SelectTrigger id="themePreset">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {Object.keys(themePresets).map(name => (
+                    <SelectItem key={name} value={name}>
+                      {name}
+                    </SelectItem>
+                  ))}
+                  <SelectItem value="custom">custom</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
             <div className="space-y-2">
               <Label htmlFor="bgColor">Hintergrund</Label>
               <Input


### PR DESCRIPTION
## Summary
- add light, dark and ocean theme presets
- allow choosing presets in settings
- store selected preset name
- document theme presets in README

## Testing
- `npm run lint` *(fails: Unexpected any and other pre-existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_684972d76060832a8a47ef07a29e1d89