### PR TITLE
Add multilingual support

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,12 @@ npm start    # startet die gebaute App auf Port 3002
   Einstellungen mitgespeichert und abgeglichen, der Ordnerpfad
   selbst wird jedoch nicht in der Sync-Datei gespeichert.
 - Standard-Priorität für neue Tasks einstellbar
+- Mehrsprachige Oberfläche (Deutsch, Englisch) auswählbar
 - Mehrere Theme-Voreinstellungen (light, dark, ocean, dark-red, hacker,
   motivation) und ein eigenes "Custom"-Theme wählbar
 - Im Custom-Theme lassen sich Farben der Oberfläche und Karten individuell anpassen
 - Neuer "Info"-Reiter in den Einstellungen zeigt Versionsnummer, Release Notes und README
+- Im Reiter "Sprache" lässt sich Deutsch oder Englisch auswählen
 - Untermenü "Server Info" in den Einstellungen listet IP-Adressen, Port und fertige URLs auf
 
 ## Verwendung

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "cmdk": "^1.0.0",
         "date-fns": "^3.6.0",
         "embla-carousel-react": "^8.3.0",
+        "i18next": "^23.10.1",
         "input-otp": "^1.2.4",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
@@ -52,6 +53,7 @@
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
+        "react-i18next": "^13.2.2",
         "react-markdown": "^9.0.0",
         "react-resizable-panels": "^2.1.3",
         "react-router-dom": "^6.26.2",
