### PR TITLE
Remove mode info text from flashcards

### DIFF
--- a/src/pages/Flashcards.tsx
+++ b/src/pages/Flashcards.tsx
@@ -294,12 +294,6 @@ const FlashcardsPage: React.FC = () => {
                 <SelectItem value="timed">Timed</SelectItem>
               </SelectContent>
             </Select>
-            <p className="text-xs text-muted-foreground">
-              Aktiver Modus: {modeLabel}.{' '}
-              {algorithmAffected
-                ? 'Bewertungen beeinflussen den Spaced-Repetition-Algorithmus.'
-                : 'Bewertungen beeinflussen den Spaced-Repetition-Algorithmus nicht.'}
-            </p>
         </div>
         <div className="space-y-1">
             {decks.map(deck => (


### PR DESCRIPTION
## Summary
- clean up the Flashcards page by removing the descriptive text next to the mode selection
- keep the description below the cards intact

## Testing
- `npm run lint` *(fails: various lint errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_684a0452256c832abd2db8d4d48db7de