### PR TITLE
Enhance i18n for notes and home sections

### DIFF
--- a/src/components/NoteModal.tsx
+++ b/src/components/NoteModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Note } from '@/types';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
@@ -16,6 +17,7 @@ interface NoteModalProps {
 }
 
 const NoteModal: React.FC<NoteModalProps> = ({ isOpen, onClose, onSave, note }) => {
+  const { t } = useTranslation();
   const [formData, setFormData] = useState({
     title: '',
     text: '',
@@ -52,11 +54,11 @@ const NoteModal: React.FC<NoteModalProps> = ({ isOpen, onClose, onSave, note }) 
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>{note ? 'Notiz bearbeiten' : 'Neue Notiz'}</DialogTitle>
+          <DialogTitle>{note ? t('noteModal.editTitle') : t('noteModal.newTitle')}</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <Label htmlFor="title">Titel *</Label>
+            <Label htmlFor="title">{t('noteModal.title')}</Label>
             <Input
               id="title"
               value={formData.title}
@@ -66,7 +68,7 @@ const NoteModal: React.FC<NoteModalProps> = ({ isOpen, onClose, onSave, note }) 
             />
           </div>
           <div>
-            <Label htmlFor="text">Text (Markdown)</Label>
+            <Label htmlFor="text">{t('noteModal.text')}</Label>
             <MarkdownEditor
               value={formData.text}
               onChange={val => handleChange('text', val)}
@@ -74,7 +76,7 @@ const NoteModal: React.FC<NoteModalProps> = ({ isOpen, onClose, onSave, note }) 
             />
           </div>
           <div>
-            <Label>Farbe</Label>
+            <Label>{t('noteModal.color')}</Label>
             <div className="flex space-x-2 mt-2">
               {colorOptions.map(color => (
                 <button
@@ -91,9 +93,11 @@ const NoteModal: React.FC<NoteModalProps> = ({ isOpen, onClose, onSave, note }) 
           </div>
           <div className="flex justify-end space-x-2 pt-4">
             <Button type="button" variant="outline" onClick={onClose}>
-              Abbrechen
+              {t('common.cancel')}
             </Button>
-            <Button type="submit">{note ? 'Speichern' : 'Erstellen'}</Button>
+            <Button type="submit">
+              {note ? t('common.save') : t('common.create')}
+            </Button>
           </div>
         </form>
       </DialogContent>

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -35,5 +35,37 @@
     "languageLabel": "Sprache der Anwendung",
     "english": "Englisch",
     "german": "Deutsch"
+  },
+  "noteModal": {
+    "editTitle": "Notiz bearbeiten",
+    "newTitle": "Neue Notiz",
+    "title": "Titel *",
+    "text": "Text (Markdown)",
+    "color": "Farbe"
+  },
+  "common": {
+    "cancel": "Abbrechen",
+    "save": "Speichern",
+    "create": "Erstellen",
+    "edit": "Bearbeiten",
+    "delete": "Löschen",
+    "back": "Zurück"
+  },
+  "noteDetail": {
+    "notFound": "Notiz nicht gefunden.",
+    "title": "Notiz"
+  },
+  "homeSections": {
+    "tasks": "Tasks",
+    "kanban": "Kanban",
+    "schedule": "Zeitplan",
+    "statistics": "Task-Statistiken",
+    "cards": "Karten",
+    "decks": "Decks",
+    "cardStats": "Karten-Statistik",
+    "pomodoro": "Pomodoro",
+    "notes": "Notizen",
+    "recurring": "Wiederkehrend",
+    "settings": "Einstellungen"
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -35,5 +35,37 @@
     "languageLabel": "App Language",
     "english": "English",
     "german": "German"
+  },
+  "noteModal": {
+    "editTitle": "Edit Note",
+    "newTitle": "New Note",
+    "title": "Title *",
+    "text": "Text (Markdown)",
+    "color": "Color"
+  },
+  "common": {
+    "cancel": "Cancel",
+    "save": "Save",
+    "create": "Create",
+    "edit": "Edit",
+    "delete": "Delete",
+    "back": "Back"
+  },
+  "noteDetail": {
+    "notFound": "Note not found.",
+    "title": "Note"
+  },
+  "homeSections": {
+    "tasks": "Tasks",
+    "kanban": "Kanban",
+    "schedule": "Schedule",
+    "statistics": "Task Statistics",
+    "cards": "Cards",
+    "decks": "Decks",
+    "cardStats": "Card Statistics",
+    "pomodoro": "Pomodoro",
+    "notes": "Notes",
+    "recurring": "Recurring",
+    "settings": "Settings"
   }
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -48,7 +48,7 @@ const Home: React.FC = () => {
                 <Card className="hover:shadow-md transition-all text-center">
                   <CardContent className="py-8">
                     <sec.icon className="h-8 w-8 mx-auto mb-2" />
-                    <CardTitle>{sec.label}</CardTitle>
+                    <CardTitle>{t(sec.labelKey)}</CardTitle>
                   </CardContent>
                 </Card>
               </Link>

--- a/src/pages/NoteDetail.tsx
+++ b/src/pages/NoteDetail.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useParams, useNavigate } from 'react-router-dom';
 import Navbar from '@/components/Navbar';
 import { useTaskStore } from '@/hooks/useTaskStore';
@@ -11,6 +12,7 @@ import ReactMarkdown from 'react-markdown';
 const NoteDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const { notes, updateNote, deleteNote } = useTaskStore();
   const note = notes.find(n => n.id === id);
 
@@ -39,11 +41,11 @@ const NoteDetailPage: React.FC = () => {
     }
   };
 
-  if (!note) return <div className="p-4">Notiz nicht gefunden.</div>;
+  if (!note) return <div className="p-4">{t('noteDetail.notFound')}</div>;
 
   return (
     <div className="min-h-screen bg-background">
-      <Navbar title="Notiz" onHomeClick={() => navigate('/notes')} />
+      <Navbar title={t('noteDetail.title')} onHomeClick={() => navigate('/notes')} />
       <div className="py-8 px-4 w-full flex justify-center">
         <div className="w-full max-w-4xl space-y-4">
           <Button
@@ -51,7 +53,7 @@ const NoteDetailPage: React.FC = () => {
             size="sm"
             onClick={() => navigate('/notes')}
           >
-            <ArrowLeft className="h-4 w-4 mr-2" /> Zurück
+            <ArrowLeft className="h-4 w-4 mr-2" /> {t('common.back')}
           </Button>
         {isEditing ? (
           <form
@@ -63,7 +65,7 @@ const NoteDetailPage: React.FC = () => {
           >
             <Input
               id="title"
-              placeholder="Titel *"
+              placeholder={t('noteModal.title')}
               value={formData.title}
               onChange={e => handleChange('title', e.target.value)}
               required
@@ -94,9 +96,9 @@ const NoteDetailPage: React.FC = () => {
             </div>
             <div className="flex justify-end gap-2">
               <Button type="button" variant="outline" onClick={() => setIsEditing(false)}>
-                Abbrechen
+                {t('common.cancel')}
               </Button>
-              <Button type="submit">Speichern</Button>
+              <Button type="submit">{t('common.save')}</Button>
             </div>
           </form>
         ) : (
@@ -107,7 +109,7 @@ const NoteDetailPage: React.FC = () => {
             <ReactMarkdown className="prose mx-auto">{note.text}</ReactMarkdown>
             <div className="flex justify-end space-x-2 pt-4">
               <Button variant="outline" onClick={() => setIsEditing(true)}>
-                Bearbeiten
+                {t('common.edit')}
               </Button>
               <Button
                 variant="destructive"
@@ -116,7 +118,7 @@ const NoteDetailPage: React.FC = () => {
                   navigate('/notes');
                 }}
               >
-                Löschen
+                {t('common.delete')}
               </Button>
             </div>
           </div>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -435,7 +435,7 @@ const SettingsPage: React.FC = () => {
                                   checked={homeSections.includes(sec.key)}
                                   onCheckedChange={() => toggleHomeSection(sec.key)}
                                 />
-                                <Label htmlFor={sec.key}>{sec.label}</Label>
+                                <Label htmlFor={sec.key}>{t(sec.labelKey)}</Label>
                               </div>
                               <GripVertical className="h-4 w-4 text-muted-foreground" />
                             </div>

--- a/src/utils/homeSections.ts
+++ b/src/utils/homeSections.ts
@@ -13,21 +13,21 @@ import {
 
 export interface HomeSection {
   key: string
-  label: string
+  labelKey: string
   path: string
   icon: LucideIcon
 }
 
 export const allHomeSections: HomeSection[] = [
-  { key: 'tasks', label: 'Tasks', path: '/tasks', icon: ClipboardList },
-  { key: 'kanban', label: 'Kanban', path: '/kanban', icon: Columns },
-  { key: 'timeblocks', label: 'Zeitplan', path: '/timeblocks', icon: CalendarIcon },
-  { key: 'statistics', label: 'Task-Statistiken', path: '/statistics', icon: BarChart3 },
-  { key: 'flashcards', label: 'Karten', path: '/flashcards', icon: BookOpen },
-  { key: 'decks', label: 'Decks', path: '/flashcards/manage', icon: Pencil },
-  { key: 'flashcard-stats', label: 'Karten-Statistik', path: '/flashcards/stats', icon: BarChart3 },
-  { key: 'pomodoro', label: 'Pomodoro', path: '/pomodoro', icon: Timer },
-  { key: 'notes', label: 'Notizen', path: '/notes', icon: List },
-  { key: 'recurring', label: 'Wiederkehrend', path: '/recurring', icon: List },
-  { key: 'settings', label: 'Einstellungen', path: '/settings', icon: Cog }
+  { key: 'tasks', labelKey: 'homeSections.tasks', path: '/tasks', icon: ClipboardList },
+  { key: 'kanban', labelKey: 'homeSections.kanban', path: '/kanban', icon: Columns },
+  { key: 'timeblocks', labelKey: 'homeSections.schedule', path: '/timeblocks', icon: CalendarIcon },
+  { key: 'statistics', labelKey: 'homeSections.statistics', path: '/statistics', icon: BarChart3 },
+  { key: 'flashcards', labelKey: 'homeSections.cards', path: '/flashcards', icon: BookOpen },
+  { key: 'decks', labelKey: 'homeSections.decks', path: '/flashcards/manage', icon: Pencil },
+  { key: 'flashcard-stats', labelKey: 'homeSections.cardStats', path: '/flashcards/stats', icon: BarChart3 },
+  { key: 'pomodoro', labelKey: 'homeSections.pomodoro', path: '/pomodoro', icon: Timer },
+  { key: 'notes', labelKey: 'homeSections.notes', path: '/notes', icon: List },
+  { key: 'recurring', labelKey: 'homeSections.recurring', path: '/recurring', icon: List },
+  { key: 'settings', labelKey: 'homeSections.settings', path: '/settings', icon: Cog }
 ]


### PR DESCRIPTION
## Summary
- extend translations for note dialogs, note detail, and home sections
- refactor `homeSections` to use translation keys
- update Home and Settings pages to display translated labels

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe8675480832a917dbe3f6e160f39