@@ -4843,6 +4845,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -4851,6 +4862,29 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "23.16.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
+      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/ieee754": {
@@ -6598,6 +6632,28 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-i18next": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-13.5.0.tgz",
+      "integrity": "sha512-CFJ5NDGJ2MUyBohEHxljOq/39NQ972rh1ajnadG9BjTk+UXbHLq4z5DKEbEQBDoIhUmmbuS/fIMJKo6VOax1HA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.22.5",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {
@@ -8360,6 +8416,15 @@
         "@esbuild/win32-arm64": "0.21.5",
         "@esbuild/win32-ia32": "0.21.5",
         "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,9 @@
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
     "zod": "^3.23.8",
-    "zustand": "^4.5.2"
+    "zustand": "^4.5.2",
+    "i18next": "^23.10.1",
+    "react-i18next": "^13.2.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import {
@@ -31,6 +32,7 @@ interface NavbarProps {
 }
 
 const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
+  const { t } = useTranslation()
   const [showMobileMenu, setShowMobileMenu] = React.useState(false)
   const [openMenu, setOpenMenu] = React.useState<string | null>(null)
   return (
@@ -89,7 +91,7 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                   className="flex items-center"
                 >
                   <ClipboardList className="h-4 w-4 mr-2" />
-                  Tasks
+                  {t('navbar.tasks')}
                   <ChevronDown
                     className={`ml-1 h-3 w-3 transition-transform ${openMenu === 'tasks' ? 'rotate-180' : ''}`}
                   />
@@ -98,27 +100,27 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
               <DropdownMenuContent className="bg-background z-50">
                 <DropdownMenuItem asChild>
                   <Link to="/tasks" className="flex items-center">
-                    <LayoutGrid className="h-4 w-4 mr-2" /> Übersicht
+                    <LayoutGrid className="h-4 w-4 mr-2" /> {t('navbar.overview')}
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
                   <Link to="/kanban" className="flex items-center">
-                    <Columns className="h-4 w-4 mr-2" /> Kanban
+                    <Columns className="h-4 w-4 mr-2" /> {t('navbar.kanban')}
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
                   <Link to="/timeblocks" className="flex items-center">
-                    <CalendarIcon className="h-4 w-4 mr-2" /> Zeitplan
+                    <CalendarIcon className="h-4 w-4 mr-2" /> {t('navbar.schedule')}
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
                   <Link to="/recurring" className="flex items-center">
-                    <List className="h-4 w-4 mr-2" /> Wiederkehrend
+                    <List className="h-4 w-4 mr-2" /> {t('navbar.recurring')}
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
                   <Link to="/statistics" className="flex items-center">
-                    <BarChart3 className="h-4 w-4 mr-2" /> Task-Statistiken
+                    <BarChart3 className="h-4 w-4 mr-2" /> {t('navbar.statistics')}
                   </Link>
                 </DropdownMenuItem>
               </DropdownMenuContent>
@@ -136,7 +138,7 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                   className="flex items-center"
                 >
                   <GraduationCap className="h-4 w-4 mr-2" />
-                  Lernen
+                  {t('navbar.learning')}
                   <ChevronDown
                     className={`ml-1 h-3 w-3 transition-transform ${openMenu === 'learning' ? 'rotate-180' : ''}`}
                   />
@@ -145,22 +147,22 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
               <DropdownMenuContent className="bg-background z-50">
                 <DropdownMenuItem asChild>
                   <Link to="/flashcards" className="flex items-center">
-                    <BookOpen className="h-4 w-4 mr-2" /> Karten
+                    <BookOpen className="h-4 w-4 mr-2" /> {t('navbar.cards')}
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
                   <Link to="/flashcards/manage" className="flex items-center">
-                    <Pencil className="h-4 w-4 mr-2" /> Decks
+                    <Pencil className="h-4 w-4 mr-2" /> {t('navbar.decks')}
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
                   <Link to="/pomodoro" className="flex items-center">
-                    <Timer className="h-4 w-4 mr-2" /> Pomodoro
+                    <Timer className="h-4 w-4 mr-2" /> {t('navbar.pomodoro')}
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
                   <Link to="/flashcards/stats" className="flex items-center">
-                    <BarChart3 className="h-4 w-4 mr-2" /> Statistiken
+                    <BarChart3 className="h-4 w-4 mr-2" /> {t('navbar.cardStatistics')}
                   </Link>
                 </DropdownMenuItem>
               </DropdownMenuContent>
@@ -168,12 +170,12 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
 
             <Link to="/notes">
               <Button variant="outline" size="sm">
-                <List className="h-4 w-4 mr-2" /> Notizen
+                <List className="h-4 w-4 mr-2" /> {t('navbar.notes')}
               </Button>
             </Link>
             <Link to="/settings">
               <Button variant="outline" size="sm">
-                <Cog className="h-4 w-4 mr-2" /> Einstellungen
+                <Cog className="h-4 w-4 mr-2" /> {t('navbar.settings')}
               </Button>
             </Link>
           </div>
@@ -181,82 +183,82 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
         {showMobileMenu && (
           <div className="sm:hidden pb-4 space-y-4">
             <div className="space-y-2">
-              <p className="text-xs font-semibold text-muted-foreground">Tasks</p>
+              <p className="text-xs font-semibold text-muted-foreground">{t('navbar.tasks')}</p>
               <div className="flex flex-wrap gap-2">
                 <Link to="/tasks" className="flex-1">
                   <Button variant="outline" size="sm" className="w-full">
                     <LayoutGrid className="h-4 w-4 mr-2" />
-                    Übersicht
+                    {t('navbar.overview')}
                   </Button>
                 </Link>
                 <Link to="/kanban" className="flex-1">
                   <Button variant="outline" size="sm" className="w-full">
                     <Columns className="h-4 w-4 mr-2" />
-                    Kanban
+                    {t('navbar.kanban')}
                   </Button>
                 </Link>
                 <Link to="/timeblocks" className="flex-1">
                   <Button variant="outline" size="sm" className="w-full">
                     <CalendarIcon className="h-4 w-4 mr-2" />
-                    Zeitplan
+                    {t('navbar.schedule')}
                   </Button>
                 </Link>
                 <Link to="/recurring" className="flex-1">
                   <Button variant="outline" size="sm" className="w-full">
                     <List className="h-4 w-4 mr-2" />
-                    Wiederkehrend
+                    {t('navbar.recurring')}
                   </Button>
                 </Link>
                 <Link to="/statistics" className="flex-1">
                   <Button variant="outline" size="sm" className="w-full">
                     <BarChart3 className="h-4 w-4 mr-2" />
-                    Task-Statistiken
+                    {t('navbar.statistics')}
                   </Button>
                 </Link>
               </div>
             </div>
             <div className="space-y-2">
-              <p className="text-xs font-semibold text-muted-foreground">Lernen</p>
+              <p className="text-xs font-semibold text-muted-foreground">{t('navbar.learning')}</p>
               <div className="flex flex-wrap gap-2">
                 <Link to="/flashcards" className="flex-1">
                   <Button variant="outline" size="sm" className="w-full">
                     <BookOpen className="h-4 w-4 mr-2" />
-                    Karten
+                    {t('navbar.cards')}
                   </Button>
                 </Link>
                 <Link to="/flashcards/manage" className="flex-1">
                   <Button variant="outline" size="sm" className="w-full">
                     <Pencil className="h-4 w-4 mr-2" />
-                    Decks
+                    {t('navbar.decks')}
                   </Button>
                 </Link>
                 <Link to="/pomodoro" className="flex-1">
                   <Button variant="outline" size="sm" className="w-full">
                     <Timer className="h-4 w-4 mr-2" />
-                    Pomodoro
+                    {t('navbar.pomodoro')}
                   </Button>
                 </Link>
                 <Link to="/flashcards/stats" className="flex-1">
                   <Button variant="outline" size="sm" className="w-full">
                     <BarChart3 className="h-4 w-4 mr-2" />
-                    Statistiken
+                    {t('navbar.cardStatistics')}
                   </Button>
                 </Link>
               </div>
             </div>
             <div className="space-y-2">
-              <p className="text-xs font-semibold text-muted-foreground">Notizen</p>
+              <p className="text-xs font-semibold text-muted-foreground">{t('navbar.notes')}</p>
               <div className="flex flex-wrap gap-2">
                 <Link to="/notes" className="flex-1">
                   <Button variant="outline" size="sm" className="w-full">
                     <List className="h-4 w-4 mr-2" />
-                    Notizen
+                    {t('navbar.notes')}
                   </Button>
                 </Link>
               </div>
             </div>
             <div className="space-y-2">
-              <p className="text-xs font-semibold text-muted-foreground">Suche</p>
+              <p className="text-xs font-semibold text-muted-foreground">{t('navbar.search')}</p>
               <div className="flex flex-wrap gap-2">
                 <Button
                   variant="outline"
@@ -268,17 +270,17 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                   }}
                 >
                   <Search className="h-4 w-4 mr-2" />
-                  Suche
+                  {t('navbar.search')}
                 </Button>
               </div>
             </div>
             <div className="space-y-2">
-              <p className="text-xs font-semibold text-muted-foreground">Einstellungen</p>
+              <p className="text-xs font-semibold text-muted-foreground">{t('navbar.settings')}</p>
               <div className="flex flex-wrap gap-2">
                 <Link to="/settings" className="flex-1">
                   <Button variant="outline" size="sm" className="w-full">
                     <Cog className="h-4 w-4 mr-2" />
-                    Einstellungen
+                    {t('navbar.settings')}
                   </Button>
                 </Link>
               </div>

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from 'react'
 import { allHomeSections } from '@/utils/homeSections'
+import i18n from '@/lib/i18n'
 
 
 export type ShortcutKeys = {
@@ -29,6 +30,7 @@ const defaultFlashcardSettings = {
 }
 const defaultSyncInterval = 5
 const defaultTaskPriority: 'low' | 'medium' | 'high' = 'medium'
+const defaultLanguage = 'de'
 const defaultTheme = {
   background: '0 0% 100%',
   foreground: '222.2 84% 4.9%',
@@ -155,6 +157,8 @@ interface SettingsContextValue {
   updateSyncInterval: (value: number) => void
   syncFolder: string
   updateSyncFolder: (folder: string) => void
+  language: string
+  updateLanguage: (lang: string) => void
 }
 
 const SettingsContext = createContext<SettingsContextValue | undefined>(undefined)
@@ -188,6 +192,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const [showPinnedNotes, setShowPinnedNotes] = useState(true)
   const [syncFolder, setSyncFolder] = useState('')
   const [syncInterval, setSyncInterval] = useState(defaultSyncInterval)
+  const [language, setLanguage] = useState(defaultLanguage)
 
   useEffect(() => {
     const load = async () => {
@@ -256,6 +261,10 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
           if (typeof data.syncInterval === 'number') {
             setSyncInterval(data.syncInterval)
           }
+          if (typeof data.language === 'string') {
+            setLanguage(data.language)
+            i18n.changeLanguage(data.language)
+          }
         }
       } catch (err) {
         console.error('Fehler beim Laden der Einstellungen', err)
@@ -284,7 +293,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
           flashcardSessionSize,
           flashcardDefaultMode,
           syncFolder,
-          syncInterval
+          syncInterval,
+          language
         })
       })
       } catch (err) {
@@ -307,7 +317,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     flashcardSessionSize,
     flashcardDefaultMode,
     syncFolder,
-    syncInterval
+    syncInterval,
+    language
   ])
 
   useEffect(() => {
@@ -367,6 +378,11 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     setSyncInterval(value)
   }
 
+  const updateLanguage = (lang: string) => {
+    setLanguage(lang)
+    i18n.changeLanguage(lang)
+  }
+
   const toggleHomeSection = (section: string) => {
     setHomeSections(prev =>
       prev.includes(section)
@@ -422,7 +438,9 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         syncInterval,
         updateSyncInterval,
         syncFolder,
-        updateSyncFolder
+        updateSyncFolder,
+        language,
+        updateLanguage
       }}
     >
       {children}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,19 @@
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+
+import en from '@/locales/en/translation.json'
+import de from '@/locales/de/translation.json'
+
+void i18n
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { translation: en },
+      de: { translation: de }
+    },
+    lng: 'de',
+    fallbackLng: 'en',
+    interpolation: { escapeValue: false }
+  })
+
+export default i18n

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1,0 +1,39 @@
+{
+  "navbar": {
+    "tasks": "Tasks",
+    "overview": "Übersicht",
+    "kanban": "Kanban",
+    "schedule": "Zeitplan",
+    "recurring": "Wiederkehrend",
+    "statistics": "Task-Statistiken",
+    "learning": "Lernen",
+    "cards": "Karten",
+    "decks": "Decks",
+    "pomodoro": "Pomodoro",
+    "cardStatistics": "Statistiken",
+    "notes": "Notizen",
+    "settings": "Einstellungen",
+    "search": "Suche"
+  },
+  "home": {
+    "pinnedTasks": "Gepinnte Tasks",
+    "pinnedNotes": "Gepinnte Notizen"
+  },
+  "settings": {
+    "tabs": {
+      "shortcuts": "Shortcuts",
+      "pomodoro": "Pomodoro",
+      "flashcards": "Karten",
+      "tasks": "Tasks",
+      "home": "Startseite",
+      "theme": "Theme",
+      "data": "Daten",
+      "server": "Server",
+      "info": "Info",
+      "language": "Sprache"
+    },
+    "languageLabel": "Sprache der Anwendung",
+    "english": "Englisch",
+    "german": "Deutsch"
+  }
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,0 +1,39 @@
+{
+  "navbar": {
+    "tasks": "Tasks",
+    "overview": "Overview",
+    "kanban": "Kanban",
+    "schedule": "Schedule",
+    "recurring": "Recurring",
+    "statistics": "Task Statistics",
+    "learning": "Learning",
+    "cards": "Cards",
+    "decks": "Decks",
+    "pomodoro": "Pomodoro",
+    "cardStatistics": "Statistics",
+    "notes": "Notes",
+    "settings": "Settings",
+    "search": "Search"
+  },
+  "home": {
+    "pinnedTasks": "Pinned Tasks",
+    "pinnedNotes": "Pinned Notes"
+  },
+  "settings": {
+    "tabs": {
+      "shortcuts": "Shortcuts",
+      "pomodoro": "Pomodoro",
+      "flashcards": "Cards",
+      "tasks": "Tasks",
+      "home": "Home",
+      "theme": "Theme",
+      "data": "Data",
+      "server": "Server",
+      "info": "Info",
+      "language": "Language"
+    },
+    "languageLabel": "App Language",
+    "english": "English",
+    "german": "German"
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import './lib/i18n'
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import Navbar from '@/components/Navbar';
 import { Card, CardContent, CardTitle } from '@/components/ui/card';
@@ -10,6 +11,7 @@ import NoteCard from '@/components/NoteCard';
 import { flattenTasks } from '@/utils/taskUtils';
 
 const Home: React.FC = () => {
+  const { t } = useTranslation();
   const { notes, tasks } = useTaskStore();
   const {
     homeSections,
@@ -56,7 +58,7 @@ const Home: React.FC = () => {
         {showPinnedTasks && pinnedTasks.length > 0 && (
           <div className="mb-6">
             <h2 className="text-lg sm:text-xl font-semibold text-foreground mb-3">
-              Gepinnte Tasks
+              {t('home.pinnedTasks')}
             </h2>
             <div className="space-y-3">
               {pinnedTasks.map(item => (
@@ -84,7 +86,7 @@ const Home: React.FC = () => {
         {showPinnedNotes && pinnedNotes.length > 0 && (
           <div>
             <h2 className="text-lg sm:text-xl font-semibold text-foreground mb-3">
-              Gepinnte Notizen
+              {t('home.pinnedNotes')}
             </h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
               {pinnedNotes.map(note => (

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import Navbar from '@/components/Navbar'
 import { useSettings, themePresets } from '@/hooks/useSettings'
 import { Input } from '@/components/ui/input'
@@ -62,8 +63,12 @@ const SettingsPage: React.FC = () => {
     syncInterval,
     updateSyncInterval,
     syncFolder,
-    updateSyncFolder
+    updateSyncFolder,
+    language,
+    updateLanguage
   } = useSettings()
+
+  const { t } = useTranslation()
 
   const [serverInfo, setServerInfo] = useState<ServerInfo | null>(null)
 
@@ -265,20 +270,21 @@ const SettingsPage: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      <Navbar title="Einstellungen" />
+      <Navbar title={t('navbar.settings')} />
       <div className="max-w-2xl mx-auto px-4 py-6">
         <Tabs defaultValue="shortcuts" className="space-y-4">
-          <TabsList className="grid w-full grid-cols-9">
-            <TabsTrigger value="shortcuts">Shortcuts</TabsTrigger>
-            <TabsTrigger value="pomodoro">Pomodoro</TabsTrigger>
-            <TabsTrigger value="flashcards">Karten</TabsTrigger>
-            <TabsTrigger value="tasks">Tasks</TabsTrigger>
-            <TabsTrigger value="home">Startseite</TabsTrigger>
-            <TabsTrigger value="theme">Theme</TabsTrigger>
-            <TabsTrigger value="data">Daten</TabsTrigger>
-            <TabsTrigger value="server">Server</TabsTrigger>
-            <TabsTrigger value="info">Info</TabsTrigger>
-          </TabsList>
+        <TabsList className="grid w-full grid-cols-10">
+          <TabsTrigger value="shortcuts">{t('settings.tabs.shortcuts')}</TabsTrigger>
+          <TabsTrigger value="pomodoro">{t('settings.tabs.pomodoro')}</TabsTrigger>
+          <TabsTrigger value="flashcards">{t('settings.tabs.flashcards')}</TabsTrigger>
+          <TabsTrigger value="tasks">{t('settings.tabs.tasks')}</TabsTrigger>
+          <TabsTrigger value="home">{t('settings.tabs.home')}</TabsTrigger>
+          <TabsTrigger value="theme">{t('settings.tabs.theme')}</TabsTrigger>
+          <TabsTrigger value="language">{t('settings.tabs.language')}</TabsTrigger>
+          <TabsTrigger value="data">{t('settings.tabs.data')}</TabsTrigger>
+          <TabsTrigger value="server">{t('settings.tabs.server')}</TabsTrigger>
+          <TabsTrigger value="info">{t('settings.tabs.info')}</TabsTrigger>
+        </TabsList>
           <TabsContent value="shortcuts" className="space-y-4">
             <div>
               <Label htmlFor="open">Command Palette</Label>
@@ -576,9 +582,26 @@ const SettingsPage: React.FC = () => {
                 value={hslToHex(theme['pomodoro-break-ring'])}
                 onChange={e => updateTheme('pomodoro-break-ring', hexToHsl(e.target.value))}
               />
-            </div>
-          </TabsContent>
-          <TabsContent value="data" className="space-y-4">
+          </div>
+        </TabsContent>
+        <TabsContent value="language" className="space-y-4">
+          <div>
+            <Label htmlFor="languageSelect">{t('settings.languageLabel')}</Label>
+            <Select
+              value={language}
+              onValueChange={updateLanguage}
+            >
+              <SelectTrigger id="languageSelect">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="de">{t('settings.german')}</SelectItem>
+                <SelectItem value="en">{t('settings.english')}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </TabsContent>
+        <TabsContent value="data" className="space-y-4">
             <h2 className="font-semibold">Datenexport / -import</h2>
             <div className="space-y-2">
               <p className="font-medium">Sync-Ordner</p>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -11,6 +11,7 @@
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",
+    "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx",
 

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -10,6 +10,7 @@
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",
+    "resolveJsonModule": true,
     "noEmit": true,
 
     /* Linting */


### PR DESCRIPTION
## Summary
- implement i18n config and translations for English and German
- add language selection to settings page
- localize navbar and home page
- update app initialization and settings context
- document new feature in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_684fd49ed920832a87af267d415b5294