### PR TITLE
Fix Docker build by including README

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,7 @@ node_modules
 npm-debug.log
 .git
 .gitignore
-README.md
+# Keep README to allow Markdown import during build
 .env
 .env.local
 .env.development.local


### PR DESCRIPTION
## Summary
- keep README in Docker context so that Settings page can import it

## Testing
- `npm ci`
- `npm run lint` *(fails: ESLint can't pass in repo)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b05161b68832ab5cb7a9cf611ce70