### PR TITLE
Move home order editing into settings

### DIFF
--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useEffect, useState } from 'react'
+import { allHomeSections } from '@/utils/homeSections'
 
 
 export type ShortcutKeys = {
@@ -134,6 +135,7 @@ interface SettingsContextValue {
   themeName: string
   updateThemeName: (name: string) => void
   homeSections: string[]
+  homeSectionOrder: string[]
   toggleHomeSection: (section: string) => void
   reorderHomeSections: (start: number, end: number) => void
   showPinnedTasks: boolean
@@ -169,6 +171,9 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   )
   const [theme, setTheme] = useState(defaultTheme)
   const [themeName, setThemeName] = useState('light')
+  const [homeSectionOrder, setHomeSectionOrder] = useState<string[]>(
+    allHomeSections.map(s => s.key)
+  )
   const [homeSections, setHomeSections] = useState<string[]>([
     'tasks',
     'flashcards',
@@ -200,6 +205,25 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
             if (themePresets[data.themeName]) {
               setTheme(themePresets[data.themeName])
             }
+          }
+          if (Array.isArray(data.homeSectionOrder)) {
+            const order = data.homeSectionOrder as string[]
+            setHomeSectionOrder(
+              order.concat(
+                allHomeSections
+                  .filter(s => !order.includes(s.key))
+                  .map(s => s.key)
+              )
+            )
+          } else if (Array.isArray(data.homeSections)) {
+            setHomeSectionOrder(
+              data.homeSections.concat(
+                allHomeSections
+                  .filter(s => !data.homeSections.includes(s.key))
+                  .map(s => s.key)
+              )
+            )
+            setHomeSections(data.homeSections)
           }
           if (Array.isArray(data.homeSections)) {
             setHomeSections(data.homeSections)
@@ -240,6 +264,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
             theme,
             themeName,
             homeSections,
+            homeSectionOrder,
             showPinnedTasks,
             showPinnedNotes,
             flashcardTimer,
@@ -260,6 +285,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     theme,
     themeName,
     homeSections,
+    homeSectionOrder,
     showPinnedTasks,
     showPinnedNotes,
     flashcardTimer,
@@ -325,7 +351,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   }
 
   const reorderHomeSections = (start: number, end: number) => {
-    setHomeSections(prev => {
+    setHomeSectionOrder(prev => {
       const updated = Array.from(prev)
       const [removed] = updated.splice(start, 1)
       updated.splice(end, 0, removed)
@@ -355,6 +381,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         themeName,
         updateThemeName,
         homeSections,
+        homeSectionOrder,
         toggleHomeSection,
         reorderHomeSections,
         showPinnedTasks,

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import Navbar from '@/components/Navbar';
 import { Card, CardContent, CardTitle } from '@/components/ui/card';
-import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea/dnd';
 import { useSettings } from '@/hooks/useSettings';
 import { allHomeSections, HomeSection } from '@/utils/homeSections';
 import TaskCard from '@/components/TaskCard';
@@ -12,11 +11,16 @@ import { flattenTasks } from '@/utils/taskUtils';
 
 const Home: React.FC = () => {
   const { notes, tasks } = useTaskStore();
-  const { homeSections, reorderHomeSections, showPinnedTasks, showPinnedNotes } = useSettings();
+  const {
+    homeSections,
+    homeSectionOrder,
+    showPinnedTasks,
+    showPinnedNotes
+  } = useSettings();
 
-  const orderedSections: HomeSection[] = homeSections
+  const orderedSections: HomeSection[] = homeSectionOrder
     .map(key => allHomeSections.find(s => s.key === key))
-    .filter((s): s is HomeSection => Boolean(s));
+    .filter((s): s is HomeSection => Boolean(s && homeSections.includes(s.key)));
 
   const pinnedNotes = useMemo(
     () => notes.filter(n => n.pinned).sort((a, b) => a.order - b.order).slice(0, 3),
@@ -31,49 +35,24 @@ const Home: React.FC = () => {
     [tasks]
   );
 
-  const handleDragEnd = (result: DropResult) => {
-    if (!result.destination) return;
-    reorderHomeSections(result.source.index, result.destination.index);
-  };
-
   return (
     <div className="min-h-screen bg-background">
       <Navbar />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <DragDropContext onDragEnd={handleDragEnd}>
-          <Droppable droppableId="sections" direction="horizontal">
-            {provided => (
-              <div
-                className="flex flex-wrap gap-6 mb-6"
-                ref={provided.innerRef}
-                {...provided.droppableProps}
-              >
-                {orderedSections.map((sec, index) => (
-                  <Draggable key={sec.key} draggableId={sec.key} index={index}>
-                    {prov => (
-                      <div
-                        ref={prov.innerRef}
-                        {...prov.draggableProps}
-                        {...prov.dragHandleProps}
-                        className="w-full sm:w-1/2 lg:w-1/3"
-                      >
-                        <Link to={sec.path}>
-                          <Card className="hover:shadow-md transition-all text-center">
-                            <CardContent className="py-8">
-                              <sec.icon className="h-8 w-8 mx-auto mb-2" />
-                              <CardTitle>{sec.label}</CardTitle>
-                            </CardContent>
-                          </Card>
-                        </Link>
-                      </div>
-                    )}
-                  </Draggable>
-                ))}
-                {provided.placeholder}
-              </div>
-            )}
-          </Droppable>
-        </DragDropContext>
+        <div className="flex flex-wrap gap-6 mb-6">
+          {orderedSections.map(sec => (
+            <div key={sec.key} className="w-full sm:w-1/2 lg:w-1/3">
+              <Link to={sec.path}>
+                <Card className="hover:shadow-md transition-all text-center">
+                  <CardContent className="py-8">
+                    <sec.icon className="h-8 w-8 mx-auto mb-2" />
+                    <CardTitle>{sec.label}</CardTitle>
+                  </CardContent>
+                </Card>
+              </Link>
+            </div>
+          ))}
+        </div>
         {showPinnedTasks && pinnedTasks.length > 0 && (
           <div className="mb-6">
             <h2 className="text-lg sm:text-xl font-semibold text-foreground mb-3">


### PR DESCRIPTION
## Summary
- sort homepage sections in Settings instead of on Home
- display draggable list of homepage sections in Settings
- store the order persistently
- update Home page to use saved order

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a057ace08832aa7028fdc469a3bcf