### PR TITLE
Improve recurring task UI and logic

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,7 +19,16 @@ export interface Task {
   recurrencePattern?: 'daily' | 'weekly' | 'monthly' | 'yearly';
   lastCompleted?: Date;
   nextDue?: Date;
-  dueDate?: Date;
+  /** How to calculate due date for recurring tasks */
+  dueOption?: 'days' | 'weekEnd' | 'monthEnd';
+  /** Number of days after creation when dueOption is 'days' */
+  dueAfterDays?: number;
+  /** Start configuration for recurring task */
+  startOption?: 'today' | 'weekday' | 'date';
+  /** Weekday number if startOption is 'weekday' (0=Sunday) */
+  startWeekday?: number;
+  /** Fixed start date if startOption is 'date' */
+  startDate?: Date;
   /** Sort order within its list */
   order: number;
   /** Whether the task is pinned */
@@ -54,6 +63,11 @@ export interface TaskFormData {
   isRecurring: boolean;
   recurrencePattern?: 'daily' | 'weekly' | 'monthly' | 'yearly';
   customIntervalDays?: number;
+  dueOption?: 'days' | 'weekEnd' | 'monthEnd';
+  dueAfterDays?: number;
+  startOption?: 'today' | 'weekday' | 'date';
+  startWeekday?: number;
+  startDate?: Date;
   titleTemplate?: string;
   template?: boolean;
 }


### PR DESCRIPTION
## Summary
- enhance TaskModal with scrollable dialog and new recurring options
- add fields for due calculations and start settings
- calculate start date and dynamic due dates in task store
- generate recurring tasks at runtime periodically

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' before install, then many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684d1e69eecc832aaab12922dadd25a7