### PR TITLE
Add recurring task template management

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ npm start    # startet die gebaute App auf Port 3002
 
 - Aufgaben anlegen, bearbeiten und in Kategorien sortieren
 - Unteraufgaben, Prioritäten und Wiederholungen
+- Separate Seite für wiederkehrende Aufgaben mit eigenen Intervallen und dynamischen Titeln
 - Kalenderansicht mit direkter Task-Erstellung; Tagesaufgaben sind klickbar und bieten alle Task-Optionen
 - Eigene Notizen mit Farbe und Drag & Drop sortierbar
   - Notizen lassen sich anpinnen; die ersten drei angepinnten erscheinen auf der Startseite
@@ -173,6 +174,7 @@ npm start    # startet die gebaute App auf Port 3002
 
 1. Nach dem Start siehst du die vorhandenen **Kategorien**. Mit dem Button `Kategorie` kannst du neue Kategorien erstellen.
 2. Wähle eine Kategorie aus, um ihre **Tasks** zu sehen. Über `Task` legst du neue Aufgaben an. Dort kannst du Titel, Beschreibung, Priorität, Farbe, Fälligkeitsdatum und optionale Wiederholung definieren.
+3. Wiederkehrende Aufgaben verwaltest du auf der Seite **Wiederkehrend**. Dort legst du Vorlagen mit festen oder benutzerdefinierten Intervallen an und kannst Platzhalter wie `{date}` oder `{counter}` im Titel nutzen.
 3. Tasks lassen sich per Drag & Drop umsortieren oder in Unteraufgaben aufteilen.
 4. Über das Suchfeld und die Filter sortierst und findest du Aufgaben nach Priorität oder Farbe.
 5. Mit dem Sternsymbol kannst du eine Task anpinnen. Die ersten drei gepinnten erscheinen auf der Startseite.

