### PR TITLE
Fix naming to Total-Task-Tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Task Tree Dashboard
+# Total-Task-Tracker
 
 Kleine Aufgabenverwaltung auf Basis von React und Node.js. Aufgaben lassen sich in Kategorien organisieren und in einem Kalender oder auf einer Statistikseite auswerten. Die Daten werden dabei auf dem Server in einer kleinen SQLite-Datenbank gespeichert.
 
@@ -12,7 +12,7 @@ Kleine Aufgabenverwaltung auf Basis von React und Node.js. Aufgaben lassen sich 
 ```bash
 # Repository klonen
 git clone <REPO_URL>
-cd total-task-tracker
+cd Total-Task-Tracker
 
 # Abhängigkeiten installieren
 npm install
@@ -47,7 +47,7 @@ Die Anwendung kann komplett über einen Docker-Container ausgeführt werden. Dab
 VERSION=$(git describe --tags --abbrev=0) docker-compose up --build
 ```
 
-Der Dienst lauscht anschließend auf Port **3002**. Im Browser unter `http://localhost:3002` erreichst du das Dashboard. Die Daten werden in einem benannten Docker-Volume (`task-tracker-data`) gespeichert, das automatisch erstellt wird. Mit `docker-compose down` kann der Container gestoppt werden, ohne dass die Daten verloren gehen.
+Der Dienst lauscht anschließend auf Port **3002**. Im Browser unter `http://localhost:3002` erreichst du das Dashboard. Die Daten werden in einem benannten Docker-Volume (`total-task-tracker-data`) gespeichert, das automatisch erstellt wird. Mit `docker-compose down` kann der Container gestoppt werden, ohne dass die Daten verloren gehen.
 
 ## Nutzung des vorgefertigten Images
 
@@ -56,21 +56,21 @@ Wenn du nicht lokal bauen möchtest, kannst du das bereits bereitgestellte Docke
 ```bash
 docker pull ghcr.io/timbornemann/total-task-tracker:latest
 docker run -d \
-  --name task-tracker \
+  --name total-task-tracker \
   -p 3002:3002 \
-  -v task-tracker-data:/app/server/data \
+  -v total-task-tracker-data:/app/server/data \
   ghcr.io/timbornemann/total-task-tracker:latest
 ```
 
-Die Daten werden dabei automatisch im Volume `task-tracker-data` gespeichert, sodass Updates mit Tools wie **Watchtower** keine Daten verlieren.
+Die Daten werden dabei automatisch im Volume `total-task-tracker-data` gespeichert, sodass Updates mit Tools wie **Watchtower** keine Daten verlieren.
 
-Die Anwendung legt die SQLite-Daten standardmäßig im Volume `task-tracker-data` ab. Dieses Volume wird beim ersten Start automatisch angelegt und bleibt auch nach einem Container-Update erhalten.
+Die Anwendung legt die SQLite-Daten standardmäßig im Volume `total-task-tracker-data` ab. Dieses Volume wird beim ersten Start automatisch angelegt und bleibt auch nach einem Container-Update erhalten.
 
 Möchtest du stattdessen ein bestimmtes Verzeichnis binden, kannst du ein Volume angeben:
 
 ```bash
 docker run -d \
-  --name task-tracker \
+  --name total-task-tracker \
   -p 3002:3002 \
   -v ./server/data:/app/server/data \
   ghcr.io/timbornemann/total-task-tracker:latest
@@ -97,7 +97,7 @@ Der Parameter `--interval` gibt das Prüfintervall in Sekunden an. Im Beispiel s
 docker run -d --name watchtower \
   --restart unless-stopped \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  containrrr/watchtower task-tracker-app --interval 3600
+  containrrr/watchtower total-task-tracker-app --interval 3600
 ```
 
 Soll Watchtower lediglich einmalig prüfen und danach beendet werden, füge `--run-once` hinzu:
@@ -105,7 +105,7 @@ Soll Watchtower lediglich einmalig prüfen und danach beendet werden, füge `--r
 ```bash
 docker run --rm \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  containrrr/watchtower task-tracker-app --run-once
+  containrrr/watchtower total-task-tracker-app --run-once
 ```
 
 ## Manuelle Produktion (optional)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 
 services:
-  task-tracker:
+  total-task-tracker:
     build:
       context: .
       args:
@@ -9,13 +9,13 @@ services:
     ports:
       - "3002:3002"
     restart: unless-stopped
-    container_name: task-tracker-app
+    container_name: total-task-tracker-app
     environment:
       - NODE_ENV=production
       - APP_VERSION=${VERSION:-0.0.0}
     volumes:
-      - task-tracker-data:/app/server/data
+      - total-task-tracker-data:/app/server/data
 
 volumes:
-  task-tracker-data:
-    name: task-tracker-data
+  total-task-tracker-data:
+    name: total-task-tracker-data

--- a/index.html
+++ b/index.html
@@ -4,12 +4,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Task Tracker - Moderne Aufgabenverwaltung</title>
-    <meta name="description" content="Moderner Task Tracker mit Kategorien und rekursiven Unteraufgaben" />
-    <meta name="author" content="Task Tracker App" />
+    <title>Total-Task-Tracker - Moderne Aufgabenverwaltung</title>
+    <meta name="description" content="Moderner Total-Task-Tracker mit Kategorien und rekursiven Unteraufgaben" />
+    <meta name="author" content="Total-Task-Tracker App" />
 
-    <meta property="og:title" content="Task Tracker - Moderne Aufgabenverwaltung" />
-    <meta property="og:description" content="Moderner Task Tracker mit Kategorien und rekursiven Unteraufgaben" />
+    <meta property="og:title" content="Total-Task-Tracker - Moderne Aufgabenverwaltung" />
+    <meta property="og:description" content="Moderner Total-Task-Tracker mit Kategorien und rekursiven Unteraufgaben" />
     <meta property="og:type" content="website" />
 
     <meta name="twitter:card" content="summary_large_image" />

--- a/server/index.js
+++ b/server/index.js
@@ -293,7 +293,7 @@ function mergeData(curr, inc) {
 
 function performSync() {
   if (!syncFolder) return;
-  const file = path.join(syncFolder, 'task-tracker-sync.json');
+  const file = path.join(syncFolder, 'total-task-tracker-sync.json');
   try {
     let incoming = null;
     if (fs.existsSync(file)) {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -44,7 +44,7 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
               onClick={onHomeClick}
               className="text-lg sm:text-2xl font-bold text-foreground"
             >
-              Task Tracker
+              Total-Task-Tracker
             </Link>
             {title && (
               <span className="hidden sm:inline text-muted-foreground">/ {title}</span>


### PR DESCRIPTION
## Summary
- rename app references from "Task Tracker" to "Total-Task-Tracker"
- update container names in docker-compose
- adjust volume references and docs

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-require-imports errors)*

------
https://chatgpt.com/codex/tasks/task_e_684bb6580e28832aa1403e820d26a84e