### PR TITLE
Fix cursor visibility in markdown editor

### DIFF
--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -353,10 +353,9 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
             }
           }}
           className={cn(
-            'absolute inset-0 p-8 min-h-[80px] opacity-0 border rounded-sm shadow-sm focus-visible:ring-0 focus-visible:outline-none resize-none',
+            'absolute inset-0 p-8 min-h-[80px] text-transparent caret-black border rounded-sm shadow-sm focus-visible:ring-0 focus-visible:outline-none resize-none',
             className
           )}
-          style={{ caretColor: 'black' }}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- show caret while keeping text hidden in `MarkdownEditor`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684f5548ea30832a8b514d22632dd581