### PR TITLE
Implement task pinning feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ npm start    # startet die gebaute App auf Port 3002
 - Kalenderansicht mit direkter Task-Erstellung; Tagesaufgaben sind klickbar und bieten alle Task-Optionen
 - Eigene Notizen mit Farbe und Drag & Drop sortierbar
   - Notizen lassen sich anpinnen; die ersten drei angepinnten erscheinen auf der Startseite
+  - Tasks lassen sich ebenfalls anpinnen; die ersten drei werden auf der Startseite gezeigt
   - Text kann im Markdown-Format geschrieben werden
 - Lernkarten mit Spaced-Repetition-Training und Verwaltung eigener Karten
   - Decks lassen sich beim Lernen ein- oder ausblenden
@@ -95,11 +96,12 @@ npm start    # startet die gebaute App auf Port 3002
 2. Wähle eine Kategorie aus, um ihre **Tasks** zu sehen. Über `Task` legst du neue Aufgaben an. Dort kannst du Titel, Beschreibung, Priorität, Farbe, Fälligkeitsdatum und optionale Wiederholung definieren.
 3. Tasks lassen sich per Drag & Drop umsortieren oder in Unteraufgaben aufteilen.
 4. Über das Suchfeld und die Filter sortierst und findest du Aufgaben nach Priorität oder Farbe.
