### PR TITLE
Fix home page drag-and-drop shift

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -44,7 +44,7 @@ const Home: React.FC = () => {
           <Droppable droppableId="sections" direction="horizontal">
             {provided => (
               <div
-                className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-6"
+                className="flex flex-wrap gap-6 mb-6"
                 ref={provided.innerRef}
                 {...provided.droppableProps}
               >
@@ -52,6 +52,7 @@ const Home: React.FC = () => {
                   <Draggable key={sec.key} draggableId={sec.key} index={index}>
                     {prov => (
                       <div
+                        className="w-full sm:w-1/2 lg:w-1/3"
                         ref={prov.innerRef}
                         {...prov.draggableProps}
                         {...prov.dragHandleProps}


### PR DESCRIPTION
## Summary
- fix layout shift on home page drag-and-drop cards

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6849fa8e9f6c832a9727c6b7fce66aba