### PR TITLE
Improve note editor layout

### DIFF
--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -27,9 +27,15 @@ interface MarkdownEditorProps {
   value: string;
   onChange: (value: string) => void;
   rows?: number;
+  className?: string;
 }
 
-const MarkdownEditor: React.FC<MarkdownEditorProps> = ({ value, onChange, rows = 5 }) => {
+const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
+  value,
+  onChange,
+  rows = 5,
+  className,
+}) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const wrapSelection = (prefix: string, suffix = '') => {
@@ -259,6 +265,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({ value, onChange, rows =
         value={value}
         onChange={e => onChange(e.target.value)}
         rows={rows}
+        className={className}
       />
     </div>
   );

--- a/src/pages/NoteDetail.tsx
+++ b/src/pages/NoteDetail.tsx
@@ -45,7 +45,7 @@ const NoteDetailPage: React.FC = () => {
   return (
     <div className="min-h-screen bg-background">
       <Navbar title="Notiz" onHomeClick={() => navigate('/notes')} />
-      <div className="max-w-6xl mx-auto py-8 px-4">
+      <div className="py-8 px-4 w-full">
         <Button
           variant="ghost"
           size="sm"
@@ -56,8 +56,8 @@ const NoteDetailPage: React.FC = () => {
         </Button>
         {isEditing ? (
           <form className="space-y-4" onSubmit={e => { e.preventDefault(); handleSave(); }}>
-            <div className="md:flex md:space-x-8">
-              <div className="md:w-2/3 space-y-4">
+            <div className="md:grid md:grid-cols-2 md:gap-8">
+              <div className="flex flex-col space-y-4 h-[60vh]">
                 <div>
                   <Label htmlFor="title">Titel *</Label>
                   <Input
@@ -72,7 +72,8 @@ const NoteDetailPage: React.FC = () => {
                   <MarkdownEditor
                     value={formData.text}
                     onChange={val => handleChange('text', val)}
-                    rows={10}
+                    rows={20}
+                    className="h-full"
                   />
                 </div>
                 <div>
@@ -94,9 +95,9 @@ const NoteDetailPage: React.FC = () => {
                   </div>
                 </div>
               </div>
-              <div className="md:w-1/3 mt-4 md:mt-0">
+              <div className="flex flex-col mt-4 md:mt-0 h-[60vh]">
                 <Label>Vorschau</Label>
-                <div className="p-2 border rounded-sm bg-background max-h-96 overflow-auto mt-2">
+                <div className="p-4 border rounded-sm bg-background flex-1 overflow-auto mt-2">
                   {formData.text ? (
                     <ReactMarkdown className="prose">{formData.text}</ReactMarkdown>
                   ) : (


### PR DESCRIPTION
## Summary
- accept `className` in `MarkdownEditor`
- enlarge note editor and preview on note details page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f41a55bac832abd1216b35fb4241b