### PR TITLE
Fix JSX structure in NoteDetail page

### DIFF
--- a/src/pages/NoteDetail.tsx
+++ b/src/pages/NoteDetail.tsx
@@ -121,6 +121,7 @@ const NoteDetailPage: React.FC = () => {
             </div>
           </div>
         )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- close missing `<div>` in NoteDetail page

## Testing
- `npm run lint` *(fails: parsing and type errors)*
- `npm run build` *(fails: MarkdownEditor compile error)*

------
https://chatgpt.com/codex/tasks/task_e_684f45efe714832ab174f8829df5277a