### PR TITLE
Improve theme support and search modal

### DIFF
--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -39,8 +39,8 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
       >
         <div className="flex items-start justify-between">
           <div className="flex items-start space-x-2 sm:space-x-3 flex-1 min-w-0">
-            <div 
-              className="w-5 h-5 sm:w-6 sm:h-6 rounded-full border-2 border-gray-300 flex-shrink-0 mt-1"
+            <div
+              className="w-5 h-5 sm:w-6 sm:h-6 rounded-full border-2 border-muted flex-shrink-0 mt-1"
               style={{ backgroundColor: category.color }}
             />
             <div className="flex-1 min-w-0">
@@ -48,7 +48,7 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
                 {category.name}
               </CardTitle>
               {category.description && (
-                <p className="text-xs sm:text-sm text-gray-600 mt-1 line-clamp-2 break-words">
+                <p className="text-xs sm:text-sm text-muted-foreground mt-1 line-clamp-2 break-words">
                   {category.description}
                 </p>
               )}
@@ -121,8 +121,8 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
         <div className="space-y-3">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-2">
-              <FolderOpen className="h-4 w-4 text-gray-500 flex-shrink-0" />
-              <span className="text-xs sm:text-sm text-gray-600">
+              <FolderOpen className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+              <span className="text-xs sm:text-sm text-muted-foreground">
                 {totalTasks} Task{totalTasks !== 1 ? 's' : ''}
               </span>
             </div>
@@ -139,7 +139,7 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
             </Badge>
           </div>
           
