### PR TITLE
Add live preview when editing notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ npm start    # startet die gebaute App auf Port 3002
 7. Mit `Strg+K` (oder über das Suchsymbol) öffnest du die **globale Suche**. Sie durchsucht Tasks, Notizen und Lernkarten und führt dich bei Auswahl direkt zum entsprechenden Eintrag.
 8. In der **Zeitplan**-Ansicht wählst du einen Tag, eine Woche oder einen Monat aus. Aufgaben mit Uhrzeit erscheinen als Blöcke, solche ohne Zeit als Liste unterhalb des Plans. 
    Die **Statistiken** geben einen Überblick über erledigte Tasks.
-9. Unter **Notizen** kannst du unabhängige Notizen verwalten und per Drag & Drop sortieren. Gepinnte Notizen erscheinen auf der Startseite. Deine Inhalte kannst du dabei in Markdown verfassen. Beim Anklicken einer Notiz siehst du zunächst eine Vorschau, die du dort auch bearbeiten kannst. Der Editor stellt zahlreiche Schaltflächen für gängige Formatierungen bereit.
+9. Unter **Notizen** kannst du unabhängige Notizen verwalten und per Drag & Drop sortieren. Gepinnte Notizen erscheinen auf der Startseite. Deine Inhalte kannst du dabei in Markdown verfassen. Beim Anklicken einer Notiz siehst du zunächst eine Vorschau und kannst sie direkt bearbeiten. Auf dem Desktop erscheint nun während des Bearbeitens eine Live-Vorschau rechts neben dem Editor. Der Editor stellt zahlreiche Schaltflächen für gängige Formatierungen bereit.
 10. Unter **Decks** legst du Kartendecks an und kannst sie bearbeiten. In der Detailansicht eines Decks fügst du einzelne Karten hinzu.
 11. Der Bereich **Karten** zeigt dir fällige Karten zum Lernen an. Dort kannst du
    gezielt Decks ein- oder ausblenden, einen Zufallsmodus aktivieren und im

--- a/src/pages/NoteDetail.tsx
+++ b/src/pages/NoteDetail.tsx
@@ -56,28 +56,53 @@ const NoteDetailPage: React.FC = () => {
         </Button>
         {isEditing ? (
           <form className="space-y-4" onSubmit={e => { e.preventDefault(); handleSave(); }}>
-            <div>
-              <Label htmlFor="title">Titel *</Label>
-              <Input id="title" value={formData.title} onChange={e => handleChange('title', e.target.value)} required />
-            </div>
-            <div>
-              <Label htmlFor="text">Text (Markdown)</Label>
-              <MarkdownEditor value={formData.text} onChange={val => handleChange('text', val)} rows={10} />
-            </div>
-            <div>
-              <Label>Farbe</Label>
-              <div className="flex space-x-2 mt-2">
-                {colorOptions.map(color => (
-                  <button
-                    key={color}
-                    type="button"
-                    className={`w-8 h-8 rounded-full border-2 transition-all ${
-                      formData.color === color ? 'border-gray-800 scale-110' : 'border-gray-300 hover:scale-105'
-                    }`}
-                    style={{ backgroundColor: color }}
-                    onClick={() => handleChange('color', color)}
+            <div className="md:flex md:space-x-4">
+              <div className="md:w-1/2 space-y-4">
+                <div>
+                  <Label htmlFor="title">Titel *</Label>
+                  <Input
+                    id="title"
+                    value={formData.title}
+                    onChange={e => handleChange('title', e.target.value)}
+                    required
                   />
-                ))}
+                </div>
+                <div>
+                  <Label htmlFor="text">Text (Markdown)</Label>
+                  <MarkdownEditor
+                    value={formData.text}
+                    onChange={val => handleChange('text', val)}
+                    rows={10}
+                  />
+                </div>
+                <div>
+                  <Label>Farbe</Label>
+                  <div className="flex space-x-2 mt-2">
+                    {colorOptions.map(color => (
+                      <button
+                        key={color}
+                        type="button"
+                        className={`w-8 h-8 rounded-full border-2 transition-all ${
+                          formData.color === color
+                            ? 'border-gray-800 scale-110'
+                            : 'border-gray-300 hover:scale-105'
+                        }`}
+                        style={{ backgroundColor: color }}
+                        onClick={() => handleChange('color', color)}
+                      />
+                    ))}
+                  </div>
+                </div>
+              </div>
+              <div className="md:w-1/2 mt-4 md:mt-0">
+                <Label>Vorschau</Label>
+                <div className="p-2 border rounded-sm bg-background max-h-96 overflow-auto mt-2">
+                  {formData.text ? (
+                    <ReactMarkdown className="prose">{formData.text}</ReactMarkdown>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">Noch keine Vorschau</p>
+                  )}
+                </div>
               </div>
             </div>
             <div className="flex justify-end space-x-2 pt-4">


### PR DESCRIPTION
## Summary
- show a live preview next to the editor on the note detail page
- document the live preview in the README

## Testing
- `npm run lint` *(fails: no-empty statements and unexpected any types)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f3dc44c98832ab80c8bd58d73ef7d