### PR TITLE
Add i18n to remaining pages

### DIFF
--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -162,5 +162,82 @@
   "releaseNotes": {
     "title": "Release Notes",
     "none": "Keine Release Notes gefunden."
+  },
+  "flashcardManager": {
+    "title": "Decks",
+    "newDeck": "Neues Deck",
+    "none": "Noch keine Decks vorhanden."
+  },
+  "flashcardStats": {
+    "title": "Karten Statistiken",
+    "totalCards": "Gesamt Karten",
+    "due": "Fällig",
+    "avgInterval": "Ø Intervall",
+    "difficulty": "Schwierigkeiten",
+    "upcoming": "Fälligkeit nächste 7 Tage",
+    "deckDetails": "Decks im Detail",
+    "deck": "Deck",
+    "total": "Gesamt",
+    "dueShare": "Fälligkeitsanteil",
+    "cards": "Karten",
+    "easy": "Leicht",
+    "medium": "Mittel",
+    "hard": "Schwer"
+  },
+  "flashcardsPage": {
+    "title": "Karteikarten",
+    "mode": "Modus",
+    "spaced": "Spaced Repetition",
+    "training": "Training",
+    "random": "Random",
+    "typing": "Eingabe",
+    "timed": "Timed",
+    "useSpaced": "Spaced Repetition",
+    "noDue": "Keine fälligen Karten.",
+    "check": "Check",
+    "hard": "Schwer",
+    "medium": "Mittel",
+    "easy": "Leicht",
+    "nextCard": "Nächste Karte",
+    "timerStart": "Timer starten?",
+    "start": "Start",
+    "trainingDone": "Training beendet",
+    "sessionDone": "Session beendet",
+    "continue": "Weiter",
+    "allDone": "Alle Karten durch",
+    "correct": "Richtig!",
+    "wrong": "Falsch",
+    "description": {
+      "training": "Im Training-Modus werden Karten zufällig wiederholt, bis sie richtig beantwortet wurden. Bewertungen beeinflussen den Spaced-Repetition-Algorithmus nicht.",
+      "random": "Im Random-Modus werden alle ausgewählten Karten in zufälliger Reihenfolge angezeigt. Bewertungen wirken sich nicht auf den Algorithmus aus.",
+      "typingSpaced": "Im Eingabe-Modus tippst du die Antwort ein. Bewertungen beeinflussen den Algorithmus.",
+      "typing": "Im Eingabe-Modus tippst du die Antwort ein. Bewertungen beeinflussen den Algorithmus nicht.",
+      "timedSpaced": "Im Timed-Modus hast du ein Zeitlimit pro Karte. Bewertungen beeinflussen den Algorithmus.",
+      "timed": "Im Timed-Modus hast du ein Zeitlimit pro Karte. Bewertungen beeinflussen den Algorithmus nicht.",
+      "spaced": "Spaced Repetition zeigt nur fällige Karten entsprechend deinem Lernfortschritt an."
+    }
+  },
+  "surprise": {
+    "navbar": "Überraschung",
+    "title": "Ich hab dich lieb",
+    "poem": "Für dich, mein Schatz, ein kleines Wort,\nVersteckt im Code, wo nur du es findest.\nEin Funke Licht in dunkler Nacht,\nEin Zeichen dafür, dass ich immer an dich wach’.\n\nDein Lächeln strahlt wie Sonnenschein,\nDa schlägt mein Herz im schönsten Takt.\nDoch mehr als Code und süße Zeilen –\nBist du die Liebe, die ich nie verlier’.\n\nDies ist erst der Anfang unserer Magie,\nDenn mit dir wird Glück ganz leicht geschrieben.\nLass uns die Welt, die nur uns gehört,\nMit Küssen, Lachen und Sternen verzieren.",
+    "toast": "Geheime Liebesbotschaft entdeckt!"
+  },
+  "timeBlocking": {
+    "title": "Zeitplan",
+    "day": "Tag",
+    "week": "Woche",
+    "month": "Monat"
+  },
+  "kanban": {
+    "todo": "To Do",
+    "inprogress": "In Bearbeitung",
+    "done": "Erledigt",
+    "created": "Task erstellt",
+    "updated": "Task aktualisiert",
+    "deleted": "Task gelöscht",
+    "completed": "Task abgeschlossen",
+    "reactivated": "Task reaktiviert",
+    "deleteConfirm": "Sind Sie sicher, dass Sie \"{{title}}\" löschen möchten?"
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -162,5 +162,82 @@
   "releaseNotes": {
     "title": "Release Notes",
     "none": "No release notes found."
+  },
+  "flashcardManager": {
+    "title": "Decks",
+    "newDeck": "New Deck",
+    "none": "No decks available."
+  },
+  "flashcardStats": {
+    "title": "Card Statistics",
+    "totalCards": "Total Cards",
+    "due": "Due",
+    "avgInterval": "Avg Interval",
+    "difficulty": "Difficulty",
+    "upcoming": "Due Next 7 Days",
+    "deckDetails": "Deck Details",
+    "deck": "Deck",
+    "total": "Total",
+    "dueShare": "Due Share",
+    "cards": "Cards",
+    "easy": "Easy",
+    "medium": "Medium",
+    "hard": "Hard"
+  },
+  "flashcardsPage": {
+    "title": "Flashcards",
+    "mode": "Mode",
+    "spaced": "Spaced Repetition",
+    "training": "Training",
+    "random": "Random",
+    "typing": "Typing",
+    "timed": "Timed",
+    "useSpaced": "Spaced Repetition",
+    "noDue": "No cards due.",
+    "check": "Check",
+    "hard": "Hard",
+    "medium": "Medium",
+    "easy": "Easy",
+    "nextCard": "Next Card",
+    "timerStart": "Start timer?",
+    "start": "Start",
+    "trainingDone": "Training completed",
+    "sessionDone": "Session ended",
+    "continue": "Continue",
+    "allDone": "All cards done",
+    "correct": "Correct!",
+    "wrong": "Wrong",
+    "description": {
+      "training": "In training mode cards repeat randomly until answered correctly. Ratings do not influence the spaced repetition algorithm.",
+      "random": "Random mode shows all selected cards in random order. Ratings do not affect the algorithm.",
+      "typingSpaced": "In typing mode you type the answer. Ratings influence the algorithm.",
+      "typing": "In typing mode you type the answer. Ratings do not influence the algorithm.",
+      "timedSpaced": "In timed mode you have a time limit per card. Ratings influence the algorithm.",
+      "timed": "In timed mode you have a time limit per card. Ratings do not influence the algorithm.",
+      "spaced": "Spaced Repetition only shows due cards according to your progress."
+    }
+  },
+  "surprise": {
+    "navbar": "Surprise",
+    "title": "I love you",
+    "poem": "For you, my dear, a little word,\nHidden in the code where only you can find it.\nA spark of light in the darkest night,\nA sign that I'm always awake for you.\n\nYour smile shines like sunshine,\nIt makes my heart beat in the finest rhythm.\nBut more than code and sweet lines –\nYou are the love that I never lose.\n\nThis is just the start of our magic,\nBecause with you happiness is easily written.\nLet's take the world that's only ours,\nAnd decorate it with kisses, laughter and stars.",
+    "toast": "Secret love message discovered!"
+  },
+  "timeBlocking": {
+    "title": "Schedule",
+    "day": "Day",
+    "week": "Week",
+    "month": "Month"
+  },
+  "kanban": {
+    "todo": "To Do",
+    "inprogress": "In Progress",
+    "done": "Done",
+    "created": "Task created",
+    "updated": "Task updated",
+    "deleted": "Task deleted",
+    "completed": "Task completed",
+    "reactivated": "Task reactivated",
+    "deleteConfirm": "Are you sure you want to delete \"{{title}}\"?"
   }
 }