-          <div className="w-full bg-gray-200 rounded-full h-2">
+          <div className="w-full bg-muted rounded-full h-2">
             <div 
               className="h-2 rounded-full transition-all duration-300"
               style={{ 
@@ -149,7 +149,7 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
             />
           </div>
           
-          <div className="text-xs text-gray-500 text-center">
+          <div className="text-xs text-muted-foreground text-center">
             {completedTasks} von {totalTasks} abgeschlossen
           </div>
         </div>

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -62,7 +62,12 @@ const CommandPalette: React.FC = () => {
       }
     }
     document.addEventListener('keydown', handler)
-    return () => document.removeEventListener('keydown', handler)
+    const openListener = () => setOpen(true)
+    window.addEventListener('open-command-palette', openListener)
+    return () => {
+      document.removeEventListener('keydown', handler)
+      window.removeEventListener('open-command-palette', openListener)
+    }
   }, [shortcuts])
 
   const create = () => {

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -359,26 +359,26 @@ const Dashboard: React.FC = () => {
         <div className="grid grid-cols-1 sm:grid-cols-4 gap-4 sm:gap-6 mb-6 sm:mb-8">
           <Card>
             <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-gray-600">Gesamt Tasks</CardTitle>
+              <CardTitle className="text-sm font-medium text-muted-foreground">Gesamt Tasks</CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="text-xl sm:text-2xl font-bold text-gray-900">{totalTasks}</div>
+              <div className="text-xl sm:text-2xl font-bold text-foreground">{totalTasks}</div>
             </CardContent>
           </Card>
           <Card>
             <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-gray-600">Abgeschlossen</CardTitle>
+              <CardTitle className="text-sm font-medium text-muted-foreground">Abgeschlossen</CardTitle>
             </CardHeader>
             <CardContent>
               <div className="text-xl sm:text-2xl font-bold text-accent">{completedTasks}</div>
-              <div className="text-xs sm:text-sm text-gray-500">
+              <div className="text-xs sm:text-sm text-muted-foreground">
                 {totalTasks > 0 ? Math.round((completedTasks / totalTasks) * 100) : 0}% erledigt
               </div>
             </CardContent>
           </Card>
           <Card>
             <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-gray-600">Offen</CardTitle>
+              <CardTitle className="text-sm font-medium text-muted-foreground">Offen</CardTitle>
             </CardHeader>
             <CardContent>
               <div className="text-xl sm:text-2xl font-bold text-primary">{pendingTasks}</div>
@@ -386,7 +386,7 @@ const Dashboard: React.FC = () => {
           </Card>
           <Card>
             <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-gray-600">Kategorien</CardTitle>
+              <CardTitle className="text-sm font-medium text-muted-foreground">Kategorien</CardTitle>
             </CardHeader>
             <CardContent>
               <div className="text-xl sm:text-2xl font-bold text-primary">{totalCategories}</div>
@@ -399,7 +399,7 @@ const Dashboard: React.FC = () => {
         {viewMode === 'categories' ? (
           <div>
             <div className="flex items-center justify-between mb-4 sm:mb-6">
-              <h2 className="text-lg sm:text-xl font-semibold text-gray-900">Kategorien</h2>
+              <h2 className="text-lg sm:text-xl font-semibold text-foreground">Kategorien</h2>
               <Badge variant="secondary">{filteredCategories.length} Kategorien</Badge>
             </div>
             <div className="flex items-center gap-2 mb-4 sm:mb-6">
@@ -499,7 +499,7 @@ const Dashboard: React.FC = () => {
                 >
                   <ArrowLeft className="h-4 w-4" />
                 </Button>
-                <h2 className="text-lg sm:text-xl font-semibold text-gray-900">Tasks</h2>
+                <h2 className="text-lg sm:text-xl font-semibold text-foreground">Tasks</h2>
               </div>
               <Badge variant="secondary">{filteredTasks.length} Tasks</Badge>
             </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -18,6 +18,7 @@ import {
   Timer,
   BookOpen,
   Pencil,
+  Search,
 } from 'lucide-react'
 
 interface NavbarProps {
@@ -66,6 +67,13 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
             </Button>
           </div>
           <div className="hidden sm:flex items-center space-x-4">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => window.dispatchEvent(new Event('open-command-palette'))}
+            >
+              <Search className="h-4 w-4" />
+            </Button>
             <DropdownMenu
               open={openMenu === 'tasks'}
               onOpenChange={(open) => setOpenMenu(open ? 'tasks' : null)}
@@ -231,6 +239,23 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                     Notizen
                   </Button>
                 </Link>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <p className="text-xs font-semibold text-muted-foreground">Suche</p>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full"
+                  onClick={() => {
+                    window.dispatchEvent(new Event('open-command-palette'))
+                    setShowMobileMenu(false)
+                  }}
+                >
+                  <Search className="h-4 w-4 mr-2" />
+                  Suche
+                </Button>
               </div>
             </div>
             <div className="space-y-2">

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -44,7 +44,7 @@ const NoteCard: React.FC<NoteCardProps> = ({ note, onClick }) => {
         </button>
       </CardHeader>
       <CardContent className="flex-1">
-        <ReactMarkdown className="prose prose-sm text-gray-600 line-clamp-3">
+        <ReactMarkdown className="prose prose-sm text-muted-foreground line-clamp-3">
           {note.text}
         </ReactMarkdown>
       </CardContent>

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -20,6 +20,7 @@ const defaultTheme = {
   foreground: '222.2 84% 4.9%',
   accent: '212 100% 47%',
   card: '0 0% 98%',
+  popover: '0 0% 98%',
   'card-foreground': '222.2 84% 4.9%',
   'stat-bar-primary': '212 100% 47%',
   'stat-bar-secondary': '215 28% 80%',
@@ -37,6 +38,7 @@ export const themePresets: Record<string, typeof defaultTheme> = {
     foreground: '210 40% 98%',
     accent: '217 91% 60%',
     card: '218 28% 17%',
+    popover: '218 28% 17%',
     'card-foreground': '210 40% 98%',
     'stat-bar-primary': '217 91% 60%',
     'stat-bar-secondary': '218 14% 30%',
@@ -51,6 +53,7 @@ export const themePresets: Record<string, typeof defaultTheme> = {
     foreground: '222.2 47.4% 11.2%',
     accent: '199 94% 48%',
     card: '210 60% 96%',
+    popover: '210 60% 96%',
     'card-foreground': '222.2 47.4% 11.2%',
     'stat-bar-primary': '199 94% 48%',
     'stat-bar-secondary': '214.3 31.8% 91.4%',
@@ -65,6 +68,7 @@ export const themePresets: Record<string, typeof defaultTheme> = {
     foreground: '0 0% 98%',
     accent: '0 72% 51%',
     card: '0 0% 15%',
+    popover: '0 0% 15%',
     'card-foreground': '0 0% 98%',
     'stat-bar-primary': '0 72% 51%',
     'stat-bar-secondary': '0 0% 25%',
@@ -79,6 +83,7 @@ export const themePresets: Record<string, typeof defaultTheme> = {
     foreground: '120 100% 80%',
     accent: '120 70% 40%',
     card: '120 10% 12%',
+    popover: '120 10% 12%',
     'card-foreground': '120 100% 80%',
     'stat-bar-primary': '120 70% 40%',
     'stat-bar-secondary': '120 10% 20%',
@@ -93,6 +98,7 @@ export const themePresets: Record<string, typeof defaultTheme> = {
     foreground: '20 90% 10%',
     accent: '30 100% 50%',
     card: '0 0% 100%',
+    popover: '0 0% 100%',
     'card-foreground': '20 90% 10%',
     'stat-bar-primary': '30 100% 50%',
     'stat-bar-secondary': '38 88% 80%',
@@ -186,7 +192,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     Object.entries(theme).forEach(([key, value]) => {
       document.documentElement.style.setProperty(`--${key}`, value)
     })
-    if (themeName === 'dark') {
+    if (['dark', 'dark-red', 'hacker'].includes(themeName)) {
       document.documentElement.classList.add('dark')
     } else {
       document.documentElement.classList.remove('dark')

--- a/src/pages/DeckDetail.tsx
+++ b/src/pages/DeckDetail.tsx
@@ -62,7 +62,7 @@ const DeckDetailPage: React.FC = () => {
                 </CardHeader>
                 <CardContent className="space-y-2">
                   <div className="font-medium">{card.front}</div>
-                  <div className="text-sm text-gray-600">{card.back}</div>
+                  <div className="text-sm text-muted-foreground">{card.back}</div>
                 </CardContent>
                 <CardFooter className="flex justify-end space-x-2">
                   <Button variant="outline" size="sm" onClick={() => { setEditingIndex(index); setIsModalOpen(true); }}>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -46,7 +46,7 @@ const Home: React.FC = () => {
         </div>
         {pinnedNotes.length > 0 && (
           <div>
-            <h2 className="text-lg sm:text-xl font-semibold text-gray-900 mb-3">
+            <h2 className="text-lg sm:text-xl font-semibold text-foreground mb-3">
               Gepinnte Notizen
             </h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -13,13 +13,13 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen bg-gray-100">
+    <div className="min-h-screen bg-background">
       <Navbar title="404" />
       <div className="flex items-center justify-center py-8">
         <div className="text-center">
           <h1 className="text-4xl font-bold mb-4">404</h1>
-          <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-          <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+          <p className="text-xl text-muted-foreground mb-4">Oops! Page not found</p>
+          <a href="/" className="text-primary hover:text-primary/80 underline">
             Return to Home
           </a>
         </div>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -338,6 +338,15 @@ const SettingsPage: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
+              <Label htmlFor="popoverColor">Dropdown-Hintergrund</Label>
+              <Input
+                id="popoverColor"
+                type="color"
+                value={hslToHex(theme.popover)}
+                onChange={e => updateTheme('popover', hexToHsl(e.target.value))}
+              />
+            </div>
+            <div className="space-y-2">
               <Label htmlFor="statBarPrimary">Statistik Balken Primär</Label>
               <Input
                 id="statBarPrimary"

--- a/src/utils/taskUtils.ts
+++ b/src/utils/taskUtils.ts
@@ -39,7 +39,7 @@ export const getPriorityColor = (priority: string): string => {
     case 'low':
       return 'text-accent bg-accent/10 border-accent/30';
     default:
-      return 'text-gray-600 bg-background border-gray-200';
+      return 'text-muted-foreground bg-background border-border';
   }
 };
 


### PR DESCRIPTION
## Summary
- allow popover color customization and extend theme presets
- treat dark-red and hacker presets as dark mode
- expose command palette via global event and add search button in navbar
- fix several components to use theme variables

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68497a822208832a9bbb72e0d77f37a0