### PR TITLE
Fix syntax error in MarkdownEditor

### DIFF
--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -86,7 +86,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
               type="button"
               size="sm"
               variant="outline"
-              onClick={() => wrapSelection('**', '**')
+              onClick={() => wrapSelection('**', '**')}
             >
               <Bold />
             </Button>
@@ -99,7 +99,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
               type="button"
               size="sm"
               variant="outline"
-              onClick={() => wrapSelection('*', '*')
+              onClick={() => wrapSelection('*', '*')}
             >
               <Italic />
             </Button>
@@ -290,8 +290,8 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
             className
           )}
         />
-      )
-    </div>
+        )}
+      </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- fix missing JSX closures in MarkdownEditor

## Testing
- `npm run build`
- `npm run lint` *(fails: Unexpected any, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_684f471f88a4832aae0aebd78f674c50