### PR TITLE
Improve theme presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ npm start    # startet die gebaute App auf Port 3002
 - Lern- und Pausendauer frei konfigurierbar (auch direkt im Timer anpassbar)
 - Daten können im Einstellungsbereich exportiert und importiert werden
 - Standard-Priorität für neue Tasks einstellbar
-- Mehrere Theme-Voreinstellungen (light, dark, ocean) und ein eigenes
-  "Custom"-Theme wählbar
+- Mehrere Theme-Voreinstellungen (light, dark, ocean, dark-red, hacker,
+  motivation) und ein eigenes "Custom"-Theme wählbar
 
 ## Verwendung
 

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -18,39 +18,39 @@ const defaultTaskPriority: 'low' | 'medium' | 'high' = 'medium'
 const defaultTheme = {
   background: '0 0% 100%',
   foreground: '222.2 84% 4.9%',
-  accent: '210 40% 96.1%',
-  card: '0 0% 100%',
+  accent: '212 100% 47%',
+  card: '0 0% 98%',
   'card-foreground': '222.2 84% 4.9%',
-  'stat-bar-primary': '210 40% 96.1%',
-  'stat-bar-secondary': '214.3 31.8% 91.4%',
+  'stat-bar-primary': '212 100% 47%',
+  'stat-bar-secondary': '215 28% 80%',
   'kanban-todo': '210 40% 96.1%',
-  'kanban-inprogress': '214.3 31.8% 91.4%',
-  'kanban-done': '140 40% 96.1%',
+  'kanban-inprogress': '215 28% 80%',
+  'kanban-done': '158 55% 52%',
   'pomodoro-work-ring': '222.2 47.4% 11.2%',
-  'pomodoro-break-ring': '210 40% 96.1%'
+  'pomodoro-break-ring': '212 100% 47%'
 }
 
 export const themePresets: Record<string, typeof defaultTheme> = {
   light: { ...defaultTheme },
   dark: {
-    background: '222.2 84% 4.9%',
+    background: '222 47% 11%',
     foreground: '210 40% 98%',
-    accent: '217.2 32.6% 17.5%',
-    card: '222.2 84% 4.9%',
+    accent: '217 91% 60%',
+    card: '218 28% 17%',
     'card-foreground': '210 40% 98%',
-    'stat-bar-primary': '217.2 32.6% 17.5%',
-    'stat-bar-secondary': '217.2 32.6% 17.5%',
-    'kanban-todo': '217.2 32.6% 17.5%',
-    'kanban-inprogress': '217.2 32.6% 17.5%',
-    'kanban-done': '217.2 32.6% 17.5%',
+    'stat-bar-primary': '217 91% 60%',
+    'stat-bar-secondary': '218 14% 30%',
+    'kanban-todo': '218 14% 30%',
+    'kanban-inprogress': '217 91% 60%',
+    'kanban-done': '158 64% 52%',
     'pomodoro-work-ring': '210 40% 98%',
-    'pomodoro-break-ring': '217.2 32.6% 17.5%'
+    'pomodoro-break-ring': '217 91% 60%'
   },
   ocean: {
     background: '210 60% 98%',
     foreground: '222.2 47.4% 11.2%',
     accent: '199 94% 48%',
-    card: '210 60% 98%',
+    card: '210 60% 96%',
     'card-foreground': '222.2 47.4% 11.2%',
     'stat-bar-primary': '199 94% 48%',
     'stat-bar-secondary': '214.3 31.8% 91.4%',
@@ -59,6 +59,48 @@ export const themePresets: Record<string, typeof defaultTheme> = {
     'kanban-done': '199 94% 48%',
     'pomodoro-work-ring': '199 94% 48%',
     'pomodoro-break-ring': '210 40% 96.1%'
+  },
+  'dark-red': {
+    background: '0 0% 9%',
+    foreground: '0 0% 98%',
+    accent: '0 72% 51%',
+    card: '0 0% 15%',
+    'card-foreground': '0 0% 98%',
+    'stat-bar-primary': '0 72% 51%',
+    'stat-bar-secondary': '0 0% 25%',
+    'kanban-todo': '0 0% 25%',
+    'kanban-inprogress': '0 72% 51%',
+    'kanban-done': '0 72% 51%',
+    'pomodoro-work-ring': '0 0% 98%',
+    'pomodoro-break-ring': '0 72% 51%'
+  },
+  hacker: {
+    background: '120 12% 8%',
+    foreground: '120 100% 80%',
+    accent: '120 70% 40%',
+    card: '120 10% 12%',
+    'card-foreground': '120 100% 80%',
+    'stat-bar-primary': '120 70% 40%',
+    'stat-bar-secondary': '120 10% 20%',
+    'kanban-todo': '120 20% 20%',
+    'kanban-inprogress': '120 40% 30%',
+    'kanban-done': '120 70% 40%',
+    'pomodoro-work-ring': '120 100% 80%',
+    'pomodoro-break-ring': '120 70% 40%'
+  },
+  motivation: {
+    background: '40 100% 98%',
+    foreground: '20 90% 10%',
+    accent: '30 100% 50%',
+    card: '0 0% 100%',
+    'card-foreground': '20 90% 10%',
+    'stat-bar-primary': '30 100% 50%',
+    'stat-bar-secondary': '38 88% 80%',
+    'kanban-todo': '38 88% 80%',
+    'kanban-inprogress': '30 100% 50%',
+    'kanban-done': '88 50% 50%',
+    'pomodoro-work-ring': '20 90% 10%',
+    'pomodoro-break-ring': '30 100% 50%'
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -11,7 +11,7 @@
     --card-foreground: 222.2 84% 4.9%;
 
     --popover: 0 0% 98%;
-    --popover-foreground: 222.2 84% 4.9%;
+    --popover-foreground: var(--foreground);
 
     --primary: 222.2 47.4% 11.2%;
     --primary-foreground: 210 40% 98%;
@@ -67,7 +67,7 @@
     --card-foreground: 210 40% 98%;
 
     --popover: 217.2 32.6% 17.5%;
-    --popover-foreground: 210 40% 98%;
+    --popover-foreground: var(--foreground);
 
     --primary: 210 40% 98%;
     --primary-foreground: 222.2 47.4% 11.2%;
@@ -113,5 +113,9 @@
 
   body {
     @apply bg-background text-foreground;
+  }
+
+  .prose {
+    @apply text-foreground;
   }
 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -293,7 +293,7 @@ const SettingsPage: React.FC = () => {
               </Select>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="bgColor">Hintergrund</Label>
+              <Label htmlFor="bgColor">Hintergrund (App)</Label>
               <Input
                 id="bgColor"
                 type="color"
@@ -302,7 +302,7 @@ const SettingsPage: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="fgColor">Vordergrund</Label>
+              <Label htmlFor="fgColor">Textfarbe</Label>
               <Input
                 id="fgColor"
                 type="color"
@@ -311,7 +311,7 @@ const SettingsPage: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="accentColor">Akzent</Label>
+              <Label htmlFor="accentColor">Akzentfarbe</Label>
               <Input
                 id="accentColor"
                 type="color"
@@ -329,7 +329,7 @@ const SettingsPage: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="cardFgColor">Karten-Vordergrund</Label>
+              <Label htmlFor="cardFgColor">Karten-Textfarbe</Label>
               <Input
                 id="cardFgColor"
                 type="color"
@@ -338,7 +338,7 @@ const SettingsPage: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="statBarPrimary">Statistik Balken 1</Label>
+              <Label htmlFor="statBarPrimary">Statistik Balken Primär</Label>
               <Input
                 id="statBarPrimary"
                 type="color"
@@ -347,7 +347,7 @@ const SettingsPage: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="statBarSecondary">Statistik Balken 2</Label>
+              <Label htmlFor="statBarSecondary">Statistik Balken Sekundär</Label>
               <Input
                 id="statBarSecondary"
                 type="color"
@@ -374,7 +374,7 @@ const SettingsPage: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="kanbanDone">Kanban Done</Label>
+              <Label htmlFor="kanbanDone">Kanban Erledigt</Label>
               <Input
                 id="kanbanDone"
                 type="color"


### PR DESCRIPTION
## Summary
- add new theme presets and tweak defaults for more dynamic colors
- rename color pickers for clarity
- ensure dropdowns respect custom foreground
- make note detail text inherit theme
- document new presets in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68497723e018832a9b251811dcd68a12