### PR TITLE
Add settings to sync process

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,10 @@ npm start    # startet die gebaute App auf Port 3002
   sofort aktualisiert.
 - Lern- und Pausendauer frei konfigurierbar (auch direkt im Timer anpassbar)
 - Daten können im Einstellungsbereich exportiert und importiert werden
+  (inklusive Einstellungen)
 - Automatische Synchronisation mit optional wählbarem Ordner
-  und einstellbarem Sync-Intervall
+  und einstellbarem Sync-Intervall. Dabei werden nun auch die
+  Einstellungen mitgespeichert und abgeglichen.
 - Standard-Priorität für neue Tasks einstellbar
 - Mehrere Theme-Voreinstellungen (light, dark, ocean, dark-red, hacker,
   motivation) und ein eigenes "Custom"-Theme wählbar

--- a/server/index.js
+++ b/server/index.js
@@ -244,7 +244,8 @@ function loadAllData() {
     categories: loadCategories(),
     notes: loadNotes(),
     flashcards: loadFlashcards(),
-    decks: loadDecks()
+    decks: loadDecks(),
+    settings: loadSettings()
   };
 }
 
@@ -252,6 +253,15 @@ function saveAllData(data) {
   saveData(data);
   saveFlashcards(data.flashcards || []);
   saveDecks(data.decks || []);
+  if (data.settings) {
+    saveSettings(data.settings);
+    if (data.settings.syncFolder !== undefined) {
+      setSyncFolder(data.settings.syncFolder);
+    }
+    if (data.settings.syncInterval !== undefined) {
+      setSyncInterval(data.settings.syncInterval);
+    }
+  }
 }
 
 function mergeLists(curr = [], inc = [], compare = 'updatedAt') {
@@ -276,7 +286,8 @@ function mergeData(curr, inc) {
     categories: mergeLists(curr.categories, inc.categories),
     notes: mergeLists(curr.notes, inc.notes),
     flashcards: mergeLists(curr.flashcards, inc.flashcards, null),
-    decks: mergeLists(curr.decks, inc.decks, null)
+    decks: mergeLists(curr.decks, inc.decks, null),
+    settings: { ...curr.settings, ...inc.settings }
   };
 }
 


### PR DESCRIPTION
## Summary
- sync settings along with tasks and notes
- update sync description in README

## Testing
- `npm run lint` *(fails: eslint missing type definitions and other warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b55535714832ab30ae3de88f36e19