### PR TITLE
Add icons for Tasks and Lernen in navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -19,6 +19,8 @@ import {
   BookOpen,
   Pencil,
   Search,
+  ClipboardList,
+  GraduationCap,
 } from 'lucide-react'
 
 interface NavbarProps {
@@ -84,7 +86,9 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                   size="sm"
                   onMouseEnter={() => setOpenMenu('tasks')}
                   onMouseLeave={() => setOpenMenu(null)}
+                  className="flex items-center"
                 >
+                  <ClipboardList className="h-4 w-4 mr-2" />
                   Tasks
                 </Button>
               </DropdownMenuTrigger>
@@ -126,7 +130,9 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                   size="sm"
                   onMouseEnter={() => setOpenMenu('learning')}
                   onMouseLeave={() => setOpenMenu(null)}
+                  className="flex items-center"
                 >
+                  <GraduationCap className="h-4 w-4 mr-2" />
                   Lernen
                 </Button>
               </DropdownMenuTrigger>


### PR DESCRIPTION
## Summary
- add icons for Tasks and Lernen dropdown triggers

## Testing
- `npm run lint` *(fails: cannot find module `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6849808bbd1c832aac691006e1e4ab58