### PR TITLE
Fix multi-line README commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,22 +30,13 @@ Wenn du nicht lokal bauen möchtest, kannst du das bereits bereitgestellte Docke
 
 ```bash
 docker pull ghcr.io/timbornemann/total-task-tracker:latest
-docker run -d `
-  --name total-task-tracker `
-  -p 3002:3002 `
-  -v total-task-tracker-data:/app/server/data `
-  ghcr.io/timbornemann/total-task-tracker:latest
-
+docker run -d --name total-task-tracker -p 3002:3002 -v total-task-tracker-data:/app/server/data ghcr.io/timbornemann/total-task-tracker:latest
 ```
 
 Die Anwendung legt ihre SQLite-Daten standardmäßig im Volume `total-task-tracker-data` ab. Dieses Volume wird beim ersten Start automatisch angelegt und bleibt auch nach einem Container-Update erhalten. Möchtest du stattdessen ein bestimmtes Verzeichnis binden, kannst du ein Volume angeben:
 
 ```bash
-docker run -d `
-  --name total-task-tracker `
-  -p 3002:3002 `
-  -v ./server/data:/app/server/data `
-  ghcr.io/timbornemann/total-task-tracker:latest
+docker run -d --name total-task-tracker -p 3002:3002 -v ./server/data:/app/server/data ghcr.io/timbornemann/total-task-tracker:latest
 ```
 
 ## Docker-Compose: Image selbst bauen
@@ -97,10 +88,7 @@ Um den Container stets aktuell zu halten, kannst du [Watchtower](https://contain
 ### Alle Container überwachen
 
 ```bash
-docker run -d --name watchtower `
-  --restart unless-stopped `
-  -v /var/run/docker.sock:/var/run/docker.sock `
-  containrrr/watchtower --interval 3600
+docker run -d --name watchtower --restart unless-stopped -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --interval 3600
 ```
 
 Der Parameter `--interval` gibt das Prüfintervall in Sekunden an. Im Beispiel sucht Watchtower also jede Stunde nach Updates und startet betroffene Container neu.
@@ -108,18 +96,13 @@ Der Parameter `--interval` gibt das Prüfintervall in Sekunden an. Im Beispiel s
 ### Nur diesen Container aktualisieren
 
 ```bash
-docker run -d --name watchtower `
-  --restart unless-stopped `
-  -v /var/run/docker.sock:/var/run/docker.sock `
-  containrrr/watchtower total-task-tracker-app --interval 3600
+docker run -d --name watchtower --restart unless-stopped -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower total-task-tracker-app --interval 3600
 ```
 
 Soll Watchtower lediglich einmalig prüfen und danach beendet werden, füge `--run-once` hinzu:
 
 ```bash
-docker run --rm `
-  -v /var/run/docker.sock:/var/run/docker.sock `
-  containrrr/watchtower total-task-tracker-app --run-once
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower total-task-tracker-app --run-once
 ```
 
 ## Manuelle Produktion ohne Docker


### PR DESCRIPTION
## Summary
- update README to use one-line commands

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ed5f4f238832aa179c60a19dcaa54