### PR TITLE
Add flashcard settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ npm start    # startet die gebaute App auf Port 3002
 - Lernkarten mit Spaced-Repetition-Training und Verwaltung eigener Karten
   - Decks lassen sich beim Lernen ein- oder ausblenden
   - Optionaler Zufallsmodus ohne Bewertung
-  - Trainingsmodus direkt auf der Kartenseite mit 5 Karten pro Runde und Fazit
+  - Trainingsmodus direkt auf der Kartenseite mit frei einstellbarer Rundengröße
   - Eingabemodus zum Tippen der Antworten; nach dem Prüfen bewertest du selbst, ob die Karte leicht, mittel oder schwer war
-  - Timed-Modus mit 10 Sekunden Countdown pro Karte; der Timer wird einmalig gestartet und kann pausiert werden. Bei Ablauf wird automatisch "schwer" gewertet
+  - Timed-Modus mit anpassbarem Countdown pro Karte; der Timer wird einmalig gestartet und kann pausiert werden. Bei Ablauf wird automatisch "schwer" gewertet
 - Statistikseite für Lernkarten
   - Deck-Statistiken mit Übersicht fälliger Karten
 - Speicherung der Daten auf dem lokalen Server
@@ -106,7 +106,7 @@ npm start    # startet die gebaute App auf Port 3002
    gezielt Decks ein- oder ausblenden, einen Zufallsmodus aktivieren und im
    Eingabemodus Antworten eintippen. Nach dem Vergleich der Lösung entscheidest
    du selbst, wie schwer dir die Karte fiel.
-   Im Timed-Modus bleiben dir pro Karte 10 Sekunden. Der Timer startet einmalig zu Beginn der Session und kann jederzeit pausiert werden. Bei 0 wird automatisch "schwer" gewertet.
+   Im Timed-Modus bestimmt ein einstellbarer Countdown die Zeit pro Karte. Der Timer startet einmalig zu Beginn der Session und kann jederzeit pausiert werden. Bei 0 wird automatisch "schwer" gewertet.
 
 Viel Spaß beim Ausprobieren!
 

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -16,6 +16,16 @@ const defaultShortcuts: ShortcutKeys = {
 }
 
 const defaultPomodoro = { workMinutes: 25, breakMinutes: 5 }
+const defaultFlashcardSettings = {
+  timerSeconds: 10,
+  sessionSize: 5,
+  defaultMode: 'spaced' as
+    | 'spaced'
+    | 'training'
+    | 'random'
+    | 'typing'
+    | 'timed'
+}
 const defaultTaskPriority: 'low' | 'medium' | 'high' = 'medium'
 const defaultTheme = {
   background: '0 0% 100%',
@@ -130,6 +140,14 @@ interface SettingsContextValue {
   toggleShowPinnedTasks: () => void
   showPinnedNotes: boolean
   toggleShowPinnedNotes: () => void
+  flashcardTimer: number
+  updateFlashcardTimer: (value: number) => void
+  flashcardSessionSize: number
+  updateFlashcardSessionSize: (value: number) => void
+  flashcardDefaultMode: 'spaced' | 'training' | 'random' | 'typing' | 'timed'
+  updateFlashcardDefaultMode: (
+    value: 'spaced' | 'training' | 'random' | 'typing' | 'timed'
+  ) => void
 }
 
 const SettingsContext = createContext<SettingsContextValue | undefined>(undefined)
@@ -137,6 +155,15 @@ const SettingsContext = createContext<SettingsContextValue | undefined>(undefine
 export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [shortcuts, setShortcuts] = useState<ShortcutKeys>(defaultShortcuts)
   const [pomodoro, setPomodoro] = useState(defaultPomodoro)
+  const [flashcardTimer, setFlashcardTimer] = useState(
+    defaultFlashcardSettings.timerSeconds
+  )
+  const [flashcardSessionSize, setFlashcardSessionSize] = useState(
+    defaultFlashcardSettings.sessionSize
+  )
+  const [flashcardDefaultMode, setFlashcardDefaultMode] = useState(
+    defaultFlashcardSettings.defaultMode
+  )
   const [priority, setPriority] = useState<'low' | 'medium' | 'high'>(
     defaultTaskPriority
   )
@@ -183,6 +210,15 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
           if (typeof data.showPinnedNotes === 'boolean') {
             setShowPinnedNotes(data.showPinnedNotes)
           }
+          if (typeof data.flashcardTimer === 'number') {
+            setFlashcardTimer(data.flashcardTimer)
+          }
+          if (typeof data.flashcardSessionSize === 'number') {
+            setFlashcardSessionSize(data.flashcardSessionSize)
+          }
+          if (typeof data.flashcardDefaultMode === 'string') {
+            setFlashcardDefaultMode(data.flashcardDefaultMode)
+          }
         }
       } catch (err) {
         console.error('Fehler beim Laden der Einstellungen', err)
@@ -205,7 +241,10 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
             themeName,
             homeSections,
             showPinnedTasks,
-            showPinnedNotes
+            showPinnedNotes,
+            flashcardTimer,
+            flashcardSessionSize,
+            flashcardDefaultMode
           })
         })
       } catch (err) {
@@ -214,7 +253,19 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     }
 
     save()
