### PR TITLE
Add persistent volume definition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,9 @@ COPY package*.json ./
 
 RUN npm prune --production || true
 
+# Persist application data
+VOLUME /app/server/data
+
 EXPOSE 3002
 
 CMD ["node", "server/index.js"]

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ docker pull ghcr.io/timbornemann/total-task-tracker:latest
 docker run -d --name task-tracker -p 3002:3002 ghcr.io/timbornemann/total-task-tracker:latest
 ```
 
-Optional lassen sich die Daten per Volume auf dem Host speichern:
+Die Anwendung legt die SQLite-Daten standardmäßig im Docker-Volume `/app/server/data` ab. Dieses Volume wird automatisch erzeugt und bleibt auch nach einem Update des Containers erhalten.
+
+Möchtest du stattdessen ein bestimmtes Verzeichnis binden, kannst du ein Volume angeben:
 
 ```bash
 docker run -d \


### PR DESCRIPTION
## Summary
- persist data by default via Docker `VOLUME`
- document new default volume in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b1cc49788832abd027c0efee61228