### PR TITLE
Add Markdown editing toolbar

### DIFF
--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -1,0 +1,58 @@
+import React, { useRef } from 'react';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+
+interface MarkdownEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  rows?: number;
+}
+
+const MarkdownEditor: React.FC<MarkdownEditorProps> = ({ value, onChange, rows = 5 }) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const wrapSelection = (prefix: string, suffix = '') => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const selected = value.slice(start, end);
+    const newValue = value.slice(0, start) + prefix + selected + suffix + value.slice(end);
+    onChange(newValue);
+    requestAnimationFrame(() => {
+      textarea.focus();
+      const cursor = start + prefix.length;
+      textarea.selectionStart = cursor;
+      textarea.selectionEnd = cursor + selected.length;
+    });
+  };
+
+  const insertPrefix = (prefix: string) => {
+    wrapSelection(prefix);
+  };
+
+  return (
+    <div>
+      <div className="flex flex-wrap gap-1 mb-2">
+        <Button type="button" size="sm" variant="outline" onClick={() => wrapSelection('**', '**')}>B</Button>
+        <Button type="button" size="sm" variant="outline" onClick={() => wrapSelection('*', '*')}>I</Button>
+        <Button type="button" size="sm" variant="outline" onClick={() => insertPrefix('# ')}>H1</Button>
+        <Button type="button" size="sm" variant="outline" onClick={() => insertPrefix('## ')}>H2</Button>
+        <Button type="button" size="sm" variant="outline" onClick={() => insertPrefix('### ')}>H3</Button>
+        <Button type="button" size="sm" variant="outline" onClick={() => wrapSelection('[', '](url)')}>Link</Button>
+        <Button type="button" size="sm" variant="outline" onClick={() => insertPrefix('- ')}>•</Button>
+        <Button type="button" size="sm" variant="outline" onClick={() => insertPrefix('1. ')}>1.</Button>
+        <Button type="button" size="sm" variant="outline" onClick={() => wrapSelection('`', '`')}>Code</Button>
+        <Button type="button" size="sm" variant="outline" onClick={() => insertPrefix('> ')}>&gt;</Button>
+      </div>
+      <Textarea
+        ref={textareaRef}
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        rows={rows}
+      />
+    </div>
+  );
+};
+
+export default MarkdownEditor;

--- a/src/components/NoteModal.tsx
+++ b/src/components/NoteModal.tsx
@@ -4,7 +4,7 @@ import { Note } from '@/types';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
+import MarkdownEditor from './MarkdownEditor';
 import { Label } from '@/components/ui/label';
 
 interface NoteModalProps {
@@ -68,10 +68,9 @@ const NoteModal: React.FC<NoteModalProps> = ({ isOpen, onClose, onSave, note }) 
           </div>
           <div>
             <Label htmlFor="text">Text (Markdown)</Label>
-            <Textarea
-              id="text"
+            <MarkdownEditor
               value={formData.text}
-              onChange={e => handleChange('text', e.target.value)}
+              onChange={val => handleChange('text', val)}
               rows={5}
             />
             {formData.text && (

--- a/src/pages/NoteDetail.tsx
+++ b/src/pages/NoteDetail.tsx
@@ -5,7 +5,7 @@ import { useTaskStore } from '@/hooks/useTaskStore';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft } from 'lucide-react';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
+import MarkdownEditor from '@/components/MarkdownEditor';
 import { Label } from '@/components/ui/label';
 import ReactMarkdown from 'react-markdown';
 
@@ -62,7 +62,7 @@ const NoteDetailPage: React.FC = () => {
             </div>
             <div>
               <Label htmlFor="text">Text (Markdown)</Label>
-              <Textarea id="text" rows={10} value={formData.text} onChange={e => handleChange('text', e.target.value)} />
+              <MarkdownEditor value={formData.text} onChange={val => handleChange('text', val)} rows={10} />
             </div>
             <div>
               <Label>Farbe</Label>


### PR DESCRIPTION
## Summary
- add `MarkdownEditor` component with formatting buttons
- use toolbar for adding notes in the modal
- integrate toolbar in note detail editing view

## Testing
- `npm run lint` *(fails: 30 errors, 26 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684f07216624832ab046c4e386dd3286