--- a/server/index.js
+++ b/server/index.js
@@ -28,6 +28,10 @@ db.exec(`
     id TEXT PRIMARY KEY,
     data TEXT NOT NULL
   );
+  CREATE TABLE IF NOT EXISTS recurring (
+    id TEXT PRIMARY KEY,
+    data TEXT NOT NULL
+  );
   CREATE TABLE IF NOT EXISTS flashcards (
     id TEXT PRIMARY KEY,
     data TEXT NOT NULL
@@ -111,11 +115,23 @@ function loadNotes() {
   }
 }
 
+function loadRecurring() {
+  try {
+    return db
+      .prepare('SELECT data FROM recurring')
+      .all()
+      .map(row => JSON.parse(row.data, dateReviver));
+  } catch {
+    return [];
+  }
+}
+
 function loadData() {
   return {
     tasks: loadTasks(),
     categories: loadCategories(),
-    notes: loadNotes()
+    notes: loadNotes(),
+    recurring: loadRecurring()
   };
 }
 
@@ -152,11 +168,23 @@ function saveNotes(notes) {
   tx();
 }
 
+function saveRecurring(list) {
+  const tx = db.transaction(() => {
+    db.exec('DELETE FROM recurring');
+    for (const item of list || []) {
+      db.prepare('INSERT INTO recurring (id, data) VALUES (?, ?)')
+        .run(item.id, toJson(item));
+    }
+  });
+  tx();
+}
+
 function saveData(data) {
   const tx = db.transaction(() => {
     saveTasks(data.tasks || []);
     saveCategories(data.categories || []);
     saveNotes(data.notes || []);
+    saveRecurring(data.recurring || []);
   });
   tx();
 }
@@ -243,6 +271,7 @@ function loadAllData() {
     tasks: loadTasks(),
     categories: loadCategories(),
     notes: loadNotes(),
+    recurring: loadRecurring(),
     flashcards: loadFlashcards(),
     decks: loadDecks(),
     settings: loadSettings()
@@ -253,6 +282,7 @@ function saveAllData(data) {
   saveData(data);
   saveFlashcards(data.flashcards || []);
   saveDecks(data.decks || []);
+  if (data.recurring) saveRecurring(data.recurring);
   if (data.settings) {
     saveSettings(data.settings);
     if (data.settings.syncFolder !== undefined) {
@@ -285,6 +315,7 @@ function mergeData(curr, inc) {
     tasks: mergeLists(curr.tasks, inc.tasks),
     categories: mergeLists(curr.categories, inc.categories),
     notes: mergeLists(curr.notes, inc.notes),
+    recurring: mergeLists(curr.recurring, inc.recurring),
     flashcards: mergeLists(curr.flashcards, inc.flashcards, null),
     decks: mergeLists(curr.decks, inc.decks, null),
     settings: { ...curr.settings, ...inc.settings }
@@ -427,6 +458,30 @@ const server = http.createServer((req, res) => {
         try {
           const decks = JSON.parse(body || '[]');
           saveDecks(decks);
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ status: 'ok' }));
+        } catch {
+          res.writeHead(400);
+          res.end();
+        }
+      });
+      return;
+    }
+  }
+
+  if (parsed.pathname === '/api/recurring' || parsed.pathname === '/api/recurring/') {
+    if (req.method === 'GET') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(loadRecurring()));
+      return;
+    }
+    if (req.method === 'PUT') {
+      let body = '';
+      req.on('data', chunk => { body += chunk; });
+      req.on('end', () => {
+        try {
+          const list = JSON.parse(body || '[]');
+          saveRecurring(list);
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ status: 'ok' }));
         } catch {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import { PomodoroHistoryProvider } from "@/hooks/usePomodoroHistory.tsx";
 import ReleaseNotesModal from "@/components/ReleaseNotesModal";
 import SurprisePage from "./pages/Surprise";
 import SurpriseListener from "@/components/SurpriseListener";
+import RecurringTasksPage from "./pages/RecurringTasks";
 
 const queryClient = new QueryClient();
 
@@ -52,6 +53,7 @@ const App = () => (
               <Route path="/statistics" element={<Statistics />} />
               <Route path="/calendar" element={<CalendarPage />} />
               <Route path="/kanban" element={<Kanban />} />
+              <Route path="/recurring" element={<RecurringTasksPage />} />
               <Route path="/flashcards/manage" element={<FlashcardManagerPage />} />
               <Route path="/flashcards/deck/:deckId" element={<DeckDetailPage />} />
               <Route path="/flashcards" element={<FlashcardsPage />} />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -113,6 +113,11 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
+                  <Link to="/recurring" className="flex items-center">
+                    <List className="h-4 w-4 mr-2" /> Wiederkehrend
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
                   <Link to="/statistics" className="flex items-center">
                     <BarChart3 className="h-4 w-4 mr-2" /> Statistiken
                   </Link>
@@ -195,6 +200,12 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                   <Button variant="outline" size="sm" className="w-full">
                     <CalendarIcon className="h-4 w-4 mr-2" />
                     Kalender
+                  </Button>
+                </Link>
+                <Link to="/recurring" className="flex-1">
+                  <Button variant="outline" size="sm" className="w-full">
+                    <List className="h-4 w-4 mr-2" />
+                    Wiederkehrend
                   </Button>
                 </Link>
                 <Link to="/statistics" className="flex-1">

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -49,7 +49,10 @@ const TaskModal: React.FC<TaskModalProps> = ({
     parentId: parentTask?.id,
     dueDate: undefined,
     isRecurring: false,
-    recurrencePattern: undefined
+    recurrencePattern: undefined,
+    customIntervalDays: undefined,
+    titleTemplate: undefined,
+    template: false
   });
 
   const colorOptions = [
@@ -70,7 +73,10 @@ const TaskModal: React.FC<TaskModalProps> = ({
         parentId: task.parentId,
         dueDate: task.dueDate,
         isRecurring: task.isRecurring,
-        recurrencePattern: task.recurrencePattern
+        recurrencePattern: task.recurrencePattern,
+        customIntervalDays: task.customIntervalDays,
+        titleTemplate: task.titleTemplate,
+        template: task.template
       });
     } else {
       setFormData({
@@ -83,7 +89,10 @@ const TaskModal: React.FC<TaskModalProps> = ({
         parentId: parentTask?.id,
         dueDate: defaultDueDate,
         isRecurring: false,
-        recurrencePattern: undefined
+        recurrencePattern: undefined,
+        customIntervalDays: undefined,
+        titleTemplate: undefined,
+        template: false
       });
     }
   }, [
@@ -242,11 +251,32 @@ const TaskModal: React.FC<TaskModalProps> = ({
                     <SelectItem value="daily">Täglich</SelectItem>
                     <SelectItem value="weekly">Wöchentlich</SelectItem>
                     <SelectItem value="monthly">Monatlich</SelectItem>
-                    <SelectItem value="yearly">Jährlich</SelectItem>
-                  </SelectContent>
-                </Select>
+                <SelectItem value="yearly">Jährlich</SelectItem>
+                </SelectContent>
+              </Select>
+              <div className="mt-2">
+                <Label htmlFor="customDays">Benutzerdefinierte Tage</Label>
+                <Input
+                  id="customDays"
+                  type="number"
+                  value={formData.customIntervalDays ?? ''}
+                  onChange={(e) =>
+                    handleChange('customIntervalDays', e.target.value ? Number(e.target.value) : undefined)
+                  }
+                  placeholder="z.B. 3"
+                />
               </div>
-            )}
+              <div className="mt-2">
+                <Label htmlFor="titleTemplate">Dynamischer Titel</Label>
+                <Input
+                  id="titleTemplate"
+                  value={formData.titleTemplate || ''}
+                  onChange={(e) => handleChange('titleTemplate', e.target.value)}
+                  placeholder="{date} oder {counter} nutzen"
+                />
+              </div>
+            </div>
+          )}
           </div>
 
           <div className="flex justify-end space-x-2 pt-4">

--- a/src/pages/RecurringTasks.tsx
+++ b/src/pages/RecurringTasks.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { Plus } from 'lucide-react';
+import Navbar from '@/components/Navbar';
+import TaskModal from '@/components/TaskModal';
+import TaskCard from '@/components/TaskCard';
+import { Button } from '@/components/ui/button';
+import { useTaskStore } from '@/hooks/useTaskStore';
+
+const RecurringTasksPage = () => {
+  const {
+    recurring,
+    categories,
+    addRecurringTask,
+    updateRecurringTask,
+    deleteRecurringTask
+  } = useTaskStore();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingTask, setEditingTask] = useState<any | null>(null);
+
+  const handleSave = (data: any) => {
+    if (editingTask) {
+      updateRecurringTask(editingTask.id, data);
+    } else {
+      addRecurringTask({ ...data, isRecurring: true, template: true });
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Navbar title="Wiederkehrend" />
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-8">
+        <div className="flex justify-end mb-4">
+          <Button size="sm" onClick={() => setIsModalOpen(true)}>
+            <Plus className="h-4 w-4 mr-2" /> Vorlage
+          </Button>
+        </div>
+        {recurring.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Keine Vorlagen vorhanden.</p>
+        ) : (
+          <div className="space-y-2">
+            {recurring.map(t => (
+              <TaskCard
+                key={t.id}
+                task={t}
+                parentPathTitles={[]}
+                showSubtasks={false}
+                onEdit={() => { setEditingTask(t); setIsModalOpen(true); }}
+                onDelete={() => deleteRecurringTask(t.id)}
+                onAddSubtask={() => {}}
+                onToggleComplete={() => {}}
+                onViewDetails={() => {}}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+      <TaskModal
+        isOpen={isModalOpen}
+        onClose={() => { setIsModalOpen(false); setEditingTask(null); }}
+        onSave={handleSave}
+        task={editingTask || undefined}
+        categories={categories}
+      />
+    </div>
+  );
+};
+
+export default RecurringTasksPage;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,6 +24,9 @@ export interface Task {
   order: number;
   /** Whether the task is pinned */
   pinned: boolean;
+  template?: boolean;
+  titleTemplate?: string;
+  customIntervalDays?: number;
 }
 
 export interface Category {
@@ -50,6 +53,9 @@ export interface TaskFormData {
   dueDate?: Date;
   isRecurring: boolean;
   recurrencePattern?: 'daily' | 'weekly' | 'monthly' | 'yearly';
+  customIntervalDays?: number;
+  titleTemplate?: string;
+  template?: boolean;
 }
 
 export interface CategoryFormData {


### PR DESCRIPTION
## Summary
- implement new DB table and API for recurring tasks
- extend task types to allow templates and custom intervals
- enhance TaskModal with dynamic title and custom day fields
- manage recurring tasks in TaskStore and auto-generate tasks
- add dedicated Recurring tasks page and link from Navbar
- document recurring task templates in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_684be0b0c4bc832aa81d70f4deb75b58