### PR TITLE
Add translations for multiple pages

### DIFF
--- a/src/components/CategoryModal.tsx
+++ b/src/components/CategoryModal.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Category, CategoryFormData } from '@/types';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
@@ -20,6 +21,7 @@ const CategoryModal: React.FC<CategoryModalProps> = ({
   onSave,
   category
 }) => {
+  const { t } = useTranslation();
   const [formData, setFormData] = useState<CategoryFormData>({
     name: '',
     description: '',
@@ -66,36 +68,36 @@ const CategoryModal: React.FC<CategoryModalProps> = ({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>
-            {category ? 'Kategorie bearbeiten' : 'Neue Kategorie erstellen'}
+            {category ? t('categoryModal.editTitle') : t('categoryModal.newTitle')}
           </DialogTitle>
         </DialogHeader>
         
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <Label htmlFor="name">Name *</Label>
+            <Label htmlFor="name">{t('categoryModal.name')}</Label>
             <Input
               id="name"
               value={formData.name}
               onChange={(e) => handleChange('name', e.target.value)}
-              placeholder="Kategorie-Name eingeben..."
+              placeholder={t('categoryModal.placeholderName')}
               required
               autoFocus
             />
           </div>
 
           <div>
-            <Label htmlFor="description">Beschreibung</Label>
+            <Label htmlFor="description">{t('categoryModal.description')}</Label>
             <Textarea
               id="description"
               value={formData.description}
               onChange={(e) => handleChange('description', e.target.value)}
-              placeholder="Optionale Beschreibung..."
+              placeholder={t('categoryModal.placeholderDescription')}
               rows={3}
             />
           </div>
 
           <div>
-            <Label>Farbe</Label>
+            <Label>{t('categoryModal.color')}</Label>
             <div className="flex space-x-2 mt-2">
               {colorOptions.map(color => (
                 <button
@@ -113,10 +115,10 @@ const CategoryModal: React.FC<CategoryModalProps> = ({
 
           <div className="flex justify-end space-x-2 pt-4">
             <Button type="button" variant="outline" onClick={onClose}>
-              Abbrechen
+              {t('common.cancel')}
             </Button>
             <Button type="submit">
-              {category ? 'Speichern' : 'Erstellen'}
+              {category ? t('common.save') : t('common.create')}
             </Button>
           </div>
         </form>

--- a/src/components/DeckModal.tsx
+++ b/src/components/DeckModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Deck } from '@/types';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
@@ -13,6 +14,7 @@ interface DeckModalProps {
 }
 
 const DeckModal: React.FC<DeckModalProps> = ({ isOpen, onClose, onSave, deck }) => {
+  const { t } = useTranslation();
   const [name, setName] = useState('');
 
   useEffect(() => {
@@ -32,16 +34,28 @@ const DeckModal: React.FC<DeckModalProps> = ({ isOpen, onClose, onSave, deck }) 
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>{deck ? 'Deck bearbeiten' : 'Neues Deck'}</DialogTitle>
+          <DialogTitle>
+            {deck ? t('deckModal.editTitle') : t('deckModal.newTitle')}
+          </DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <Label htmlFor="name">Name *</Label>
-            <Input id="name" value={name} onChange={e => setName(e.target.value)} required />
+            <Label htmlFor="name">{t('deckModal.name')}</Label>
+            <Input
+              id="name"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder={t('deckModal.placeholderName')}
+              required
+            />
           </div>
           <div className="flex justify-end space-x-2 pt-4">
-            <Button type="button" variant="outline" onClick={onClose}>Abbrechen</Button>
-            <Button type="submit">{deck ? 'Speichern' : 'Erstellen'}</Button>
+            <Button type="button" variant="outline" onClick={onClose}>
+              {t('common.cancel')}
+            </Button>
+            <Button type="submit">
+              {deck ? t('common.save') : t('common.create')}
+            </Button>
           </div>
         </form>
       </DialogContent>

--- a/src/components/FlashcardModal.tsx
+++ b/src/components/FlashcardModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Flashcard, Deck } from '@/types';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
@@ -15,6 +16,7 @@ interface FlashcardModalProps {
 }
 
 const FlashcardModal: React.FC<FlashcardModalProps> = ({ isOpen, onClose, onSave, decks, card }) => {
+  const { t } = useTranslation();
   const [formData, setFormData] = useState({ front: '', back: '', deckId: '' });
 
   useEffect(() => {
@@ -42,14 +44,16 @@ const FlashcardModal: React.FC<FlashcardModalProps> = ({ isOpen, onClose, onSave
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>{card ? 'Karte bearbeiten' : 'Neue Karte'}</DialogTitle>
+          <DialogTitle>
+            {card ? t('flashcardModal.editTitle') : t('flashcardModal.newTitle')}
+          </DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <Label htmlFor="deck">Deck</Label>
+            <Label htmlFor="deck">{t('flashcardModal.deck')}</Label>
             <Select value={formData.deckId} onValueChange={v => handleChange('deckId', v)}>
               <SelectTrigger id="deck">
-                <SelectValue placeholder="Deck wählen" />
+                <SelectValue placeholder={t('flashcardModal.chooseDeck')} />
               </SelectTrigger>
               <SelectContent>
                 {decks.map(d => (
@@ -59,7 +63,7 @@ const FlashcardModal: React.FC<FlashcardModalProps> = ({ isOpen, onClose, onSave
             </Select>
           </div>
           <div>
-            <Label htmlFor="front">Vorderseite *</Label>
+            <Label htmlFor="front">{t('flashcardModal.front')}</Label>
             <Textarea
               id="front"
               value={formData.front}
@@ -69,7 +73,7 @@ const FlashcardModal: React.FC<FlashcardModalProps> = ({ isOpen, onClose, onSave
             />
           </div>
           <div>
-            <Label htmlFor="back">Rückseite *</Label>
+            <Label htmlFor="back">{t('flashcardModal.back')}</Label>
             <Textarea
               id="back"
               value={formData.back}
@@ -80,9 +84,11 @@ const FlashcardModal: React.FC<FlashcardModalProps> = ({ isOpen, onClose, onSave
           </div>
           <div className="flex justify-end space-x-2 pt-4">
             <Button type="button" variant="outline" onClick={onClose}>
-              Abbrechen
+              {t('common.cancel')}
             </Button>
-            <Button type="submit">{card ? 'Speichern' : 'Erstellen'}</Button>
+            <Button type="submit">
+              {card ? t('common.save') : t('common.create')}
+            </Button>
           </div>
         </form>
       </DialogContent>

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Task, TaskFormData, Category } from '@/types';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
@@ -63,6 +64,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
   defaultStartTime,
   defaultEndTime
 }) => {
+  const { t } = useTranslation();
   const { defaultTaskPriority } = useSettings()
   const [formData, setFormData] = useState<TaskFormData>({
     title: '',
@@ -191,37 +193,41 @@ const TaskModal: React.FC<TaskModalProps> = ({
       <DialogContent className="sm:max-w-md max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
-            {task ? 'Task bearbeiten' : parentTask ? 'Unteraufgabe erstellen' : 'Neue Task erstellen'}
+            {task
+              ? t('taskModal.editTitle')
+              : parentTask
+              ? t('taskModal.newSubtaskTitle')
+              : t('taskModal.newTitle')}
           </DialogTitle>
         </DialogHeader>
         
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <Label htmlFor="title">Titel *</Label>
+            <Label htmlFor="title">{t('taskModal.title')}</Label>
             <Input
               id="title"
               value={formData.title}
               onChange={(e) => handleChange('title', e.target.value)}
-              placeholder="Task-Titel eingeben..."
+              placeholder={t('taskModal.title')}
               required
               autoFocus
             />
           </div>
 
           <div>
-            <Label htmlFor="description">Beschreibung</Label>
+            <Label htmlFor="description">{t('taskModal.description')}</Label>
             <Textarea
               id="description"
               value={formData.description}
               onChange={(e) => handleChange('description', e.target.value)}
-              placeholder="Optionale Beschreibung..."
+              placeholder={t('taskModal.description')}
               rows={3}
             />
           </div>
 
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <Label htmlFor="priority">Priorität</Label>
+              <Label htmlFor="priority">{t('taskModal.priority')}</Label>
               <Select value={formData.priority} onValueChange={(value) => handleChange('priority', value)}>
                 <SelectTrigger>
                   <SelectValue />
@@ -229,17 +235,17 @@ const TaskModal: React.FC<TaskModalProps> = ({
                 <SelectContent>
                   <SelectItem value="low">
                     <span className={`px-2 py-1 rounded text-sm ${getPriorityColor('low')}`}>
-                      🟢 Niedrig
+                      🟢 {t('taskModal.low')}
                     </span>
                   </SelectItem>
                   <SelectItem value="medium">
                     <span className={`px-2 py-1 rounded text-sm ${getPriorityColor('medium')}`}>
-                      🟡 Mittel
+                      🟡 {t('taskModal.medium')}
                     </span>
                   </SelectItem>
                   <SelectItem value="high">
                     <span className={`px-2 py-1 rounded text-sm ${getPriorityColor('high')}`}>
-                      🔴 Hoch
+                      🔴 {t('taskModal.high')}
                     </span>
                   </SelectItem>
                 </SelectContent>
@@ -247,7 +253,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
             </div>
 
             <div>
-              <Label htmlFor="category">Kategorie</Label>
+              <Label htmlFor="category">{t('taskModal.category')}</Label>
               <Select value={formData.categoryId} onValueChange={(value) => handleChange('categoryId', value)}>
                 <SelectTrigger>
                   <SelectValue />
@@ -271,7 +277,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
 
         {!formData.isRecurring && (
           <div>
-            <Label htmlFor="dueDate">Fällig am</Label>
+            <Label htmlFor="dueDate">{t('taskModal.dueDate')}</Label>
             <Input
               id="dueDate"
               type="date"
@@ -280,7 +286,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
             />
             <div className="mt-2 grid grid-cols-2 gap-2">
               <div>
-                <Label htmlFor="startTime">Startzeit</Label>
+                <Label htmlFor="startTime">{t('taskModal.startTime')}</Label>
                 <Input
                   id="startTime"
                   type="time"
@@ -289,7 +295,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
                 />
               </div>
               <div>
-                <Label htmlFor="endTime">Endzeit</Label>
+                <Label htmlFor="endTime">{t('taskModal.endTime')}</Label>
                 <Input
                   id="endTime"
                   type="time"
@@ -303,15 +309,15 @@ const TaskModal: React.FC<TaskModalProps> = ({
 
         {formData.isRecurring && (
           <div>
-            <Label>Fälligkeit</Label>
+            <Label>{t('taskModal.recurrence')}</Label>
             <Select value={formData.dueOption} onValueChange={(v) => handleChange('dueOption', v as any)}>
               <SelectTrigger>
-                <SelectValue placeholder="Fälligkeit wählen..." />
+                <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="days">Nach Tagen</SelectItem>
-                <SelectItem value="weekEnd">Ende der Woche</SelectItem>
-                <SelectItem value="monthEnd">Ende des Monats</SelectItem>
+                <SelectItem value="days">{t('taskModal.customDays')}</SelectItem>
+                <SelectItem value="weekEnd">{t('taskModal.weekEnd')}</SelectItem>
+                <SelectItem value="monthEnd">{t('taskModal.monthEnd')}</SelectItem>
               </SelectContent>
             </Select>
             {formData.dueOption === 'days' && (
@@ -328,7 +334,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
         )}
 
         <div>
-          <Label>Farbe</Label>
+          <Label>{t('taskModal.color')}</Label>
           <div className="flex space-x-2 mt-2">
             {colorOptions.map(color => (
                 <button
@@ -347,7 +353,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
           {allowRecurring && (
             <div className="space-y-3">
               <div className="flex items-center justify-between">
-                <Label htmlFor="recurring">Wiederkehrende Aufgabe</Label>
+                <Label htmlFor="recurring">{t('taskModal.recurring')}</Label>
                 <Switch
                   id="recurring"
                   checked={formData.isRecurring}
@@ -357,23 +363,23 @@ const TaskModal: React.FC<TaskModalProps> = ({
 
               {formData.isRecurring && (
                 <div>
-                  <Label htmlFor="recurrence">Wiederholung</Label>
+                  <Label htmlFor="recurrence">{t('taskModal.recurrence')}</Label>
                   <Select
                     value={formData.recurrencePattern}
                     onValueChange={(value) => handleChange('recurrencePattern', value)}
                   >
                   <SelectTrigger>
-                    <SelectValue placeholder="Wiederholung auswählen..." />
+                    <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="daily">Täglich</SelectItem>
-                    <SelectItem value="weekly">Wöchentlich</SelectItem>
-                    <SelectItem value="monthly">Monatlich</SelectItem>
-                <SelectItem value="yearly">Jährlich</SelectItem>
+                    <SelectItem value="daily">{t('taskModal.daily')}</SelectItem>
+                    <SelectItem value="weekly">{t('taskModal.weekly')}</SelectItem>
+                    <SelectItem value="monthly">{t('taskModal.monthly')}</SelectItem>
+                    <SelectItem value="yearly">{t('taskModal.yearly')}</SelectItem>
                 </SelectContent>
               </Select>
               <div className="mt-2">
-                <Label htmlFor="customDays">Benutzerdefinierte Tage</Label>
+                <Label htmlFor="customDays">{t('taskModal.customDays')}</Label>
                 <Input
                   id="customDays"
                   type="number"
@@ -385,15 +391,15 @@ const TaskModal: React.FC<TaskModalProps> = ({
                 />
               </div>
               <div className="mt-2">
-                <Label>Start</Label>
+                <Label>{t('taskModal.start')}</Label>
                 <Select value={formData.startOption} onValueChange={(v) => handleChange('startOption', v as any)}>
                   <SelectTrigger>
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="today">Heute</SelectItem>
-                    <SelectItem value="weekday">Wochentag</SelectItem>
-                    <SelectItem value="date">Festes Datum</SelectItem>
+                    <SelectItem value="today">{t('taskModal.today')}</SelectItem>
+                    <SelectItem value="weekday">{t('taskModal.weekday')}</SelectItem>
+                    <SelectItem value="date">{t('taskModal.date')}</SelectItem>
                   </SelectContent>
                 </Select>
                 {formData.startOption === 'weekday' && (
@@ -403,7 +409,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
                     className="mt-2"
                   >
                     <SelectTrigger>
-                      <SelectValue placeholder="Wochentag wählen..." />
+                      <SelectValue placeholder={t('taskModal.weekday')} />
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="0">Sonntag</SelectItem>
@@ -426,12 +432,12 @@ const TaskModal: React.FC<TaskModalProps> = ({
                 )}
               </div>
               <div className="mt-2">
-                <Label htmlFor="titleTemplate">Dynamischer Titel</Label>
+                <Label htmlFor="titleTemplate">{t('taskModal.titleTemplate')}</Label>
                 <Input
                   id="titleTemplate"
                   value={formData.titleTemplate || ''}
                   onChange={(e) => handleChange('titleTemplate', e.target.value)}
-                  placeholder="{date} oder {counter} nutzen"
+                  placeholder="{date} / {counter}"
                 />
               </div>
                 </div>
@@ -441,10 +447,10 @@ const TaskModal: React.FC<TaskModalProps> = ({
 
           <div className="flex justify-end space-x-2 pt-4">
             <Button type="button" variant="outline" onClick={onClose}>
-              Abbrechen
+              {t('common.cancel')}
             </Button>
             <Button type="submit">
-              {task ? 'Speichern' : 'Erstellen'}
+              {task ? t('common.save') : t('common.create')}
             </Button>
           </div>
         </form>

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -67,5 +67,73 @@
     "notes": "Notizen",
     "recurring": "Wiederkehrend",
     "settings": "Einstellungen"
+  },
+  "categoryModal": {
+    "editTitle": "Kategorie bearbeiten",
+    "newTitle": "Neue Kategorie",
+    "name": "Name *",
+    "description": "Beschreibung",
+    "color": "Farbe",
+    "placeholderName": "Kategorie-Name eingeben...",
+    "placeholderDescription": "Optionale Beschreibung..."
+  },
+  "taskModal": {
+    "editTitle": "Task bearbeiten",
+    "newTitle": "Neue Task",
+    "newSubtaskTitle": "Unteraufgabe erstellen",
+    "title": "Titel *",
+    "description": "Beschreibung",
+    "priority": "Priorität",
+    "category": "Kategorie",
+    "dueDate": "Fällig am",
+    "startTime": "Startzeit",
+    "endTime": "Endzeit",
+    "recurring": "Wiederkehrende Aufgabe",
+    "recurrence": "Wiederholung",
+    "daily": "Täglich",
+    "weekly": "Wöchentlich",
+    "monthly": "Monatlich",
+    "yearly": "Jährlich",
+    "customDays": "Benutzerdefinierte Tage",
+    "weekEnd": "Ende der Woche",
+    "monthEnd": "Ende des Monats",
+    "start": "Start",
+    "today": "Heute",
+    "weekday": "Wochentag",
+    "date": "Festes Datum",
+    "titleTemplate": "Dynamischer Titel",
+    "color": "Farbe"
+  },
+  "deckModal": {
+    "editTitle": "Deck bearbeiten",
+    "newTitle": "Neues Deck",
+    "name": "Name *",
+    "placeholderName": "Deck-Name eingeben..."
+  },
+  "flashcardModal": {
+    "editTitle": "Karte bearbeiten",
+    "newTitle": "Neue Karte",
+    "deck": "Deck",
+    "front": "Vorderseite *",
+    "back": "Rückseite *",
+    "chooseDeck": "Deck wählen"
+  },
+  "notFound": {
+    "title": "404",
+    "message": "Oops! Seite nicht gefunden",
+    "backHome": "Zur Startseite"
+  },
+  "notes": {
+    "newNote": "Neue Notiz",
+    "none": "Keine Notizen vorhanden."
+  },
+  "recurring": {
+    "template": "Vorlage",
+    "none": "Keine Vorlagen vorhanden."
+  },
+  "deckDetail": {
+    "newCard": "Neue Karte",
+    "noCards": "Noch keine Karten vorhanden.",
+    "notFound": "Deck nicht gefunden."
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -67,5 +67,73 @@
     "notes": "Notes",
     "recurring": "Recurring",
     "settings": "Settings"
+  },
+  "categoryModal": {
+    "editTitle": "Edit Category",
+    "newTitle": "New Category",
+    "name": "Name *",
+    "description": "Description",
+    "color": "Color",
+    "placeholderName": "Enter category name...",
+    "placeholderDescription": "Optional description..."
+  },
+  "taskModal": {
+    "editTitle": "Edit Task",
+    "newTitle": "New Task",
+    "newSubtaskTitle": "Create Subtask",
+    "title": "Title *",
+    "description": "Description",
+    "priority": "Priority",
+    "category": "Category",
+    "dueDate": "Due Date",
+    "startTime": "Start Time",
+    "endTime": "End Time",
+    "recurring": "Recurring Task",
+    "recurrence": "Recurrence",
+    "daily": "Daily",
+    "weekly": "Weekly",
+    "monthly": "Monthly",
+    "yearly": "Yearly",
+    "customDays": "Custom days",
+    "weekEnd": "End of week",
+    "monthEnd": "End of month",
+    "start": "Start",
+    "today": "Today",
+    "weekday": "Weekday",
+    "date": "Fixed date",
+    "titleTemplate": "Dynamic Title",
+    "color": "Color"
+  },
+  "deckModal": {
+    "editTitle": "Edit Deck",
+    "newTitle": "New Deck",
+    "name": "Name *",
+    "placeholderName": "Enter deck name..."
+  },
+  "flashcardModal": {
+    "editTitle": "Edit Card",
+    "newTitle": "New Card",
+    "deck": "Deck",
+    "front": "Front *",
+    "back": "Back *",
+    "chooseDeck": "Choose deck"
+  },
+  "notFound": {
+    "title": "404",
+    "message": "Oops! Page not found",
+    "backHome": "Return to Home"
+  },
+  "notes": {
+    "newNote": "New Note",
+    "none": "No notes available."
+  },
+  "recurring": {
+    "template": "Template",
+    "none": "No templates available."
+  },
+  "deckDetail": {
+    "newCard": "New Card",
+    "noCards": "No cards available.",
+    "notFound": "Deck not found."
   }
 }

--- a/src/pages/DeckDetail.tsx
+++ b/src/pages/DeckDetail.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useParams, useNavigate } from 'react-router-dom';
 import Navbar from '@/components/Navbar';
 import { Button } from '@/components/ui/button';
@@ -8,6 +9,7 @@ import { useFlashcardStore } from '@/hooks/useFlashcardStore';
 import { Plus, Pencil, Trash2 } from 'lucide-react';
 
 const DeckDetailPage: React.FC = () => {
+  const { t } = useTranslation();
   const { deckId } = useParams<{ deckId: string }>();
   const navigate = useNavigate();
   const {
@@ -26,7 +28,7 @@ const DeckDetailPage: React.FC = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
 
-  if (!deck) return <div className="p-4">Deck nicht gefunden.</div>;
+  if (!deck) return <div className="p-4">{t('deckDetail.notFound')}</div>;
 
   const handleSave = (data: { front: string; back: string; deckId: string }) => {
     const payload = { ...data, deckId: deckId! };
@@ -48,11 +50,11 @@ const DeckDetailPage: React.FC = () => {
             {dueCount}/{totalCount} fällig
           </span>
           <Button size="sm" onClick={() => setIsModalOpen(true)}>
-            <Plus className="h-4 w-4 mr-2" /> Neue Karte
+            <Plus className="h-4 w-4 mr-2" /> {t('deckDetail.newCard')}
           </Button>
         </div>
         {cards.length === 0 ? (
-          <p className="text-sm text-muted-foreground">Noch keine Karten vorhanden.</p>
+          <p className="text-sm text-muted-foreground">{t('deckDetail.noCards')}</p>
         ) : (
           <div className="space-y-4">
             {cards.map((card, index) => (

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,9 +1,11 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import { useTranslation } from 'react-i18next';
 import Navbar from "@/components/Navbar";
 
 const NotFound = () => {
   const location = useLocation();
+  const { t } = useTranslation();
 
   useEffect(() => {
     console.error(
@@ -14,13 +16,13 @@ const NotFound = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      <Navbar title="404" />
+      <Navbar title={t('notFound.title')} />
       <div className="flex items-center justify-center py-8">
         <div className="text-center">
           <h1 className="text-4xl font-bold mb-4">404</h1>
-          <p className="text-xl text-muted-foreground mb-4">Oops! Page not found</p>
+          <p className="text-xl text-muted-foreground mb-4">{t('notFound.message')}</p>
           <a href="/" className="text-primary hover:text-primary/80 underline">
-            Return to Home
+            {t('notFound.backHome')}
           </a>
         </div>
       </div>

--- a/src/pages/Notes.tsx
+++ b/src/pages/Notes.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Plus } from 'lucide-react';
 import { useTaskStore } from '@/hooks/useTaskStore';
 import NoteModal from '@/components/NoteModal';
@@ -12,6 +13,7 @@ const NotesPage = () => {
   const { notes, addNote, reorderNotes } = useTaskStore();
   const navigate = useNavigate();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const { t } = useTranslation();
 
   const handleSave = (data: { title: string; text: string; color: string }) => {
     addNote(data);
@@ -24,15 +26,15 @@ const NotesPage = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      <Navbar title="Notizen" />
+      <Navbar title={t('navbar.notes')} />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-8">
         <div className="flex justify-end mb-4">
           <Button size="sm" onClick={() => setIsModalOpen(true)}>
-            <Plus className="h-4 w-4 mr-2" /> Neue Notiz
+            <Plus className="h-4 w-4 mr-2" /> {t('notes.newNote')}
           </Button>
         </div>
         {notes.length === 0 ? (
-          <p className="text-sm text-muted-foreground">Keine Notizen vorhanden.</p>
+          <p className="text-sm text-muted-foreground">{t('notes.none')}</p>
         ) : (
           <DragDropContext onDragEnd={onDragEnd}>
             <Droppable droppableId="notes" direction="horizontal">

--- a/src/pages/Pomodoro.tsx
+++ b/src/pages/Pomodoro.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import Navbar from '@/components/Navbar';
 import PomodoroTimer from '@/components/PomodoroTimer';
 import PomodoroStats from '@/components/PomodoroStats';
 
 const PomodoroPage: React.FC = () => {
+  const { t } = useTranslation();
   return (
     <div className="min-h-screen bg-background flex flex-col">
-      <Navbar title="Pomodoro" />
+      <Navbar title={t('navbar.pomodoro')} />
       <div className="flex-grow p-4 space-y-6 flex flex-col items-center">
         <PomodoroTimer size={150} />
         <div className="w-full max-w-4xl"><PomodoroStats /></div>

--- a/src/pages/RecurringTasks.tsx
+++ b/src/pages/RecurringTasks.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Plus } from 'lucide-react';
 import Navbar from '@/components/Navbar';
 import TaskModal from '@/components/TaskModal';
@@ -15,6 +16,7 @@ const RecurringTasksPage = () => {
     deleteRecurringTask
   } = useTaskStore();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const { t } = useTranslation();
   const [editingTask, setEditingTask] = useState<any | null>(null);
 
   const handleSave = (data: any) => {
@@ -27,15 +29,15 @@ const RecurringTasksPage = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      <Navbar title="Wiederkehrend" />
+      <Navbar title={t('navbar.recurring')} />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-8">
         <div className="flex justify-end mb-4">
           <Button size="sm" onClick={() => setIsModalOpen(true)}>
-            <Plus className="h-4 w-4 mr-2" /> Vorlage
+            <Plus className="h-4 w-4 mr-2" /> {t('recurring.template')}
           </Button>
         </div>
         {recurring.length === 0 ? (
-          <p className="text-sm text-muted-foreground">Keine Vorlagen vorhanden.</p>
+          <p className="text-sm text-muted-foreground">{t('recurring.none')}</p>
         ) : (
           <div className="space-y-2">
             {recurring.map(t => (


### PR DESCRIPTION
## Summary
- extend locale files with missing translations
- use i18n in several components and pages

## Testing
- `npm run lint` *(fails: cannot find package @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_684fec8291cc832a9ac3283af39bfc29