### PR TITLE
Improve Markdown editor in notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ npm start    # startet die gebaute App auf Port 3002
   - Notizen lassen sich anpinnen; die ersten drei angepinnten erscheinen auf der Startseite
   - Tasks lassen sich ebenfalls anpinnen; die ersten drei werden auf der Startseite gezeigt
   - Text kann im Markdown-Format geschrieben werden
+  - Eingebauter Editor bietet Icons und Tooltips für häufige Formatierungen (z. B. Listen, Links, Codeblöcke)
 - Lernkarten mit Spaced-Repetition-Training und Verwaltung eigener Karten
   - Decks lassen sich beim Lernen ein- oder ausblenden
   - Optionaler Zufallsmodus ohne Bewertung
@@ -167,7 +168,7 @@ npm start    # startet die gebaute App auf Port 3002
 6. Mit dem Sternsymbol kannst du eine Task anpinnen. Die ersten drei gepinnten erscheinen auf der Startseite.
 7. Mit `Strg+K` (oder über das Suchsymbol) öffnest du die **globale Suche**. Sie durchsucht Tasks, Notizen und Lernkarten und führt dich bei Auswahl direkt zum entsprechenden Eintrag.
 8. In der **Kalender**-Ansicht klickst du auf ein Datum, um alle bis dahin fälligen Aufgaben zu sehen. Dort kannst du die Tasks direkt öffnen, bearbeiten, Unteraufgaben anlegen oder löschen. Die **Statistiken** geben einen Überblick über erledigte Tasks.
-9. Unter **Notizen** kannst du unabhängige Notizen verwalten und per Drag & Drop sortieren. Gepinnte Notizen erscheinen auf der Startseite. Deine Inhalte kannst du dabei in Markdown verfassen. Beim Anklicken einer Notiz siehst du zunächst eine Vorschau, die du dort auch bearbeiten kannst.
+9. Unter **Notizen** kannst du unabhängige Notizen verwalten und per Drag & Drop sortieren. Gepinnte Notizen erscheinen auf der Startseite. Deine Inhalte kannst du dabei in Markdown verfassen. Beim Anklicken einer Notiz siehst du zunächst eine Vorschau, die du dort auch bearbeiten kannst. Der Editor stellt zahlreiche Schaltflächen für gängige Formatierungen bereit.
 10. Unter **Decks** legst du Kartendecks an und kannst sie bearbeiten. In der Detailansicht eines Decks fügst du einzelne Karten hinzu.
 11. Der Bereich **Karten** zeigt dir fällige Karten zum Lernen an. Dort kannst du
    gezielt Decks ein- oder ausblenden, einen Zufallsmodus aktivieren und im

--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -1,6 +1,27 @@
 import React, { useRef } from 'react';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
+import {
+  Bold,
+  Italic,
+  Strikethrough,
+  Heading1,
+  Heading2,
+  Heading3,
+  Link as LinkIcon,
+  Image as ImageIcon,
+  List,
+  ListOrdered,
+  Code,
+  Code2,
+  Quote,
+  Minus,
+} from 'lucide-react';
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui/tooltip';
 
 interface MarkdownEditorProps {
   value: string;
@@ -17,13 +38,29 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({ value, onChange, rows =
     const start = textarea.selectionStart;
     const end = textarea.selectionEnd;
     const selected = value.slice(start, end);
-    const newValue = value.slice(0, start) + prefix + selected + suffix + value.slice(end);
+    const newValue =
+      value.slice(0, start) + prefix + selected + suffix + value.slice(end);
     onChange(newValue);
     requestAnimationFrame(() => {
       textarea.focus();
       const cursor = start + prefix.length;
       textarea.selectionStart = cursor;
       textarea.selectionEnd = cursor + selected.length;
+    });
+  };
+
+  const insertBlock = (content: string) => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    const start = textarea.selectionStart;
+    const newValue =
+      value.slice(0, start) + content + value.slice(start);
+    onChange(newValue);
+    requestAnimationFrame(() => {
+      textarea.focus();
+      const cursor = start + content.length;
+      textarea.selectionStart = cursor;
+      textarea.selectionEnd = cursor;
     });
   };
 
@@ -34,16 +71,188 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({ value, onChange, rows =
   return (
     <div>
       <div className="flex flex-wrap gap-1 mb-2">
-        <Button type="button" size="sm" variant="outline" onClick={() => wrapSelection('**', '**')}>B</Button>
-        <Button type="button" size="sm" variant="outline" onClick={() => wrapSelection('*', '*')}>I</Button>
-        <Button type="button" size="sm" variant="outline" onClick={() => insertPrefix('# ')}>H1</Button>
-        <Button type="button" size="sm" variant="outline" onClick={() => insertPrefix('## ')}>H2</Button>
-        <Button type="button" size="sm" variant="outline" onClick={() => insertPrefix('### ')}>H3</Button>
-        <Button type="button" size="sm" variant="outline" onClick={() => wrapSelection('[', '](url)')}>Link</Button>
-        <Button type="button" size="sm" variant="outline" onClick={() => insertPrefix('- ')}>•</Button>
-        <Button type="button" size="sm" variant="outline" onClick={() => insertPrefix('1. ')}>1.</Button>
-        <Button type="button" size="sm" variant="outline" onClick={() => wrapSelection('`', '`')}>Code</Button>
-        <Button type="button" size="sm" variant="outline" onClick={() => insertPrefix('> ')}>&gt;</Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => wrapSelection('**', '**')}
+            >
+              <Bold />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Bold</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => wrapSelection('*', '*')}
+            >
+              <Italic />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Italic</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => wrapSelection('~~', '~~')}
+            >
+              <Strikethrough />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Strikethrough</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => insertPrefix('# ')}
+            >
+              <Heading1 />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Heading 1</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => insertPrefix('## ')}
+            >
+              <Heading2 />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Heading 2</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => insertPrefix('### ')}
+            >
+              <Heading3 />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Heading 3</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => wrapSelection('[', '](url)')}
+            >
+              <LinkIcon />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Link</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => wrapSelection('![', '](url)')}
+            >
+              <ImageIcon />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Image</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => insertPrefix('- ')}
+            >
+              <List />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Bullet List</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => insertPrefix('1. ')}
+            >
+              <ListOrdered />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Numbered List</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => insertPrefix('> ')}
+            >
+              <Quote />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Quote</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => wrapSelection('`', '`')}
+            >
+              <Code />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Inline Code</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => wrapSelection('\n```\n', '\n```\n')}
+            >
+              <Code2 />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Code Block</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => insertBlock('\n---\n')}
+            >
+              <Minus />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Horizontal Rule</TooltipContent>
+        </Tooltip>
       </div>
       <Textarea
         ref={textareaRef}


### PR DESCRIPTION
## Summary
- enhance MarkdownEditor with icons, tooltips and extra formatting
- document new editor features in README

## Testing
- `npm run lint` *(fails: 56 problems)*

------
https://chatgpt.com/codex/tasks/task_e_684f21b0d5f4832a85947609c9304a09