--- a/src/pages/FlashcardManager.tsx
+++ b/src/pages/FlashcardManager.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/componen
 import DeckModal from '@/components/DeckModal';
 import { useFlashcardStore } from '@/hooks/useFlashcardStore';
 import { Deck } from '@/types';
+import { useTranslation } from 'react-i18next';
 
 const FlashcardManagerPage: React.FC = () => {
   const {
@@ -18,6 +19,7 @@ const FlashcardManagerPage: React.FC = () => {
     countDueCardsForDeck
   } = useFlashcardStore();
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const [isDeckModalOpen, setIsDeckModalOpen] = useState(false);
   const [editingDeck, setEditingDeck] = useState<Deck | null>(null);
 
@@ -32,15 +34,15 @@ const FlashcardManagerPage: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      <Navbar title="Decks" />
+      <Navbar title={t('flashcardManager.title')} />
       <div className="max-w-2xl mx-auto py-8 px-4 space-y-4">
         <div className="flex justify-end">
           <Button size="sm" onClick={() => setIsDeckModalOpen(true)}>
-            <Plus className="h-4 w-4 mr-2" /> Neues Deck
+            <Plus className="h-4 w-4 mr-2" /> {t('flashcardManager.newDeck')}
           </Button>
         </div>
         {decks.length === 0 ? (
-          <p className="text-sm text-muted-foreground">Noch keine Decks vorhanden.</p>
+          <p className="text-sm text-muted-foreground">{t('flashcardManager.none')}</p>
         ) : (
           <div className="space-y-4">
             {decks.map(deck => {

--- a/src/pages/FlashcardStatistics.tsx
+++ b/src/pages/FlashcardStatistics.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Navbar from "@/components/Navbar";
 import { useFlashcardStatistics } from "@/hooks/useFlashcardStatistics";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useTranslation } from 'react-i18next';
 import {
   ResponsiveContainer,
   PieChart,
@@ -18,34 +19,35 @@ import { BookOpen, Clock, TrendingUp } from "lucide-react";
 
 const FlashcardStatisticsPage: React.FC = () => {
   const stats = useFlashcardStatistics();
+  const { t } = useTranslation();
 
   const difficultyData = [
     {
-      name: "Leicht",
+      name: t('flashcardStats.easy'),
       value: stats.difficultyCounts.easy,
-      color: "hsl(var(--accent))",
+      color: 'hsl(var(--accent))',
     },
     {
-      name: "Mittel",
+      name: t('flashcardStats.medium'),
       value: stats.difficultyCounts.medium,
-      color: "hsl(var(--primary))",
+      color: 'hsl(var(--primary))',
     },
     {
-      name: "Schwer",
+      name: t('flashcardStats.hard'),
       value: stats.difficultyCounts.hard,
-      color: "hsl(var(--destructive))",
+      color: 'hsl(var(--destructive))',
     },
   ];
 
   return (
     <div className="min-h-screen bg-background">
-      <Navbar title="Karten Statistiken" />
+      <Navbar title={t('flashcardStats.title')} />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-8">
         <div className="grid grid-cols-2 lg:grid-cols-6 gap-3 sm:gap-6 mb-6 sm:mb-8">
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-xs sm:text-sm font-medium">
-                Gesamt Karten
+                {t('flashcardStats.totalCards')}
               </CardTitle>
               <BookOpen className="h-4 w-4 text-muted-foreground" />
             </CardHeader>
@@ -58,7 +60,7 @@ const FlashcardStatisticsPage: React.FC = () => {
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-xs sm:text-sm font-medium">
-                Fällig
+                {t('flashcardStats.due')}
               </CardTitle>
               <Clock className="h-4 w-4 text-destructive" />
             </CardHeader>
@@ -71,7 +73,7 @@ const FlashcardStatisticsPage: React.FC = () => {
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-xs sm:text-sm font-medium">
-                Ø Intervall
+                {t('flashcardStats.avgInterval')}
               </CardTitle>
               <TrendingUp className="h-4 w-4 text-primary" />
             </CardHeader>
@@ -86,7 +88,7 @@ const FlashcardStatisticsPage: React.FC = () => {
           <Card>
             <CardHeader>
               <CardTitle className="text-base sm:text-lg">
-                Schwierigkeiten
+                {t('flashcardStats.difficulty')}
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -128,7 +130,7 @@ const FlashcardStatisticsPage: React.FC = () => {
           <Card>
             <CardHeader>
               <CardTitle className="text-base sm:text-lg">
-                Fälligkeit nächste 7 Tage
+                {t('flashcardStats.upcoming')}
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -145,7 +147,7 @@ const FlashcardStatisticsPage: React.FC = () => {
                     <Bar
                       dataKey="count"
                       fill="hsl(var(--stat-bar-primary))"
-                      name="Karten"
+                      name={t('flashcardStats.cards')}
                     />
                   </BarChart>
                 </ResponsiveContainer>
@@ -157,7 +159,7 @@ const FlashcardStatisticsPage: React.FC = () => {
           <Card className="mt-6">
             <CardHeader>
               <CardTitle className="text-base sm:text-lg">
-                Decks im Detail
+                {t('flashcardStats.deckDetails')}
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -165,11 +167,11 @@ const FlashcardStatisticsPage: React.FC = () => {
                 <table className="w-full text-xs sm:text-sm">
                   <thead>
                     <tr className="border-b">
-                      <th className="text-left py-2 font-medium">Deck</th>
-                      <th className="text-right py-2 font-medium">Gesamt</th>
-                      <th className="text-right py-2 font-medium">Fällig</th>
+                      <th className="text-left py-2 font-medium">{t('flashcardStats.deck')}</th>
+                      <th className="text-right py-2 font-medium">{t('flashcardStats.total')}</th>
+                      <th className="text-right py-2 font-medium">{t('flashcardStats.due')}</th>
                       <th className="text-right py-2 font-medium">
-                        Fälligkeitsanteil
+                        {t('flashcardStats.dueShare')}
                       </th>
                     </tr>
                   </thead>

--- a/src/pages/Flashcards.tsx
+++ b/src/pages/Flashcards.tsx
@@ -25,9 +25,11 @@ import {
   AlertDialogTitle,
   AlertDialogAction
 } from '@/components/ui/alert-dialog';
+import { useTranslation } from 'react-i18next';
 
 const FlashcardsPage: React.FC = () => {
   const { flashcards, decks, rateFlashcard } = useFlashcardStore();
+  const { t } = useTranslation();
   const {
     flashcardTimer,
     flashcardSessionSize,
@@ -292,21 +294,21 @@ const FlashcardsPage: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      <Navbar title="Karteikarten" />
+      <Navbar title={t('flashcardsPage.title')} />
       <div className="max-w-md mx-auto py-8 px-4 space-y-4">
         <div className="space-y-2">
           <div className="flex items-center space-x-2">
-            <Label className="text-sm">Modus:</Label>
+            <Label className="text-sm">{t('flashcardsPage.mode')}:</Label>
             <Select value={mode} onValueChange={handleModeChange}>
               <SelectTrigger className="w-40">
-                <SelectValue placeholder="Modus" />
+                <SelectValue placeholder={t('flashcardsPage.mode')} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="spaced">Spaced Repetition</SelectItem>
-                <SelectItem value="training">Training</SelectItem>
-                <SelectItem value="random">Random</SelectItem>
-                <SelectItem value="typing">Eingabe</SelectItem>
-                <SelectItem value="timed">Timed</SelectItem>
+                <SelectItem value="spaced">{t('flashcardsPage.spaced')}</SelectItem>
+                <SelectItem value="training">{t('flashcardsPage.training')}</SelectItem>
+                <SelectItem value="random">{t('flashcardsPage.random')}</SelectItem>
+                <SelectItem value="typing">{t('flashcardsPage.typing')}</SelectItem>
+                <SelectItem value="timed">{t('flashcardsPage.timed')}</SelectItem>
               </SelectContent>
             </Select>
         </div>
@@ -329,7 +331,7 @@ const FlashcardsPage: React.FC = () => {
           </div>
           {(typingMode || timedMode) && (
             <div className="flex items-center justify-between pt-2">
-              <Label htmlFor="useSpaced">Spaced Repetition</Label>
+              <Label htmlFor="useSpaced">{t('flashcardsPage.useSpaced')}</Label>
               <Switch
                 id="useSpaced"
                 checked={useSpaced}
@@ -339,7 +341,7 @@ const FlashcardsPage: React.FC = () => {
           )}
         </div>
         {!current ? (
-          <p className="text-sm text-muted-foreground">Keine fälligen Karten.</p>
+          <p className="text-sm text-muted-foreground">{t('flashcardsPage.noDue')}</p>
         ) : (
           <Card>
             <CardHeader>
@@ -367,7 +369,7 @@ const FlashcardsPage: React.FC = () => {
                   </div>
                   {timerPaused ? (
                     <Button size="sm" variant="outline" onClick={() => setTimerPaused(false)}>
-                      Weiter
+                      {t('flashcardsPage.continue')}
                     </Button>
                   ) : (
                     <Button size="sm" variant="outline" onClick={() => setTimerPaused(true)}>
@@ -385,7 +387,7 @@ const FlashcardsPage: React.FC = () => {
                       <div
                         className={`text-sm text-center ${isCorrect ? 'text-accent' : 'text-destructive'}`}
                       >
-                        {isCorrect ? 'Richtig!' : 'Falsch'}
+                        {isCorrect ? t('flashcardsPage.correct') : t('flashcardsPage.wrong')}
                       </div>
                     </>
                   ) : (
@@ -422,7 +424,7 @@ const FlashcardsPage: React.FC = () => {
                       setShowBack(true);
                     }}
                   >
-                    Check
+                    {t('flashcardsPage.check')}
                   </Button>
                 ) : (
                   <>
@@ -430,36 +432,36 @@ const FlashcardsPage: React.FC = () => {
                       variant="outline"
                       onClick={() => handleRate('hard')}
                     >
-                      Schwer
+                      {t('flashcardsPage.hard')}
                     </Button>
                     <Button
                       variant="outline"
                       onClick={() => handleRate('medium')}
                     >
-                      Mittel
+                      {t('flashcardsPage.medium')}
                     </Button>
                     <Button
                       variant="outline"
                       onClick={() => handleRate('easy')}
                     >
-                      Leicht
+                      {t('flashcardsPage.easy')}
                     </Button>
                   </>
                 )
               ) : randomMode && !trainingMode ? (
                 <Button variant="outline" onClick={() => handleRate('easy')}>
-                  Nächste Karte
+                  {t('flashcardsPage.nextCard')}
                 </Button>
               ) : (
                 <>
                   <Button variant="outline" onClick={() => handleRate('hard')}>
-                    Schwer
+                    {t('flashcardsPage.hard')}
                   </Button>
                   <Button variant="outline" onClick={() => handleRate('medium')}>
-                    Mittel
+                    {t('flashcardsPage.medium')}
                   </Button>
                   <Button variant="outline" onClick={() => handleRate('easy')}>
-                    Leicht
+                    {t('flashcardsPage.easy')}
                   </Button>
                 </>
               )}
@@ -473,13 +475,13 @@ const FlashcardsPage: React.FC = () => {
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Timer starten?</AlertDialogTitle>
+            <AlertDialogTitle>{t('flashcardsPage.timerStart')}</AlertDialogTitle>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogAction
               onClick={() => setTimerStarted(true)}
             >
-              Start
+              {t('flashcardsPage.start')}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -508,7 +510,7 @@ const FlashcardsPage: React.FC = () => {
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
-              {trainingMode ? 'Training beendet' : 'Session beendet'}
+              {trainingMode ? t('flashcardsPage.trainingDone') : t('flashcardsPage.sessionDone')}
             </AlertDialogTitle>
           </AlertDialogHeader>
           <div className="max-h-60 overflow-y-auto space-y-2 my-2 text-sm">
@@ -517,14 +519,16 @@ const FlashcardsPage: React.FC = () => {
               return (
                 <div key={id}>
                   <div className="font-medium">{card?.front}</div>
-                  <div>Leicht: {counts.easy}, Mittel: {counts.medium}, Schwer: {counts.hard}</div>
+                  <div>
+                    {t('flashcardsPage.easy')}: {counts.easy}, {t('flashcardsPage.medium')}: {counts.medium}, {t('flashcardsPage.hard')}: {counts.hard}
+                  </div>
                 </div>
               );
             })}
           </div>
           <AlertDialogFooter>
             <AlertDialogAction onClick={() => setShowSummary(false)}>
-              Weiter
+              {t('flashcardsPage.continue')}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -537,10 +541,10 @@ const FlashcardsPage: React.FC = () => {
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Alle Karten durch</AlertDialogTitle>
+            <AlertDialogTitle>{t('flashcardsPage.allDone')}</AlertDialogTitle>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogAction onClick={handleRestart}>Weiter</AlertDialogAction>
+            <AlertDialogAction onClick={handleRestart}>{t('flashcardsPage.continue')}</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/src/pages/Kanban.tsx
+++ b/src/pages/Kanban.tsx
@@ -14,6 +14,7 @@ import {
   Draggable,
   DropResult
 } from '@hello-pangea/dnd';
+import { useTranslation } from 'react-i18next';
 
 const Kanban: React.FC = () => {
   const {
@@ -25,6 +26,7 @@ const Kanban: React.FC = () => {
     findTaskById
   } = useTaskStore();
   const { toast } = useToast();
+  const { t } = useTranslation();
 
   const [isTaskModalOpen, setIsTaskModalOpen] = useState(false);
   const [isTaskDetailModalOpen, setIsTaskDetailModalOpen] = useState(false);
@@ -52,8 +54,8 @@ const Kanban: React.FC = () => {
       completed: false
     });
     toast({
-      title: 'Task erstellt',
-      description: `"${taskData.title}" wurde erfolgreich erstellt.`
+      title: t('kanban.created'),
+      description: `"${taskData.title}" ${t('kanban.created')}`
     });
     setParentTask(null);
   };
@@ -65,8 +67,8 @@ const Kanban: React.FC = () => {
         completed: editingTask.completed
       });
       toast({
-        title: 'Task aktualisiert',
-        description: `"${taskData.title}" wurde erfolgreich aktualisiert.`
+        title: t('kanban.updated'),
+        description: `"${taskData.title}" ${t('kanban.updated')}`
       });
       setEditingTask(null);
     }
@@ -74,11 +76,11 @@ const Kanban: React.FC = () => {
 
   const handleDeleteTask = (taskId: string) => {
     const task = findTaskById(taskId);
-    if (task && window.confirm(`Sind Sie sicher, dass Sie "${task.title}" löschen möchten?`)) {
+    if (task && window.confirm(t('kanban.deleteConfirm', { title: task.title }))) {
       deleteTask(taskId);
       toast({
-        title: 'Task gelöscht',
-        description: 'Die Task wurde erfolgreich gelöscht.'
+        title: t('kanban.deleted'),
+        description: t('kanban.deleted')
       });
     }
   };
@@ -87,8 +89,8 @@ const Kanban: React.FC = () => {
     updateTask(taskId, { completed });
     const task = findTaskById(taskId);
     toast({
-      title: completed ? 'Task abgeschlossen' : 'Task reaktiviert',
-      description: `"${task?.title}" wurde ${completed ? 'als erledigt markiert' : 'reaktiviert'}.`
+      title: completed ? t('kanban.completed') : t('kanban.reactivated'),
+      description: `"${task?.title}" ${completed ? t('kanban.completed') : t('kanban.reactivated')}`
     });
   };
 
@@ -144,14 +146,14 @@ const Kanban: React.FC = () => {
   ];
 
   const labels: Record<'todo' | 'inprogress' | 'done', string> = {
-    todo: 'To Do',
-    inprogress: 'In Bearbeitung',
-    done: 'Erledigt'
+    todo: t('kanban.todo'),
+    inprogress: t('kanban.inprogress'),
+    done: t('kanban.done')
   };
 
   return (
     <div className="min-h-screen bg-background">
-      <Navbar title="Kanban" />
+      <Navbar title={t('navbar.kanban')} />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-8">
         <DragDropContext onDragEnd={onDragEnd}>

--- a/src/pages/Surprise.tsx
+++ b/src/pages/Surprise.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useMemo } from 'react'
 import Navbar from '@/components/Navbar'
 import { toast } from '@/hooks/use-toast'
+import { useTranslation } from 'react-i18next'
 
 const SurprisePage: React.FC = () => {
+  const { t } = useTranslation()
   useEffect(() => {
-    toast({ description: 'Geheime Liebesbotschaft entdeckt!' })
+    toast({ description: t('surprise.toast') })
   }, [])
 
   const hearts = useMemo(
@@ -19,27 +21,14 @@ const SurprisePage: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-pink-50 dark:bg-pink-900 relative overflow-hidden">
-      <Navbar title="Überraschung" />
+      <Navbar title={t('surprise.navbar')} />
       <div className="flex flex-col items-center justify-center py-20">
         <h1 className="text-4xl font-bold text-pink-600 dark:text-pink-200">
-          Ich hab dich lieb
+          {t('surprise.title')}
         </h1>
         <br/>
         <p className="text-lg text-pink-600 dark:text-pink-200 whitespace-pre-line text-center max-w-2xl mx-auto leading-relaxed">
-        Für dich, mein Schatz, ein kleines Wort,<br/>
-        Versteckt im Code, wo nur du es findest.<br/>
-        Ein Funke Licht in dunkler Nacht,<br/>
-        Ein Zeichen dafür, dass ich immer an dich wach’.<br/>
-        <br/>
-        Dein Lächeln strahlt wie Sonnenschein,<br/>
-        Da schlägt mein Herz im schönsten Takt.<br/>
-        Doch mehr als Code und süße Zeilen –<br/>
-        Bist du die Liebe, die ich nie verlier’.<br/>
-        <br/>
-        Dies ist erst der Anfang unserer Magie,<br/>
-        Denn mit dir wird Glück ganz leicht geschrieben.<br/>
-        Lass uns die Welt, die nur uns gehört,<br/>
-        Mit Küssen, Lachen und Sternen verzieren.<br/>
+        {t('surprise.poem')}
         </p>
       </div>
       <div className="absolute inset-0 pointer-events-none overflow-hidden">

--- a/src/pages/TimeBlocking.tsx
+++ b/src/pages/TimeBlocking.tsx
@@ -6,6 +6,7 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { ChevronLeft, ChevronRight, Move, GripVertical } from 'lucide-react';
 import TaskModal from '@/components/TaskModal';
 import { TaskFormData, Task } from '@/types';
+import { useTranslation } from 'react-i18next';
 
 const parseMinutes = (time?: string) => {
   if (!time) return null;
@@ -40,6 +41,7 @@ const snap = (m: number) => {
 
 const TimeBlockingPage = () => {
   const { tasks, categories, addTask, updateTask } = useTaskStore()
+  const { t } = useTranslation()
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [modalDefaults, setModalDefaults] = useState<{
     start?: string
@@ -515,16 +517,16 @@ const TimeBlockingPage = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      <Navbar title="Zeitplan" />
+      <Navbar title={t('timeBlocking.title')} />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-8">
         <ToggleGroup
           type="single"
           value={view}
           onValueChange={v => v && setView(v as 'day' | 'week' | 'month')}
         >
-          <ToggleGroupItem value="day">Tag</ToggleGroupItem>
-          <ToggleGroupItem value="week">Woche</ToggleGroupItem>
-          <ToggleGroupItem value="month">Monat</ToggleGroupItem>
+          <ToggleGroupItem value="day">{t('timeBlocking.day')}</ToggleGroupItem>
+          <ToggleGroupItem value="week">{t('timeBlocking.week')}</ToggleGroupItem>
+          <ToggleGroupItem value="month">{t('timeBlocking.month')}</ToggleGroupItem>
         </ToggleGroup>
       <div className="mt-4">
         {view === 'day' && renderDay()}


### PR DESCRIPTION
## Summary
- expand English and German translation files
- localize Flashcards, statistics and deck manager pages
- add translations for surprise page and schedule toggle labels
- integrate translations for kanban page messages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ff3642428832aa576b87f9c625cea