### PR TITLE
Add hidden surprise hotkey

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,8 @@ import PomodoroTimer from "@/components/PomodoroTimer";
 import PomodoroTicker from "@/components/PomodoroTicker";
 import { PomodoroHistoryProvider } from "@/hooks/usePomodoroHistory.tsx";
 import ReleaseNotesModal from "@/components/ReleaseNotesModal";
+import SurprisePage from "./pages/Surprise";
+import SurpriseListener from "@/components/SurpriseListener";
 
 const queryClient = new QueryClient();
 
@@ -42,6 +44,7 @@ const App = () => (
             <Toaster />
             <Sonner />
             <BrowserRouter>
+              <SurpriseListener />
               <CommandPalette />
               <Routes>
               <Route path="/" element={<Home />} />
@@ -58,6 +61,7 @@ const App = () => (
               <Route path="/settings" element={<SettingsPage />} />
               <Route path="/release-notes" element={<ReleaseNotesPage />} />
               <Route path="/pomodoro" element={<PomodoroPage />} />
+              <Route path="/surprise" element={<SurprisePage />} />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
               <Route path="*" element={<NotFound />} />
               </Routes>

--- a/src/components/SurpriseListener.tsx
+++ b/src/components/SurpriseListener.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+const SurpriseListener: React.FC = () => {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.altKey && e.key.toLowerCase() === 'l') {
+        e.preventDefault()
+        navigate('/surprise')
+      }
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [navigate])
+
+  return null
+}
+
+export default SurpriseListener

--- a/src/index.css
+++ b/src/index.css
@@ -154,3 +154,20 @@
     --tw-prose-td-borders: hsl(var(--border));
   }
 }
+@keyframes float {
+  0% {
+    transform: translateY(100vh) rotate(0deg);
+    opacity: 0;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(-10vh) rotate(360deg);
+    opacity: 0;
+  }
+}
+
+.animate-float {
+  animation: float 6s linear infinite;
+}

--- a/src/pages/Surprise.tsx
+++ b/src/pages/Surprise.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useMemo } from 'react'
+import Navbar from '@/components/Navbar'
+import { toast } from '@/hooks/use-toast'
+
+const SurprisePage: React.FC = () => {
+  useEffect(() => {
+    toast({ description: 'Geheime Liebesbotschaft entdeckt!' })
+  }, [])
+
+  const hearts = useMemo(
+    () =>
+      Array.from({ length: 20 }, () => ({
+        left: Math.random() * 100,
+        delay: Math.random() * 5,
+        size: Math.random() * 24 + 16
+      })),
+    []
+  )
+
+  return (
+    <div className="min-h-screen bg-pink-50 dark:bg-pink-900 relative overflow-hidden">
+      <Navbar title="Überraschung" />
+      <div className="flex flex-col items-center justify-center py-20">
+        <h1 className="text-4xl font-bold text-pink-600 dark:text-pink-200">
+          Hab dich lieb
+        </h1>
+      </div>
+      <div className="absolute inset-0 pointer-events-none overflow-hidden">
+        {hearts.map((h, i) => (
+          <span
+            key={i}
+            className="absolute animate-float select-none text-pink-500 dark:text-pink-300"
+            style={{
+              left: `${h.left}%`,
+              animationDelay: `${h.delay}s`,
+              fontSize: `${h.size}px`
+            }}
+          >
+            ❤️
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default SurprisePage


### PR DESCRIPTION
## Summary
- add Surprise page with cute hearts animation
- register a hidden `Ctrl+Alt+L` hotkey to reach it
- wire up new route and listener
- include floating heart animation styles

## Testing
- `npm run lint` *(fails: several existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b58ccdfac832abc4be37d3d65f52d