### PR TITLE
Fix server initialization error

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -50,6 +50,11 @@ try {
   db.prepare('ALTER TABLE pomodoro_sessions ADD COLUMN breakEnd INTEGER').run();
 } catch {}
 
+let syncFolder = '';
+let syncInterval = 5; // minutes
+let syncTimer = null;
+let lastSyncMtime = 0;
+
 const initialSettings = loadSettings();
 if (typeof initialSettings.syncInterval === 'number') {
   syncInterval = initialSettings.syncInterval;
@@ -248,11 +253,6 @@ function saveAllData(data) {
   saveFlashcards(data.flashcards || []);
   saveDecks(data.decks || []);
 }
-
-let syncFolder = '';
-let syncInterval = 5; // minutes
-let syncTimer = null;
-let lastSyncMtime = 0;
 
 function mergeLists(curr = [], inc = [], compare = 'updatedAt') {
   const map = new Map();


### PR DESCRIPTION
## Summary
- initialize sync-related variables before accessing them

## Testing
- `npm run lint` *(fails: unexpected any, require imports)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_684b514a1188832abd87cddb0ed0b80a