### PR TITLE
Add info tab and dynamic version

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ npm start    # startet die gebaute App auf Port 3002
 - Mehrere Theme-Voreinstellungen (light, dark, ocean, dark-red, hacker,
   motivation) und ein eigenes "Custom"-Theme wählbar
 - Im Custom-Theme lassen sich Farben der Oberfläche und Karten individuell anpassen
+- Neuer "Info"-Reiter in den Einstellungen zeigt Versionsnummer, Release Notes und README
 
 ## Verwendung
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -172,11 +172,6 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                 <Cog className="h-4 w-4 mr-2" /> Einstellungen
               </Button>
             </Link>
-            <Link to="/release-notes">
-              <Button variant="outline" size="sm">
-                <Info className="h-4 w-4 mr-2" /> Release Notes
-              </Button>
-            </Link>
           </div>
         </div>
         {showMobileMenu && (
@@ -274,12 +269,6 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                   <Button variant="outline" size="sm" className="w-full">
                     <Cog className="h-4 w-4 mr-2" />
                     Einstellungen
-                  </Button>
-                </Link>
-                <Link to="/release-notes" className="flex-1">
-                  <Button variant="outline" size="sm" className="w-full">
-                    <Info className="h-4 w-4 mr-2" />
-                    Release Notes
                   </Button>
                 </Link>
               </div>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input'
 import KeyInput from '@/components/KeyInput'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
+import { Link } from 'react-router-dom'
 import { hslToHex, hexToHsl } from '@/utils/color'
 import { Checkbox } from '@/components/ui/checkbox'
 import { allHomeSections } from '@/utils/homeSections'
@@ -22,6 +23,8 @@ import {
   TabsTrigger,
   TabsContent
 } from '@/components/ui/tabs'
+import ReactMarkdown from 'react-markdown'
+import readme from '../../README.md?raw'
 
 const SettingsPage: React.FC = () => {
   const {
@@ -227,7 +230,7 @@ const SettingsPage: React.FC = () => {
       <Navbar title="Einstellungen" />
       <div className="max-w-2xl mx-auto px-4 py-6">
         <Tabs defaultValue="shortcuts" className="space-y-4">
-          <TabsList className="grid w-full grid-cols-7">
+          <TabsList className="grid w-full grid-cols-8">
             <TabsTrigger value="shortcuts">Shortcuts</TabsTrigger>
             <TabsTrigger value="pomodoro">Pomodoro</TabsTrigger>
             <TabsTrigger value="flashcards">Karten</TabsTrigger>
@@ -235,6 +238,7 @@ const SettingsPage: React.FC = () => {
             <TabsTrigger value="home">Startseite</TabsTrigger>
             <TabsTrigger value="theme">Theme</TabsTrigger>
             <TabsTrigger value="data">Daten</TabsTrigger>
+            <TabsTrigger value="info">Info</TabsTrigger>
           </TabsList>
           <TabsContent value="shortcuts" className="space-y-4">
             <div>
@@ -563,8 +567,24 @@ const SettingsPage: React.FC = () => {
               </div>
             </div>
           </TabsContent>
+          <TabsContent value="info" className="space-y-4">
+            <div className="prose dark:prose-invert">
+              <ReactMarkdown>{readme}</ReactMarkdown>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Version {__APP_VERSION__}{' '}
+              <Link to="/release-notes" className="underline">
+                Release Notes
+              </Link>
+            </p>
+          </TabsContent>
         </Tabs>
-        <p className="text-xs text-muted-foreground mt-4">Version {__APP_VERSION__}</p>
+        <p className="text-xs text-muted-foreground mt-4">
+          Version {__APP_VERSION__}{' '}
+          <Link to="/release-notes" className="underline">
+            Release Notes
+          </Link>
+        </p>
       </div>
     </div>
   )

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,12 +7,13 @@ import { componentTagger } from "lovable-tagger";
 const pkg = JSON.parse(
   fs.readFileSync(new URL("./package.json", import.meta.url), "utf8")
 );
+const version = process.env.APP_VERSION || pkg.version;
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
   base: '/',
   define: {
-    __APP_VERSION__: JSON.stringify(pkg.version),
+    __APP_VERSION__: JSON.stringify(version),
   },
   server: {
     host: "0.0.0.0",


### PR DESCRIPTION
## Summary
- remove release notes from navbar
- add Info tab in settings that renders README and links to release notes
- show release notes link next to version information
- allow overriding app version via APP_VERSION env var
- document new Info tab in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ad0aea97c832aa834cd8f03dba581