### PR TITLE
Fix recurring task creation and default

### DIFF
--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -27,6 +27,11 @@ interface TaskModalProps {
    * Default due date when creating a new task. Ignored when editing.
    */
   defaultDueDate?: Date;
+
+  /**
+   * Default value for the recurring toggle when creating a new task.
+   */
+  defaultIsRecurring?: boolean;
 }
 
 const TaskModal: React.FC<TaskModalProps> = ({
@@ -37,7 +42,8 @@ const TaskModal: React.FC<TaskModalProps> = ({
   categories,
   parentTask,
   defaultCategoryId,
-  defaultDueDate
+  defaultDueDate,
+  defaultIsRecurring = false
 }) => {
   const { defaultTaskPriority } = useSettings()
   const [formData, setFormData] = useState<TaskFormData>({
@@ -48,7 +54,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
     categoryId: '',
     parentId: parentTask?.id,
     dueDate: undefined,
-    isRecurring: false,
+    isRecurring: defaultIsRecurring,
     recurrencePattern: undefined,
     customIntervalDays: undefined,
     dueOption: undefined,
@@ -98,7 +104,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
           defaultCategoryId || parentTask?.categoryId || categories[0]?.id || '',
         parentId: parentTask?.id,
         dueDate: defaultDueDate,
-        isRecurring: false,
+        isRecurring: defaultIsRecurring,
         recurrencePattern: undefined,
         customIntervalDays: undefined,
         dueOption: undefined,
@@ -117,7 +123,8 @@ const TaskModal: React.FC<TaskModalProps> = ({
     parentTask,
     defaultCategoryId,
     defaultDueDate,
-    defaultTaskPriority
+    defaultTaskPriority,
+    defaultIsRecurring
   ]);
 
   const handleSubmit = (e: React.FormEvent) => {

--- a/src/hooks/useTaskStore.tsx
+++ b/src/hooks/useTaskStore.tsx
@@ -315,6 +315,7 @@ const useTaskStoreImpl = () => {
       }
       return new Date();
     })();
+    const shouldCreateNow = start <= new Date();
     const newItem: Task = {
       ...data,
       id: Date.now().toString(),
@@ -326,12 +327,32 @@ const useTaskStoreImpl = () => {
       order: recurring.length,
       pinned: false,
       template: true,
-      nextDue: calculateNextDue(
-        data.recurrencePattern,
-        data.customIntervalDays,
-        start
-      ),
+      nextDue: shouldCreateNow
+        ? calculateNextDue(
+            data.recurrencePattern,
+            data.customIntervalDays,
+            start
+          )
+        : start,
     };
+
+    if (shouldCreateNow) {
+      addTask({
+        ...newItem,
+        dueDate: calculateDueDate(newItem),
+        dueOption: undefined,
+        dueAfterDays: undefined,
+        startOption: undefined,
+        startWeekday: undefined,
+        startDate: undefined,
+        title: generateTitle(newItem),
+        template: undefined,
+        titleTemplate: undefined,
+        isRecurring: false,
+        parentId: undefined,
+      });
+    }
+
     setRecurring(prev => [...prev, newItem]);
   };
 

--- a/src/pages/RecurringTasks.tsx
+++ b/src/pages/RecurringTasks.tsx
@@ -60,6 +60,7 @@ const RecurringTasksPage = () => {
         onSave={handleSave}
         task={editingTask || undefined}
         categories={categories}
+        defaultIsRecurring
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- set default recurring toggle for templates
- ensure 'start today' creates a task immediately
- default recurring tasks to recurring when creating new templates

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d273c407c832a8b73889af5df9e9b