### PR TITLE
Remove recurring option from regular tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ npm start    # startet die gebaute App auf Port 3002
 ## Funktionen
 
 - Aufgaben anlegen, bearbeiten und in Kategorien sortieren
-- Unteraufgaben, Prioritäten und Wiederholungen
+- Unteraufgaben und Prioritäten
 - Separate Seite für wiederkehrende Aufgaben mit eigenen Intervallen und dynamischen Titeln
 - Kalenderansicht mit direkter Task-Erstellung; Tagesaufgaben sind klickbar und bieten alle Task-Optionen
 - Eigene Notizen mit Farbe und Drag & Drop sortierbar
@@ -173,16 +173,16 @@ npm start    # startet die gebaute App auf Port 3002
 ## Verwendung
 
 1. Nach dem Start siehst du die vorhandenen **Kategorien**. Mit dem Button `Kategorie` kannst du neue Kategorien erstellen.
-2. Wähle eine Kategorie aus, um ihre **Tasks** zu sehen. Über `Task` legst du neue Aufgaben an. Dort kannst du Titel, Beschreibung, Priorität, Farbe, Fälligkeitsdatum und optionale Wiederholung definieren.
-3. Wiederkehrende Aufgaben verwaltest du auf der Seite **Wiederkehrend**. Dort legst du Vorlagen mit festen oder benutzerdefinierten Intervallen an und kannst Platzhalter wie `{date}` oder `{counter}` im Titel nutzen.
-3. Tasks lassen sich per Drag & Drop umsortieren oder in Unteraufgaben aufteilen.
-4. Über das Suchfeld und die Filter sortierst und findest du Aufgaben nach Priorität oder Farbe.
-5. Mit dem Sternsymbol kannst du eine Task anpinnen. Die ersten drei gepinnten erscheinen auf der Startseite.
-6. Mit `Strg+K` (oder über das Suchsymbol) öffnest du die **globale Suche**. Sie durchsucht Tasks, Notizen und Lernkarten und führt dich bei Auswahl direkt zum entsprechenden Eintrag.
-7. In der **Kalender**-Ansicht klickst du auf ein Datum, um alle bis dahin fälligen Aufgaben zu sehen. Dort kannst du die Tasks direkt öffnen, bearbeiten, Unteraufgaben anlegen oder löschen. Die **Statistiken** geben einen Überblick über erledigte Tasks.
-8. Unter **Notizen** kannst du unabhängige Notizen verwalten und per Drag & Drop sortieren. Gepinnte Notizen erscheinen auf der Startseite. Deine Inhalte kannst du dabei in Markdown verfassen. Beim Anklicken einer Notiz siehst du zunächst eine Vorschau, die du dort auch bearbeiten kannst.
-9. Unter **Decks** legst du Kartendecks an und kannst sie bearbeiten. In der Detailansicht eines Decks fügst du einzelne Karten hinzu.
-10. Der Bereich **Karten** zeigt dir fällige Karten zum Lernen an. Dort kannst du
+2. Wähle eine Kategorie aus, um ihre **Tasks** zu sehen. Über `Task` legst du neue Aufgaben an. Dort kannst du Titel, Beschreibung, Priorität, Farbe und ein Fälligkeitsdatum festlegen.
+3. Wiederkehrende Aufgaben erstellst du über die Seite **Wiederkehrend**. Dort legst du Vorlagen mit festen oder benutzerdefinierten Intervallen an und kannst Platzhalter wie `{date}` oder `{counter}` im Titel nutzen.
+4. Tasks lassen sich per Drag & Drop umsortieren oder in Unteraufgaben aufteilen.
+5. Über das Suchfeld und die Filter sortierst und findest du Aufgaben nach Priorität oder Farbe.
+6. Mit dem Sternsymbol kannst du eine Task anpinnen. Die ersten drei gepinnten erscheinen auf der Startseite.
+7. Mit `Strg+K` (oder über das Suchsymbol) öffnest du die **globale Suche**. Sie durchsucht Tasks, Notizen und Lernkarten und führt dich bei Auswahl direkt zum entsprechenden Eintrag.
+8. In der **Kalender**-Ansicht klickst du auf ein Datum, um alle bis dahin fälligen Aufgaben zu sehen. Dort kannst du die Tasks direkt öffnen, bearbeiten, Unteraufgaben anlegen oder löschen. Die **Statistiken** geben einen Überblick über erledigte Tasks.
+9. Unter **Notizen** kannst du unabhängige Notizen verwalten und per Drag & Drop sortieren. Gepinnte Notizen erscheinen auf der Startseite. Deine Inhalte kannst du dabei in Markdown verfassen. Beim Anklicken einer Notiz siehst du zunächst eine Vorschau, die du dort auch bearbeiten kannst.
+10. Unter **Decks** legst du Kartendecks an und kannst sie bearbeiten. In der Detailansicht eines Decks fügst du einzelne Karten hinzu.
+11. Der Bereich **Karten** zeigt dir fällige Karten zum Lernen an. Dort kannst du
    gezielt Decks ein- oder ausblenden, einen Zufallsmodus aktivieren und im
    Eingabemodus Antworten eintippen. Nach dem Vergleich der Lösung entscheidest
    du selbst, wie schwer dir die Karte fiel.

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -644,6 +644,7 @@ const Dashboard: React.FC = () => {
         parentTask={parentTask || undefined}
         defaultCategoryId={selectedCategory ? selectedCategory.id : undefined}
         defaultDueDate={undefined}
+        allowRecurring={false}
       />
 
       <CategoryModal

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -32,6 +32,11 @@ interface TaskModalProps {
    * Default value for the recurring toggle when creating a new task.
    */
   defaultIsRecurring?: boolean;
+
+  /**
+   * Whether recurring options should be available.
+   */
+  allowRecurring?: boolean;
 }
 
 const TaskModal: React.FC<TaskModalProps> = ({
@@ -43,7 +48,8 @@ const TaskModal: React.FC<TaskModalProps> = ({
   parentTask,
   defaultCategoryId,
   defaultDueDate,
-  defaultIsRecurring = false
+  defaultIsRecurring = false,
+  allowRecurring = true
 }) => {
   const { defaultTaskPriority } = useSettings()
   const [formData, setFormData] = useState<TaskFormData>({
@@ -54,7 +60,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
     categoryId: '',
     parentId: parentTask?.id,
     dueDate: undefined,
-    isRecurring: defaultIsRecurring,
+    isRecurring: allowRecurring ? defaultIsRecurring : false,
     recurrencePattern: undefined,
     customIntervalDays: undefined,
     dueOption: undefined,
@@ -83,7 +89,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
         categoryId: task.categoryId,
         parentId: task.parentId,
         dueDate: task.dueDate,
-        isRecurring: task.isRecurring,
+        isRecurring: allowRecurring ? task.isRecurring : false,
         recurrencePattern: task.recurrencePattern,
         customIntervalDays: task.customIntervalDays,
         dueOption: task.dueOption,
@@ -104,7 +110,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
           defaultCategoryId || parentTask?.categoryId || categories[0]?.id || '',
         parentId: parentTask?.id,
         dueDate: defaultDueDate,
-        isRecurring: defaultIsRecurring,
+        isRecurring: allowRecurring ? defaultIsRecurring : false,
         recurrencePattern: undefined,
         customIntervalDays: undefined,
         dueOption: undefined,
@@ -124,7 +130,8 @@ const TaskModal: React.FC<TaskModalProps> = ({
     defaultCategoryId,
     defaultDueDate,
     defaultTaskPriority,
-    defaultIsRecurring
+    defaultIsRecurring,
+    allowRecurring
   ]);
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -297,23 +304,24 @@ const TaskModal: React.FC<TaskModalProps> = ({
             </div>
           </div>
 
-          <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <Label htmlFor="recurring">Wiederkehrende Aufgabe</Label>
-              <Switch
-                id="recurring"
-                checked={formData.isRecurring}
-                onCheckedChange={(checked) => handleChange('isRecurring', checked)}
-              />
-            </div>
+          {allowRecurring && (
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <Label htmlFor="recurring">Wiederkehrende Aufgabe</Label>
+                <Switch
+                  id="recurring"
+                  checked={formData.isRecurring}
+                  onCheckedChange={(checked) => handleChange('isRecurring', checked)}
+                />
+              </div>
 
-            {formData.isRecurring && (
-              <div>
-                <Label htmlFor="recurrence">Wiederholung</Label>
-                <Select 
-                  value={formData.recurrencePattern} 
-                  onValueChange={(value) => handleChange('recurrencePattern', value)}
-                >
+              {formData.isRecurring && (
+                <div>
+                  <Label htmlFor="recurrence">Wiederholung</Label>
+                  <Select
+                    value={formData.recurrencePattern}
+                    onValueChange={(value) => handleChange('recurrencePattern', value)}
+                  >
                   <SelectTrigger>
                     <SelectValue placeholder="Wiederholung auswählen..." />
                   </SelectTrigger>
@@ -386,9 +394,10 @@ const TaskModal: React.FC<TaskModalProps> = ({
                   placeholder="{date} oder {counter} nutzen"
                 />
               </div>
+                </div>
+              )}
             </div>
           )}
-          </div>
 
           <div className="flex justify-end space-x-2 pt-4">
             <Button type="button" variant="outline" onClick={onClose}>

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -195,6 +195,7 @@ const CalendarPage = () => {
         parentTask={parentTask || undefined}
         defaultCategoryId={categories[0]?.id}
         defaultDueDate={selected}
+        allowRecurring={false}
       />
 
       <TaskDetailModal

--- a/src/pages/Kanban.tsx
+++ b/src/pages/Kanban.tsx
@@ -215,6 +215,7 @@ const Kanban: React.FC = () => {
         categories={categories}
         parentTask={parentTask || undefined}
         defaultDueDate={undefined}
+        allowRecurring={false}
       />
 
       <TaskDetailModal


### PR DESCRIPTION
## Summary
- hide recurring task options in the normal task modal
- update dashboard, kanban and calendar to disable recurring options
- clarify README that repeating tasks are created via the recurring page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d994d003c832a989bef07d817822f