### PR TITLE
Improve keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,16 @@ npm start    # startet die gebaute App auf Port 3002
 
 Viel Spaß beim Ausprobieren!
 
+### Tastenkürzel
+
+In den Einstellungen kannst du die wichtigsten Shortcuts per Tastendruck
+anpassen. Standardmäßig gelten folgende Kombinationen:
+
+- `ctrl+k` – Command Palette öffnen
+- `ctrl+alt+t` – Schnell eine neue Task anlegen
+- `ctrl+alt+n` – Schnell eine neue Notiz anlegen
+- `ctrl+alt+f` – Neue Lernkarte erstellen
+
 ## Lernkarten-Algorithmus
 
 Beim Bewerten einer Karte merkt sich das System, wie oft sie als **leicht**, **mittel** oder **schwer** eingestuft wurde. Aus diesen Zählen berechnet sich eine Erfolgsquote:

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -33,13 +33,13 @@ const isMatching = (e: KeyboardEvent, shortcut: string) => {
 
 const CommandPalette: React.FC = () => {
   const { addTask, addNote, tasks, notes } = useTaskStore()
-  const { flashcards, decks } = useFlashcardStore()
+  const { flashcards, decks, addFlashcard } = useFlashcardStore()
   const { shortcuts, defaultTaskPriority } = useSettings()
   const { toast } = useToast()
   const { currentCategoryId, setCurrentCategoryId } = useCurrentCategory()
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
-  const [mode, setMode] = useState<'task' | 'note'>('task')
+  const [mode, setMode] = useState<'task' | 'note' | 'flashcard'>('task')
   const [value, setValue] = useState('')
 
   const flattened = useMemo(() => flattenTasks(tasks), [tasks])
@@ -84,6 +84,10 @@ const CommandPalette: React.FC = () => {
         e.preventDefault()
         setMode('note')
         setOpen(true)
+      } else if (isMatching(e, shortcuts.newFlashcard)) {
+        e.preventDefault()
+        setMode('flashcard')
+        setOpen(true)
       }
     }
     document.addEventListener('keydown', handler)
@@ -108,9 +112,14 @@ const CommandPalette: React.FC = () => {
         isRecurring: false
       })
       toast({ description: 'Task erstellt' })
-    } else {
+    } else if (mode === 'note') {
       addNote({ title, text: '', color: '#F59E0B' })
       toast({ description: 'Notiz erstellt' })
+    } else if (mode === 'flashcard') {
+      if (decks.length > 0) {
+        addFlashcard({ front: title, back: '', deckId: decks[0].id })
+        toast({ description: 'Karte erstellt' })
+      }
     }
     setValue('')
     setOpen(false)
@@ -119,7 +128,13 @@ const CommandPalette: React.FC = () => {
   return (
     <CommandDialog open={open} onOpenChange={setOpen}>
       <CommandInput
-        placeholder={mode === 'task' ? 'Task-Titel eingeben...' : 'Notiz-Titel eingeben...'}
+        placeholder={
+          mode === 'task'
+            ? 'Task-Titel eingeben...'
+            : mode === 'note'
+              ? 'Notiz-Titel eingeben...'
+              : 'Vorderseite eingeben...'
+        }
         value={value}
         onValueChange={setValue}
         onKeyDown={e => {

--- a/src/components/KeyInput.tsx
+++ b/src/components/KeyInput.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { Input } from '@/components/ui/input';
+
+interface KeyInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+const KeyInput: React.FC<KeyInputProps> = ({ value, onChange, placeholder }) => {
+  const [recording, setRecording] = useState(false);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    const keys: string[] = [];
+    if (e.ctrlKey || e.metaKey) keys.push('ctrl');
+    if (e.altKey) keys.push('alt');
+    if (e.shiftKey) keys.push('shift');
+    const key = e.key.toLowerCase();
+    if (['control', 'shift', 'alt', 'meta'].includes(key)) return;
+    keys.push(key);
+    onChange(keys.join('+'));
+    setRecording(false);
+  };
+
+  return (
+    <Input
+      value={value}
+      placeholder={placeholder}
+      readOnly
+      onFocus={() => setRecording(true)}
+      onBlur={() => setRecording(false)}
+      onKeyDown={recording ? handleKeyDown : undefined}
+    />
+  );
+};
+
+export default KeyInput;

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -5,12 +5,14 @@ export type ShortcutKeys = {
   openCommand: string
   newTask: string
   newNote: string
+  newFlashcard: string
 }
 
 const defaultShortcuts: ShortcutKeys = {
   openCommand: 'ctrl+k',
-  newTask: 'ctrl+t',
-  newNote: 'ctrl+n'
+  newTask: 'ctrl+alt+t',
+  newNote: 'ctrl+alt+n',
+  newFlashcard: 'ctrl+alt+f'
 }
 
 const defaultPomodoro = { workMinutes: 25, breakMinutes: 5 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import Navbar from '@/components/Navbar'
 import { useSettings, themePresets } from '@/hooks/useSettings'
 import { Input } from '@/components/ui/input'
+import KeyInput from '@/components/KeyInput'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
 import { hslToHex, hexToHsl } from '@/utils/color'
@@ -214,29 +215,34 @@ const SettingsPage: React.FC = () => {
           <TabsContent value="shortcuts" className="space-y-4">
             <div>
               <Label htmlFor="open">Command Palette</Label>
-              <Input
-                id="open"
+              <KeyInput
                 value={shortcuts.openCommand}
-                onChange={e => updateShortcut('openCommand', e.target.value)}
-                placeholder="z.B. ctrl+k"
+                onChange={v => updateShortcut('openCommand', v)}
+                placeholder="ctrl+k"
               />
             </div>
             <div>
               <Label htmlFor="task">Neue Task</Label>
-              <Input
-                id="task"
+              <KeyInput
                 value={shortcuts.newTask}
-                onChange={e => updateShortcut('newTask', e.target.value)}
-                placeholder="z.B. ctrl+t"
+                onChange={v => updateShortcut('newTask', v)}
+                placeholder="ctrl+alt+t"
               />
             </div>
             <div>
               <Label htmlFor="note">Neue Notiz</Label>
-              <Input
-                id="note"
+              <KeyInput
                 value={shortcuts.newNote}
-                onChange={e => updateShortcut('newNote', e.target.value)}
-                placeholder="z.B. ctrl+n"
+                onChange={v => updateShortcut('newNote', v)}
+                placeholder="ctrl+alt+n"
+              />
+            </div>
+            <div>
+              <Label htmlFor="flashcard">Neue Karte</Label>
+              <KeyInput
+                value={shortcuts.newFlashcard}
+                onChange={v => updateShortcut('newFlashcard', v)}
+                placeholder="ctrl+alt+f"
               />
             </div>
           </TabsContent>


### PR DESCRIPTION
## Summary
- capture shortcuts by pressing keys instead of typing
- switch default shortcuts to `ctrl+alt+t/n/f`
- allow quick flashcard creation via command palette
- document default shortcuts in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684988a675f8832a983af942eda92fbd