-  }, [shortcuts, pomodoro, priority, theme, themeName, homeSections, showPinnedTasks, showPinnedNotes])
+  }, [
+    shortcuts,
+    pomodoro,
+    priority,
+    theme,
+    themeName,
+    homeSections,
+    showPinnedTasks,
+    showPinnedNotes,
+    flashcardTimer,
+    flashcardSessionSize,
+    flashcardDefaultMode
+  ])
 
   useEffect(() => {
     Object.entries(theme).forEach(([key, value]) => {
@@ -249,6 +300,20 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     if (themePresets[name]) {
       setTheme(themePresets[name])
     }
+  }
+
+  const updateFlashcardTimer = (value: number) => {
+    setFlashcardTimer(value)
+  }
+
+  const updateFlashcardSessionSize = (value: number) => {
+    setFlashcardSessionSize(value)
+  }
+
+  const updateFlashcardDefaultMode = (
+    value: 'spaced' | 'training' | 'random' | 'typing' | 'timed'
+  ) => {
+    setFlashcardDefaultMode(value)
   }
 
   const toggleHomeSection = (section: string) => {
@@ -295,7 +360,13 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         showPinnedTasks,
         toggleShowPinnedTasks,
         showPinnedNotes,
-        toggleShowPinnedNotes
+        toggleShowPinnedNotes,
+        flashcardTimer,
+        updateFlashcardTimer,
+        flashcardSessionSize,
+        updateFlashcardSessionSize,
+        flashcardDefaultMode,
+        updateFlashcardDefaultMode
       }}
     >
       {children}

--- a/src/pages/Flashcards.tsx
+++ b/src/pages/Flashcards.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
 import { useFlashcardStore } from '@/hooks/useFlashcardStore';
+import { useSettings } from '@/hooks/useSettings';
 import { shuffleArray } from '@/utils/shuffle';
 import {
   AlertDialog,
@@ -26,17 +27,28 @@ import {
 
 const FlashcardsPage: React.FC = () => {
   const { flashcards, decks, rateFlashcard } = useFlashcardStore();
+  const {
+    flashcardTimer,
+    flashcardSessionSize,
+    flashcardDefaultMode
+  } = useSettings();
   const [selectedDecks, setSelectedDecks] = useState<string[]>([]);
-  const [randomMode, setRandomMode] = useState(false);
-  const [trainingMode, setTrainingMode] = useState(false);
-  const [typingMode, setTypingMode] = useState(false);
-  const [timedMode, setTimedMode] = useState(false);
+  const [randomMode, setRandomMode] = useState(
+    flashcardDefaultMode === 'random'
+  );
+  const [trainingMode, setTrainingMode] = useState(
+    flashcardDefaultMode === 'training'
+  );
+  const [typingMode, setTypingMode] = useState(
+    flashcardDefaultMode === 'typing'
+  );
+  const [timedMode, setTimedMode] = useState(flashcardDefaultMode === 'timed');
   const [useSpaced, setUseSpaced] = useState(true);
   const [timeLeft, setTimeLeft] = useState(0);
   const [timerActive, setTimerActive] = useState(false);
   const [timerStarted, setTimerStarted] = useState(false);
   const [timerPaused, setTimerPaused] = useState(false);
-  const TIMER_DURATION = 10;
+  const TIMER_DURATION = flashcardTimer;
   const [index, setIndex] = useState(0);
   const [showBack, setShowBack] = useState(false);
   const [showDone, setShowDone] = useState(false);
@@ -95,8 +107,8 @@ const FlashcardsPage: React.FC = () => {
   useEffect(() => {
     if (trainingMode) {
       const all = shuffleArray(filtered);
-      setSessionCards(all.slice(0, 5));
-      setRemainingCards(all.slice(5));
+      setSessionCards(all.slice(0, flashcardSessionSize));
+      setRemainingCards(all.slice(flashcardSessionSize));
       setIndex(0);
       setSummary({});
       setShowSummary(false);
@@ -196,8 +208,8 @@ const FlashcardsPage: React.FC = () => {
   const handleRestart = () => {
     if (trainingMode) {
       const all = shuffleArray(filtered);
-      setSessionCards(all.slice(0, 5));
-      setRemainingCards(all.slice(5));
+      setSessionCards(all.slice(0, flashcardSessionSize));
+      setRemainingCards(all.slice(flashcardSessionSize));
       setIndex(0);
       setShowBack(false);
       setSummary({});
@@ -407,9 +419,9 @@ const FlashcardsPage: React.FC = () => {
               if (remainingCards.length === 0) {
                 handleRestart();
               } else {
-                const next = remainingCards.slice(0, 5);
+                const next = remainingCards.slice(0, flashcardSessionSize);
                 setSessionCards(next);
-                setRemainingCards(remainingCards.slice(5));
+                setRemainingCards(remainingCards.slice(flashcardSessionSize));
                 setIndex(0);
                 setShowBack(false);
                 setShowSummary(false);

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -39,7 +39,13 @@ const SettingsPage: React.FC = () => {
     showPinnedTasks,
     toggleShowPinnedTasks,
     showPinnedNotes,
-    toggleShowPinnedNotes
+    toggleShowPinnedNotes,
+    flashcardTimer,
+    updateFlashcardTimer,
+    flashcardSessionSize,
+    updateFlashcardSessionSize,
+    flashcardDefaultMode,
+    updateFlashcardDefaultMode
   } = useSettings()
 
   const download = (data: any, name: string) => {
@@ -213,9 +219,10 @@ const SettingsPage: React.FC = () => {
       <Navbar title="Einstellungen" />
       <div className="max-w-2xl mx-auto px-4 py-6">
         <Tabs defaultValue="shortcuts" className="space-y-4">
-          <TabsList className="grid w-full grid-cols-6">
+          <TabsList className="grid w-full grid-cols-7">
             <TabsTrigger value="shortcuts">Shortcuts</TabsTrigger>
             <TabsTrigger value="pomodoro">Pomodoro</TabsTrigger>
+            <TabsTrigger value="flashcards">Karten</TabsTrigger>
             <TabsTrigger value="tasks">Tasks</TabsTrigger>
             <TabsTrigger value="home">Startseite</TabsTrigger>
             <TabsTrigger value="theme">Theme</TabsTrigger>
@@ -273,6 +280,44 @@ const SettingsPage: React.FC = () => {
                 value={pomodoro.breakMinutes}
                 onChange={e => updatePomodoro('breakMinutes', Number(e.target.value))}
               />
+            </div>
+          </TabsContent>
+          <TabsContent value="flashcards" className="space-y-4">
+            <div>
+              <Label htmlFor="timer">Timer pro Karte (Sekunden)</Label>
+              <Input
+                id="timer"
+                type="number"
+                value={flashcardTimer}
+                onChange={e => updateFlashcardTimer(Number(e.target.value))}
+              />
+            </div>
+            <div>
+              <Label htmlFor="sessionSize">Training-Session Größe</Label>
+              <Input
+                id="sessionSize"
+                type="number"
+                value={flashcardSessionSize}
+                onChange={e => updateFlashcardSessionSize(Number(e.target.value))}
+              />
+            </div>
+            <div>
+              <Label htmlFor="startMode">Startmodus</Label>
+              <Select
+                value={flashcardDefaultMode}
+                onValueChange={updateFlashcardDefaultMode}
+              >
+                <SelectTrigger id="startMode">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="spaced">Spaced Repetition</SelectItem>
+                  <SelectItem value="training">Training</SelectItem>
+                  <SelectItem value="random">Random</SelectItem>
+                  <SelectItem value="typing">Eingabe</SelectItem>
+                  <SelectItem value="timed">Timed</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
           </TabsContent>
           <TabsContent value="tasks" className="space-y-4">


### PR DESCRIPTION
## Summary
- add configurable flashcard timer, session size and start mode
- expose new settings via SettingsProvider and update Settings UI
- use the new settings in the flashcards page
- document options in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849ec4ed9d8832a9fb5c9820261922b