### PR TITLE
Add pages to home configuration

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -118,7 +118,7 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
                   <Link to="/statistics" className="flex items-center">
-                    <BarChart3 className="h-4 w-4 mr-2" /> Statistiken
+                    <BarChart3 className="h-4 w-4 mr-2" /> Task-Statistiken
                   </Link>
                 </DropdownMenuItem>
               </DropdownMenuContent>
@@ -210,7 +210,7 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                 <Link to="/statistics" className="flex-1">
                   <Button variant="outline" size="sm" className="w-full">
                     <BarChart3 className="h-4 w-4 mr-2" />
-                    Statistiken
+                    Task-Statistiken
                   </Button>
                 </Link>
               </div>

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -39,7 +39,7 @@ const Statistics = () => {
   return (
     <div className="min-h-screen bg-background">
       {/* Header */}
-      <Navbar title="Statistiken" />
+      <Navbar title="Task-Statistiken" />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-8">
         {/* Overview Cards */}

--- a/src/utils/homeSections.ts
+++ b/src/utils/homeSections.ts
@@ -7,6 +7,7 @@ import {
   Pencil,
   Timer,
   List,
+  Cog,
   LucideIcon
 } from 'lucide-react'
 
@@ -21,10 +22,12 @@ export const allHomeSections: HomeSection[] = [
   { key: 'tasks', label: 'Tasks', path: '/tasks', icon: ClipboardList },
   { key: 'kanban', label: 'Kanban', path: '/kanban', icon: Columns },
   { key: 'calendar', label: 'Kalender', path: '/calendar', icon: CalendarIcon },
-  { key: 'statistics', label: 'Statistiken', path: '/statistics', icon: BarChart3 },
+  { key: 'statistics', label: 'Task-Statistiken', path: '/statistics', icon: BarChart3 },
   { key: 'flashcards', label: 'Karten', path: '/flashcards', icon: BookOpen },
   { key: 'decks', label: 'Decks', path: '/flashcards/manage', icon: Pencil },
   { key: 'flashcard-stats', label: 'Karten-Statistik', path: '/flashcards/stats', icon: BarChart3 },
   { key: 'pomodoro', label: 'Pomodoro', path: '/pomodoro', icon: Timer },
-  { key: 'notes', label: 'Notizen', path: '/notes', icon: List }
+  { key: 'notes', label: 'Notizen', path: '/notes', icon: List },
+  { key: 'recurring', label: 'Wiederkehrend', path: '/recurring', icon: List },
+  { key: 'settings', label: 'Einstellungen', path: '/settings', icon: Cog }
 ]


### PR DESCRIPTION
## Summary
- allow recurring tasks and settings on the home page
- rename task stats to avoid confusion

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684eda508f18832a939689fcc656dd8a