### PR TITLE
Fix sync folder path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ npm start    # startet die gebaute App auf Port 3002
   (inklusive Einstellungen)
 - Automatische Synchronisation mit optional wählbarem Ordner
   und einstellbarem Sync-Intervall. Dabei werden nun auch die
-  Einstellungen mitgespeichert und abgeglichen.
+  Einstellungen mitgespeichert und abgeglichen, der Ordnerpfad
+  selbst wird jedoch nicht in der Sync-Datei gespeichert.
 - Standard-Priorität für neue Tasks einstellbar
 - Mehrere Theme-Voreinstellungen (light, dark, ocean, dark-red, hacker,
   motivation) und ein eigenes "Custom"-Theme wählbar


### PR DESCRIPTION
## Summary
- prevent `syncFolder` from being stored in synced data
- exclude `syncFolder` when exporting all data
- document behaviour in README

## Testing
- `npm run lint` *(fails: cannot satisfy ESLint rules)*

------
https://chatgpt.com/codex/tasks/task_e_684b57baaddc832a8271343c05711226