### PR TITLE
Persist home layout and add pinned visibility

### DIFF
--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -126,6 +126,10 @@ interface SettingsContextValue {
   homeSections: string[]
   toggleHomeSection: (section: string) => void
   reorderHomeSections: (start: number, end: number) => void
+  showPinnedTasks: boolean
+  toggleShowPinnedTasks: () => void
+  showPinnedNotes: boolean
+  toggleShowPinnedNotes: () => void
 }
 
 const SettingsContext = createContext<SettingsContextValue | undefined>(undefined)
@@ -143,6 +147,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     'flashcards',
     'notes'
   ])
+  const [showPinnedTasks, setShowPinnedTasks] = useState(true)
+  const [showPinnedNotes, setShowPinnedNotes] = useState(true)
 
   useEffect(() => {
     const load = async () => {
@@ -171,6 +177,12 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
           if (Array.isArray(data.homeSections)) {
             setHomeSections(data.homeSections)
           }
+          if (typeof data.showPinnedTasks === 'boolean') {
+            setShowPinnedTasks(data.showPinnedTasks)
+          }
+          if (typeof data.showPinnedNotes === 'boolean') {
+            setShowPinnedNotes(data.showPinnedNotes)
+          }
         }
       } catch (err) {
         console.error('Fehler beim Laden der Einstellungen', err)
@@ -191,7 +203,9 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
             defaultTaskPriority: priority,
             theme,
             themeName,
-            homeSections
+            homeSections,
+            showPinnedTasks,
+            showPinnedNotes
           })
         })
       } catch (err) {
@@ -200,7 +214,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     }
 
     save()
-  }, [shortcuts, pomodoro, priority, theme, themeName])
+  }, [shortcuts, pomodoro, priority, theme, themeName, homeSections, showPinnedTasks, showPinnedNotes])
 
   useEffect(() => {
     Object.entries(theme).forEach(([key, value]) => {
@@ -254,6 +268,14 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     })
   }
 
+  const toggleShowPinnedTasks = () => {
+    setShowPinnedTasks(prev => !prev)
+  }
+
+  const toggleShowPinnedNotes = () => {
+    setShowPinnedNotes(prev => !prev)
+  }
+
   return (
     <SettingsContext.Provider
       value={{
@@ -269,7 +291,11 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         updateThemeName,
         homeSections,
         toggleHomeSection,
-        reorderHomeSections
+        reorderHomeSections,
+        showPinnedTasks,
+        toggleShowPinnedTasks,
+        showPinnedNotes,
+        toggleShowPinnedNotes
       }}
     >
       {children}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -12,7 +12,7 @@ import { flattenTasks } from '@/utils/taskUtils';
 
 const Home: React.FC = () => {
   const { notes, tasks } = useTaskStore();
-  const { homeSections, reorderHomeSections } = useSettings();
+  const { homeSections, reorderHomeSections, showPinnedTasks, showPinnedNotes } = useSettings();
 
   const orderedSections: HomeSection[] = homeSections
     .map(key => allHomeSections.find(s => s.key === key))
@@ -73,7 +73,7 @@ const Home: React.FC = () => {
             )}
           </Droppable>
         </DragDropContext>
-        {pinnedTasks.length > 0 && (
+        {showPinnedTasks && pinnedTasks.length > 0 && (
           <div className="mb-6">
             <h2 className="text-lg sm:text-xl font-semibold text-foreground mb-3">
               Gepinnte Tasks
@@ -101,7 +101,7 @@ const Home: React.FC = () => {
           </div>
         )}
 
-        {pinnedNotes.length > 0 && (
+        {showPinnedNotes && pinnedNotes.length > 0 && (
           <div>
             <h2 className="text-lg sm:text-xl font-semibold text-foreground mb-3">
               Gepinnte Notizen

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -35,7 +35,11 @@ const SettingsPage: React.FC = () => {
     themeName,
     updateThemeName,
     homeSections,
-    toggleHomeSection
+    toggleHomeSection,
+    showPinnedTasks,
+    toggleShowPinnedTasks,
+    showPinnedNotes,
+    toggleShowPinnedNotes
   } = useSettings()
 
   const download = (data: any, name: string) => {
@@ -287,6 +291,22 @@ const SettingsPage: React.FC = () => {
             </div>
           </TabsContent>
           <TabsContent value="home" className="space-y-2">
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="showPinnedTasks"
+                checked={showPinnedTasks}
+                onCheckedChange={toggleShowPinnedTasks}
+              />
+              <Label htmlFor="showPinnedTasks">Gepinnte Tasks anzeigen</Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="showPinnedNotes"
+                checked={showPinnedNotes}
+                onCheckedChange={toggleShowPinnedNotes}
+              />
+              <Label htmlFor="showPinnedNotes">Gepinnte Notizen anzeigen</Label>
+            </div>
             {allHomeSections.map(sec => (
               <div key={sec.key} className="flex items-center space-x-2">
                 <Checkbox


### PR DESCRIPTION
## Summary
- persist home page layout settings across sessions
- allow toggling pinned notes and tasks visibility
- conditionally render pinned items on home page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e87ec654832aa0925e64f6258a41