### PR TITLE
Implement multilingual support for Pomodoro components

### DIFF
--- a/src/components/PomodoroStats.tsx
+++ b/src/components/PomodoroStats.tsx
@@ -2,19 +2,21 @@ import React from 'react';
 import { usePomodoroStats } from '@/hooks/usePomodoroStats';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts';
+import { useTranslation } from 'react-i18next';
 
 const PomodoroStats: React.FC = () => {
   const stats = usePomodoroStats();
+  const { t } = useTranslation();
   return (
     <div className="w-full grid gap-4 md:grid-cols-2">
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Gesamt</CardTitle>
+          <CardTitle className="text-base">{t('pomodoroStats.total')}</CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-sm">Arbeit: {stats.totalWorkMinutes} min</p>
-          <p className="text-sm">Pause: {stats.totalBreakMinutes} min</p>
-          <p className="text-sm mb-2">Zyklen: {stats.totalCycles}</p>
+          <p className="text-sm">{t('pomodoroStats.work')}: {stats.totalWorkMinutes} min</p>
+          <p className="text-sm">{t('pomodoroStats.break')}: {stats.totalBreakMinutes} min</p>
+          <p className="text-sm mb-2">{t('pomodoroStats.cycles')}: {stats.totalCycles}</p>
           <div className="w-full h-3 bg-muted rounded overflow-hidden">
             <div
               className="h-full bg-primary"
@@ -40,12 +42,12 @@ const PomodoroStats: React.FC = () => {
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Heute</CardTitle>
+          <CardTitle className="text-base">{t('pomodoroStats.today')}</CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-sm">Arbeit: {stats.todayTotals.workMinutes} min</p>
-          <p className="text-sm">Pause: {stats.todayTotals.breakMinutes} min</p>
-          <p className="text-sm mb-2">Zyklen: {stats.todayTotals.cycles}</p>
+          <p className="text-sm">{t('pomodoroStats.work')}: {stats.todayTotals.workMinutes} min</p>
+          <p className="text-sm">{t('pomodoroStats.break')}: {stats.todayTotals.breakMinutes} min</p>
+          <p className="text-sm mb-2">{t('pomodoroStats.cycles')}: {stats.todayTotals.cycles}</p>
           <div className="w-full h-3 bg-muted rounded overflow-hidden mb-4">
             <div
               className="h-full bg-primary"
@@ -82,16 +84,16 @@ const PomodoroStats: React.FC = () => {
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Tageszeiten (Gesamt)</CardTitle>
+          <CardTitle className="text-base">{t('pomodoroStats.timesOfDayTotal')}</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="h-40">
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={[
-                  { time: 'Morgen', value: stats.timeOfDay.morning },
-                  { time: 'Mittag', value: stats.timeOfDay.afternoon },
-                  { time: 'Abend', value: stats.timeOfDay.evening },
-                  { time: 'Nacht', value: stats.timeOfDay.night }
+                  { time: t('pomodoroStats.morning'), value: stats.timeOfDay.morning },
+                  { time: t('pomodoroStats.afternoon'), value: stats.timeOfDay.afternoon },
+                  { time: t('pomodoroStats.evening'), value: stats.timeOfDay.evening },
+                  { time: t('pomodoroStats.night'), value: stats.timeOfDay.night }
                 ]}
                 margin={{ top: 10, right: 20, left: 0, bottom: 20 }}>
                 <XAxis dataKey="time" fontSize={12} />
@@ -106,7 +108,7 @@ const PomodoroStats: React.FC = () => {
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Diese Woche</CardTitle>
+          <CardTitle className="text-base">{t('pomodoroStats.thisWeek')}</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="h-40">
@@ -125,7 +127,7 @@ const PomodoroStats: React.FC = () => {
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Dieser Monat</CardTitle>
+          <CardTitle className="text-base">{t('pomodoroStats.thisMonth')}</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="h-40">
@@ -144,7 +146,7 @@ const PomodoroStats: React.FC = () => {
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Dieses Jahr</CardTitle>
+          <CardTitle className="text-base">{t('pomodoroStats.thisYear')}</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="h-40">

--- a/src/components/PomodoroTimer.tsx
+++ b/src/components/PomodoroTimer.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import ReactDOM from 'react-dom/client';
 import { Button } from '@/components/ui/button';
 import { create } from 'zustand';
@@ -145,6 +146,7 @@ const PomodoroTimer: React.FC<PomodoroTimerProps> = ({ compact, size = 80, float
   } = usePomodoroStore();
   const { pomodoro, updatePomodoro } = useSettings();
   const { addSession, endBreak } = usePomodoroHistory();
+  const { t } = useTranslation();
   const pipWindowRef = useRef<Window | null>(null);
   const [now, setNow] = useState(Date.now());
   const [position, setPosition] = useState<{ x: number; y: number }>(() => {
@@ -353,42 +355,44 @@ const PomodoroTimer: React.FC<PomodoroTimerProps> = ({ compact, size = 80, float
           <div
             className={size > 100 ? 'text-4xl font-bold' : 'text-2xl font-bold'}
           >
-            {isPaused ? `Pause: ${formatTime(pauseDuration)}` : formatTime(remainingTime)}
+            {isPaused
+              ? `${t('pomodoroTimer.pauseLabel')} ${formatTime(pauseDuration)}`
+              : formatTime(remainingTime)}
           </div>
         </div>
       </div>
       <div className="flex space-x-2 mt-4">
-        {!isRunning && <Button onClick={() => start()}>Start</Button>}
+        {!isRunning && <Button onClick={() => start()}>{t('pomodoroTimer.start')}</Button>}
         {isRunning && !isPaused && (
           <Button onClick={handlePause} variant="outline">
-            Pause
+            {t('pomodoroTimer.pause')}
           </Button>
         )}
         {isRunning && !isPaused && mode === 'work' && !floating && !compact && (
           <Button onClick={handleStartBreak} variant="outline">
-            Break
+            {t('pomodoroTimer.break')}
           </Button>
         )}
         {isRunning && isPaused && (
           <Button onClick={handleResume} variant="outline">
-            Weiter
+            {t('pomodoroTimer.resume')}
           </Button>
         )}
         {isRunning && !floating && !compact && (
           <Button onClick={handleReset} variant="outline">
-            Reset
+            {t('pomodoroTimer.reset')}
           </Button>
         )}
         {!floating && (
           <Button onClick={openFloatingWindow} variant="outline">
-            Float
+            {t('pomodoroTimer.float')}
           </Button>
         )}
       </div>
       {!floating && !compact && (
       <div className="flex space-x-2 mt-2 text-xs">
         <div className="flex items-center space-x-1">
-          <span>Arbeit</span>
+          <span>{t('pomodoroTimer.workLabel')}</span>
           <input
             type="number"
             className="w-12 border rounded px-1"
@@ -399,7 +403,7 @@ const PomodoroTimer: React.FC<PomodoroTimerProps> = ({ compact, size = 80, float
           />
         </div>
         <div className="flex items-center space-x-1">
-          <span>Pause</span>
+          <span>{t('pomodoroTimer.breakLabel')}</span>
           <input
             type="number"
             className="w-12 border rounded px-1"

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -239,5 +239,31 @@
     "completed": "Task abgeschlossen",
     "reactivated": "Task reaktiviert",
     "deleteConfirm": "Sind Sie sicher, dass Sie \"{{title}}\" löschen möchten?"
+  },
+  "pomodoroTimer": {
+    "start": "Start",
+    "pause": "Pause",
+    "resume": "Weiter",
+    "break": "Pause",
+    "reset": "Reset",
+    "float": "Float",
+    "workLabel": "Arbeit",
+    "breakLabel": "Pause",
+    "pauseLabel": "Pause:"
+  },
+  "pomodoroStats": {
+    "total": "Gesamt",
+    "today": "Heute",
+    "thisWeek": "Diese Woche",
+    "thisMonth": "Dieser Monat",
+    "thisYear": "Dieses Jahr",
+    "work": "Arbeit",
+    "break": "Pause",
+    "cycles": "Zyklen",
+    "morning": "Morgen",
+    "afternoon": "Mittag",
+    "evening": "Abend",
+    "night": "Nacht",
+    "timesOfDayTotal": "Tageszeiten (Gesamt)"
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -239,5 +239,31 @@
     "completed": "Task completed",
     "reactivated": "Task reactivated",
     "deleteConfirm": "Are you sure you want to delete \"{{title}}\"?"
+  },
+  "pomodoroTimer": {
+    "start": "Start",
+    "pause": "Pause",
+    "resume": "Resume",
+    "break": "Break",
+    "reset": "Reset",
+    "float": "Float",
+    "workLabel": "Work",
+    "breakLabel": "Break",
+    "pauseLabel": "Pause:"
+  },
+  "pomodoroStats": {
+    "total": "Total",
+    "today": "Today",
+    "thisWeek": "This Week",
+    "thisMonth": "This Month",
+    "thisYear": "This Year",
+    "work": "Work",
+    "break": "Break",
+    "cycles": "Cycles",
+    "morning": "Morning",
+    "afternoon": "Afternoon",
+    "evening": "Evening",
+    "night": "Night",
+    "timesOfDayTotal": "Times of Day (Total)"
   }
 }


### PR DESCRIPTION
## Summary
- add new EN/DE translations for the Pomodoro timer and stats
- hook PomodoroTimer and PomodoroStats into i18n

## Testing
- `npm run lint` *(fails: 31 errors, 28 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684ff62d5694832aa83240309fa349fb