-5. Mit `Strg+K` (oder über das Suchsymbol) öffnest du die **globale Suche**. Sie durchsucht Tasks, Notizen und Lernkarten und führt dich bei Auswahl direkt zum entsprechenden Eintrag.
-6. In der **Kalender**-Ansicht klickst du auf ein Datum, um alle bis dahin fälligen Aufgaben zu sehen. Dort kannst du die Tasks direkt öffnen, bearbeiten, Unteraufgaben anlegen oder löschen. Die **Statistiken** geben einen Überblick über erledigte Tasks.
-7. Unter **Notizen** kannst du unabhängige Notizen verwalten und per Drag & Drop sortieren. Gepinnte Notizen erscheinen auf der Startseite. Deine Inhalte kannst du dabei in Markdown verfassen. Beim Anklicken einer Notiz siehst du zunächst eine Vorschau, die du dort auch bearbeiten kannst.
-8. Unter **Decks** legst du Kartendecks an und kannst sie bearbeiten. In der Detailansicht eines Decks fügst du einzelne Karten hinzu.
-9. Der Bereich **Karten** zeigt dir fällige Karten zum Lernen an. Dort kannst du
+5. Mit dem Sternsymbol kannst du eine Task anpinnen. Die ersten drei gepinnten erscheinen auf der Startseite.
+6. Mit `Strg+K` (oder über das Suchsymbol) öffnest du die **globale Suche**. Sie durchsucht Tasks, Notizen und Lernkarten und führt dich bei Auswahl direkt zum entsprechenden Eintrag.
+7. In der **Kalender**-Ansicht klickst du auf ein Datum, um alle bis dahin fälligen Aufgaben zu sehen. Dort kannst du die Tasks direkt öffnen, bearbeiten, Unteraufgaben anlegen oder löschen. Die **Statistiken** geben einen Überblick über erledigte Tasks.
+8. Unter **Notizen** kannst du unabhängige Notizen verwalten und per Drag & Drop sortieren. Gepinnte Notizen erscheinen auf der Startseite. Deine Inhalte kannst du dabei in Markdown verfassen. Beim Anklicken einer Notiz siehst du zunächst eine Vorschau, die du dort auch bearbeiten kannst.
+9. Unter **Decks** legst du Kartendecks an und kannst sie bearbeiten. In der Detailansicht eines Decks fügst du einzelne Karten hinzu.
+10. Der Bereich **Karten** zeigt dir fällige Karten zum Lernen an. Dort kannst du
    gezielt Decks ein- oder ausblenden, einen Zufallsmodus aktivieren und im
    Eingabemodus Antworten eintippen. Nach dem Vergleich der Lösung entscheidest
    du selbst, wie schwer dir die Karte fiel.

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -6,7 +6,16 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
-import { Edit, Trash2, Plus, FolderOpen, MoreVertical } from 'lucide-react';
+import {
+  Edit,
+  Trash2,
+  Plus,
+  FolderOpen,
+  MoreVertical,
+  Star,
+  StarOff
+} from 'lucide-react';
+import { useTaskStore } from '@/hooks/useTaskStore';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 
 interface TaskCardProps {
@@ -39,6 +48,12 @@ const TaskCard: React.FC<TaskCardProps> = ({
   const progressPercentage = progress.total > 0 ? (progress.completed / progress.total) * 100 : 0;
   const priorityClasses = getPriorityColor(task.priority);
   const priorityIcon = getPriorityIcon(task.priority);
+  const { updateTask } = useTaskStore();
+
+  const handleTogglePinned = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    updateTask(task.id, { pinned: !task.pinned });
+  };
 
   const handleToggleComplete = () => {
     if (task.subtasks.length === 0) {
@@ -120,6 +135,18 @@ const TaskCard: React.FC<TaskCardProps> = ({
             <Button
               variant="ghost"
               size="sm"
+              onClick={handleTogglePinned}
+              className="h-8 w-8 p-0"
+            >
+              {task.pinned ? (
+                <Star className="h-4 w-4 fill-current" />
+              ) : (
+                <StarOff className="h-4 w-4" />
+              )}
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={() => onViewDetails(task)}
               className="h-8 w-8 p-0"
             >
@@ -159,11 +186,19 @@ const TaskCard: React.FC<TaskCardProps> = ({
                   <MoreVertical className="h-4 w-4" />
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="bg-background z-50">
-                <DropdownMenuItem onClick={() => onViewDetails(task)}>
-                  <FolderOpen className="h-4 w-4 mr-2" />
-                  Details anzeigen
-                </DropdownMenuItem>
+          <DropdownMenuContent align="end" className="bg-background z-50">
+            <DropdownMenuItem onClick={handleTogglePinned}>
+              {task.pinned ? (
+                <Star className="h-4 w-4 mr-2" />
+              ) : (
+                <StarOff className="h-4 w-4 mr-2" />
+              )}
+              {task.pinned ? 'Lösen' : 'Anheften'}
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onViewDetails(task)}>
+              <FolderOpen className="h-4 w-4 mr-2" />
+              Details anzeigen
+            </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => onAddSubtask(task)}>
                   <Plus className="h-4 w-4 mr-2" />
                   Unteraufgabe hinzufügen

--- a/src/components/TaskDetailModal.tsx
+++ b/src/components/TaskDetailModal.tsx
@@ -6,7 +6,16 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Edit, Plus, Trash2, ArrowLeft, Timer } from 'lucide-react';
+import {
+  Edit,
+  Plus,
+  Trash2,
+  ArrowLeft,
+  Timer,
+  Star,
+  StarOff
+} from 'lucide-react';
+import { useTaskStore } from '@/hooks/useTaskStore';
 import { calculateTaskCompletion, getTaskProgress, getPriorityColor, getPriorityIcon } from '@/utils/taskUtils';
 import TaskCard from './TaskCard';
 
@@ -42,11 +51,17 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
 }) => {
   if (!task) return null;
 
+  const { updateTask } = useTaskStore();
+
   const isCompleted = calculateTaskCompletion(task);
   const progress = getTaskProgress(task);
   const progressPercentage = progress.total > 0 ? (progress.completed / progress.total) * 100 : 0;
   const priorityClasses = getPriorityColor(task.priority);
   const priorityIcon = getPriorityIcon(task.priority);
+
+  const handleTogglePinned = () => {
+    updateTask(task.id, { pinned: !task.pinned });
+  };
 
   const handleToggleComplete = () => {
     if (task.subtasks.length === 0) {
@@ -94,6 +109,18 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
               </div>
             </div>
             <div className="flex space-x-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleTogglePinned}
+              >
+                {task.pinned ? (
+                  <Star className="h-4 w-4 mr-2" />
+                ) : (
+                  <StarOff className="h-4 w-4 mr-2" />
+                )}
+                {task.pinned ? 'Lösen' : 'Anheften'}
+              </Button>
               <Button
                 variant="outline"
                 size="sm"

--- a/src/hooks/useTaskStore.tsx
+++ b/src/hooks/useTaskStore.tsx
@@ -44,7 +44,8 @@ const useTaskStoreImpl = () => {
               nextDue: task.nextDue ? new Date(task.nextDue) : undefined,
               order: typeof task.order === 'number' ? task.order : idx,
               completed: task.completed ?? false,
-              status: task.status ?? (task.completed ? 'done' : 'todo')
+              status: task.status ?? (task.completed ? 'done' : 'todo'),
+              pinned: task.pinned ?? false
             }))
           );
         }
@@ -109,20 +110,24 @@ const useTaskStoreImpl = () => {
     save();
   }, [tasks, categories, notes]);
 
-  const addTask = (taskData: Omit<Task, 'id' | 'createdAt' | 'updatedAt' | 'subtasks'>) => {
-  const newTask: Task = {
-    ...taskData,
-    id: Date.now().toString(),
-    subtasks: [],
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    dueDate: taskData.dueDate,
-    nextDue: taskData.isRecurring ? calculateNextDue(taskData.recurrencePattern) : undefined,
-    lastCompleted: undefined,
-    dueDate: taskData.dueDate ? new Date(taskData.dueDate) : undefined,
-    status: 'todo',
-    order: 0
-  };
+  const addTask = (
+    taskData: Omit<Task, 'id' | 'createdAt' | 'updatedAt' | 'subtasks' | 'pinned'>
+  ) => {
+    const newTask: Task = {
+      ...taskData,
+      id: Date.now().toString(),
+      subtasks: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      dueDate: taskData.dueDate ? new Date(taskData.dueDate) : undefined,
+      nextDue: taskData.isRecurring
+        ? calculateNextDue(taskData.recurrencePattern)
+        : undefined,
+      lastCompleted: undefined,
+      status: 'todo',
+      order: 0,
+      pinned: false
+    };
     
     if (taskData.parentId) {
       // Add as subtask
@@ -390,7 +395,9 @@ const useTaskStoreImpl = () => {
   const getTasksByCategory = (categoryId: string): Task[] => {
     return tasks
       .filter(task => task.categoryId === categoryId && !task.parentId)
-      .sort((a, b) => a.order - b.order);
+      .sort((a, b) =>
+        a.pinned === b.pinned ? a.order - b.order : a.pinned ? -1 : 1
+      );
   };
 
   const findTaskById = (taskId: string, tasksArray: Task[] = tasks): Task | null => {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,15 +3,20 @@ import { Link } from 'react-router-dom';
 import Navbar from '@/components/Navbar';
 import { Card, CardContent, CardTitle } from '@/components/ui/card';
 import { LayoutGrid, BookOpen, List } from 'lucide-react';
+import TaskCard from '@/components/TaskCard';
 import { useTaskStore } from '@/hooks/useTaskStore';
 import NoteCard from '@/components/NoteCard';
 
 const Home: React.FC = () => {
-  const { notes } = useTaskStore();
+  const { notes, tasks } = useTaskStore();
 
   const pinnedNotes = useMemo(
     () => notes.filter(n => n.pinned).sort((a, b) => a.order - b.order).slice(0, 3),
     [notes]
+  );
+  const pinnedTasks = useMemo(
+    () => tasks.filter(t => t.pinned && !t.parentId).sort((a, b) => a.order - b.order).slice(0, 3),
+    [tasks]
   );
 
   return (
@@ -44,6 +49,33 @@ const Home: React.FC = () => {
             </Card>
           </Link>
         </div>
+        {pinnedTasks.length > 0 && (
+          <div className="mb-6">
+            <h2 className="text-lg sm:text-xl font-semibold text-foreground mb-3">
+              Gepinnte Tasks
+            </h2>
+            <div className="space-y-3">
+              {pinnedTasks.map(task => (
+                <Link
+                  key={task.id}
+                  to={`/tasks?taskId=${task.id}`}
+                  className="block"
+                >
+                  <TaskCard
+                    task={task}
+                    onEdit={() => {}}
+                    onDelete={() => {}}
+                    onAddSubtask={() => {}}
+                    onToggleComplete={() => {}}
+                    onViewDetails={() => {}}
+                    showSubtasks={false}
+                  />
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
         {pinnedNotes.length > 0 && (
           <div>
             <h2 className="text-lg sm:text-xl font-semibold text-foreground mb-3">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,8 @@ export interface Task {
   dueDate?: Date;
   /** Sort order within its list */
   order: number;
+  /** Whether the task is pinned */
+  pinned: boolean;
 }
 
 export interface Category {


### PR DESCRIPTION
## Summary
- add `pinned` field to `Task`
- support pinning in task store and sort pinned tasks first
- show star icons in TaskCard and TaskDetailModal to toggle pin
- display pinned tasks on home page
- document pinned tasks in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' before installing packages)*


------
https://chatgpt.com/codex/tasks/task_e_684981aa36f0832aa36cafdea80520ef