### PR TITLE
Implement version display and release notes modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,11 +21,13 @@ import FlashcardManagerPage from "./pages/FlashcardManager";
 import DeckDetailPage from "./pages/DeckDetail";
 import FlashcardStatisticsPage from "./pages/FlashcardStatistics";
 import SettingsPage from "./pages/Settings";
+import ReleaseNotesPage from "./pages/ReleaseNotes";
 import NotFound from "./pages/NotFound";
 import PomodoroPage from "./pages/Pomodoro";
 import PomodoroTimer from "@/components/PomodoroTimer";
 import PomodoroTicker from "@/components/PomodoroTicker";
 import { PomodoroHistoryProvider } from "@/hooks/usePomodoroHistory.tsx";
+import ReleaseNotesModal from "@/components/ReleaseNotesModal";
 
 const queryClient = new QueryClient();
 
@@ -54,6 +56,7 @@ const App = () => (
               <Route path="/notes" element={<NotesPage />} />
               <Route path="/notes/:id" element={<NoteDetailPage />} />
               <Route path="/settings" element={<SettingsPage />} />
+              <Route path="/release-notes" element={<ReleaseNotesPage />} />
               <Route path="/pomodoro" element={<PomodoroPage />} />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
               <Route path="*" element={<NotFound />} />
@@ -61,6 +64,7 @@ const App = () => (
             </BrowserRouter>
             <PomodoroTimer compact />
             <PomodoroTicker />
+            <ReleaseNotesModal />
             </CurrentCategoryProvider>
           </FlashcardStoreProvider>
         </TaskStoreProvider>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -14,6 +14,7 @@ import {
   Columns,
   LayoutGrid,
   List,
+  Info,
   Cog,
   Timer,
   BookOpen,
@@ -171,6 +172,11 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                 <Cog className="h-4 w-4 mr-2" /> Einstellungen
               </Button>
             </Link>
+            <Link to="/release-notes">
+              <Button variant="outline" size="sm">
+                <Info className="h-4 w-4 mr-2" /> Release Notes
+              </Button>
+            </Link>
           </div>
         </div>
         {showMobileMenu && (
@@ -268,6 +274,12 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                   <Button variant="outline" size="sm" className="w-full">
                     <Cog className="h-4 w-4 mr-2" />
                     Einstellungen
+                  </Button>
+                </Link>
+                <Link to="/release-notes" className="flex-1">
+                  <Button variant="outline" size="sm" className="w-full">
+                    <Info className="h-4 w-4 mr-2" />
+                    Release Notes
                   </Button>
                 </Link>
               </div>

--- a/src/components/ReleaseNotesModal.tsx
+++ b/src/components/ReleaseNotesModal.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import ReactMarkdown from 'react-markdown';
+
+const ReleaseNotesModal: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const [notes, setNotes] = useState('');
+
+  useEffect(() => {
+    const lastSeen = localStorage.getItem('lastSeenVersion');
+    if (lastSeen !== __APP_VERSION__) {
+      const load = async () => {
+        try {
+          const res = await fetch('https://api.github.com/repos/timbornemann/Total-Task-Tracker/releases/latest');
+          if (res.ok) {
+            const data = await res.json();
+            setNotes(data.body || '');
+          }
+        } catch (err) {
+          console.error('Failed to load release notes', err);
+        } finally {
+          setOpen(true);
+          localStorage.setItem('lastSeenVersion', __APP_VERSION__);
+        }
+      };
+      load();
+    }
+  }, []);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Neu in Version {__APP_VERSION__}</DialogTitle>
+        </DialogHeader>
+        <div className="prose dark:prose-invert max-h-[60vh] overflow-y-auto">
+          <ReactMarkdown>{notes}</ReactMarkdown>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ReleaseNotesModal;

--- a/src/pages/ReleaseNotes.tsx
+++ b/src/pages/ReleaseNotes.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import Navbar from '@/components/Navbar';
+import ReactMarkdown from 'react-markdown';
+
+const ReleaseNotesPage: React.FC = () => {
+  const [notes, setNotes] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('https://api.github.com/repos/timbornemann/Total-Task-Tracker/releases/latest');
+        if (res.ok) {
+          const data = await res.json();
+          setNotes(data.body || '');
+        }
+      } catch (err) {
+        console.error('Failed to load release notes', err);
+      }
+    };
+    load();
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Navbar title="Release Notes" />
+      <div className="max-w-3xl mx-auto px-4 py-6">
+        <ReactMarkdown className="prose dark:prose-invert">
+          {notes || 'Keine Release Notes gefunden.'}
+        </ReactMarkdown>
+      </div>
+    </div>
+  );
+};
+
+export default ReleaseNotesPage;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -564,6 +564,7 @@ const SettingsPage: React.FC = () => {
             </div>
           </TabsContent>
         </Tabs>
+        <p className="text-xs text-muted-foreground mt-4">Version {__APP_VERSION__}</p>
       </div>
     </div>
   )

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,19 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
+import fs from "fs";
 import { componentTagger } from "lovable-tagger";
+
+const pkg = JSON.parse(
+  fs.readFileSync(new URL("./package.json", import.meta.url), "utf8")
+);
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
   base: '/',
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   server: {
     host: "0.0.0.0",
     port: 8081,


### PR DESCRIPTION
## Summary
- show app version on settings page
- add Release Notes page and modal
- fetch GitHub release notes when version updates
- expose app version in Vite build
- link Release Notes from the navbar

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684abdc66064832a965915a34f60e9e6