### PR TITLE
Fix multi-language texts

### DIFF
--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -151,13 +151,15 @@
     },
     "category": "Kategorie",
     "total": "Gesamt",
-    "progress": "Fortschritt"
+    "progress": "Fortschritt",
+    "ofTasks": "der Tasks"
   },
   "deckDetail": {
     "newCard": "Neue Karte",
     "noCards": "Noch keine Karten vorhanden.",
     "notFound": "Deck nicht gefunden.",
-    "cardNumber": "Karte {{number}}"
+    "cardNumber": "Karte {{number}}",
+    "dueProgress": "{{due}}/{{total}} fällig"
   },
   "releaseNotes": {
     "title": "Release Notes",
@@ -166,13 +168,17 @@
   "flashcardManager": {
     "title": "Decks",
     "newDeck": "Neues Deck",
-    "none": "Noch keine Decks vorhanden."
+    "none": "Noch keine Decks vorhanden.",
+    "cards": "{{count}} Karte",
+    "cards_plural": "{{count}} Karten",
+    "dueProgress": "{{due}}/{{total}} fällig"
   },
   "flashcardStats": {
     "title": "Karten Statistiken",
     "totalCards": "Gesamt Karten",
     "due": "Fällig",
     "avgInterval": "Ø Intervall",
+    "days": "Tage",
     "difficulty": "Schwierigkeiten",
     "upcoming": "Fälligkeit nächste 7 Tage",
     "deckDetails": "Decks im Detail",
@@ -205,6 +211,8 @@
     "sessionDone": "Session beendet",
     "continue": "Weiter",
     "allDone": "Alle Karten durch",
+    "pause": "Pause",
+    "cardProgress": "Karte {{number}} / {{total}}",
     "correct": "Richtig!",
     "wrong": "Falsch",
     "description": {
@@ -227,7 +235,8 @@
     "title": "Zeitplan",
     "day": "Tag",
     "week": "Woche",
-    "month": "Monat"
+    "month": "Monat",
+    "more": "+{{count}} mehr"
   },
   "kanban": {
     "todo": "To Do",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -151,13 +151,15 @@
     },
     "category": "Category",
     "total": "Total",
-    "progress": "Progress"
+    "progress": "Progress",
+    "ofTasks": "of tasks"
   },
   "deckDetail": {
     "newCard": "New Card",
     "noCards": "No cards available.",
     "notFound": "Deck not found.",
-    "cardNumber": "Card {{number}}"
+    "cardNumber": "Card {{number}}",
+    "dueProgress": "{{due}}/{{total}} due"
   },
   "releaseNotes": {
     "title": "Release Notes",
@@ -166,13 +168,17 @@
   "flashcardManager": {
     "title": "Decks",
     "newDeck": "New Deck",
-    "none": "No decks available."
+    "none": "No decks available.",
+    "cards": "{{count}} card",
+    "cards_plural": "{{count}} cards",
+    "dueProgress": "{{due}}/{{total}} due"
   },
   "flashcardStats": {
     "title": "Card Statistics",
     "totalCards": "Total Cards",
     "due": "Due",
     "avgInterval": "Avg Interval",
+    "days": "days",
     "difficulty": "Difficulty",
     "upcoming": "Due Next 7 Days",
     "deckDetails": "Deck Details",
@@ -205,6 +211,8 @@
     "sessionDone": "Session ended",
     "continue": "Continue",
     "allDone": "All cards done",
+    "pause": "Pause",
+    "cardProgress": "Card {{number}} / {{total}}",
     "correct": "Correct!",
     "wrong": "Wrong",
     "description": {
@@ -227,7 +235,8 @@
     "title": "Schedule",
     "day": "Day",
     "week": "Week",
-    "month": "Month"
+    "month": "Month",
+    "more": "+{{count}} more"
   },
   "kanban": {
     "todo": "To Do",

--- a/src/pages/DeckDetail.tsx
+++ b/src/pages/DeckDetail.tsx
@@ -47,7 +47,7 @@ const DeckDetailPage: React.FC = () => {
       <div className="max-w-2xl mx-auto py-8 px-4 space-y-4">
         <div className="flex items-center justify-between">
           <span className="text-sm text-muted-foreground">
-            {dueCount}/{totalCount} fällig
+            {t('deckDetail.dueProgress', { due: dueCount, total: totalCount })}
           </span>
           <Button size="sm" onClick={() => setIsModalOpen(true)}>
             <Plus className="h-4 w-4 mr-2" /> {t('deckDetail.newCard')}

--- a/src/pages/FlashcardManager.tsx
+++ b/src/pages/FlashcardManager.tsx
@@ -54,8 +54,10 @@ const FlashcardManagerPage: React.FC = () => {
                     <CardTitle>{deck.name}</CardTitle>
                   </CardHeader>
                   <CardContent>
-                    {total} Karte{total !== 1 ? 'n' : ''}
-                    <div className="text-sm text-muted-foreground">{due}/{total} fällig</div>
+                    {t('flashcardManager.cards', { count: total })}
+                    <div className="text-sm text-muted-foreground">
+                      {t('flashcardManager.dueProgress', { due, total })}
+                    </div>
                   </CardContent>
                   <CardFooter className="flex justify-end space-x-2">
                     <Button variant="outline" size="sm" onClick={e => { e.stopPropagation(); setEditingDeck(deck); setIsDeckModalOpen(true); }}>

--- a/src/pages/FlashcardStatistics.tsx
+++ b/src/pages/FlashcardStatistics.tsx
@@ -79,7 +79,8 @@ const FlashcardStatisticsPage: React.FC = () => {
             </CardHeader>
             <CardContent>
               <div className="text-lg sm:text-2xl font-bold text-primary">
-                {Math.round(stats.averageInterval * 10) / 10} Tage
+                {Math.round(stats.averageInterval * 10) / 10}{' '}
+                {t('flashcardStats.days')}
               </div>
             </CardContent>
           </Card>

--- a/src/pages/Flashcards.tsx
+++ b/src/pages/Flashcards.tsx
@@ -74,39 +74,23 @@ const FlashcardsPage: React.FC = () => {
     ? 'timed'
     : 'spaced';
 
-  const modeLabel = useMemo(() => {
-    switch (mode) {
-      case 'training':
-        return 'Training';
-      case 'random':
-        return 'Random';
-      case 'typing':
-        return 'Eingabe';
-      case 'timed':
-        return 'Timed';
-      default:
-        return 'Spaced Repetition';
-    }
-  }, [mode]);
-
   const modeDescription = useMemo(() => {
-    switch (mode) {
-      case 'training':
-        return 'Im Training-Modus werden Karten zufällig wiederholt, bis sie richtig beantwortet wurden. Bewertungen beeinflussen den Spaced-Repetition-Algorithmus nicht.';
-      case 'random':
-        return 'Im Random-Modus werden alle ausgewählten Karten in zufälliger Reihenfolge angezeigt. Bewertungen wirken sich nicht auf den Algorithmus aus.';
-      case 'typing':
-        return useSpaced
-          ? 'Im Eingabe-Modus tippst du die Antwort ein. Bewertungen beeinflussen den Algorithmus.'
-          : 'Im Eingabe-Modus tippst du die Antwort ein. Bewertungen beeinflussen den Algorithmus nicht.';
-      case 'timed':
-        return useSpaced
-          ? 'Im Timed-Modus hast du ein Zeitlimit pro Karte. Bewertungen beeinflussen den Algorithmus.'
-          : 'Im Timed-Modus hast du ein Zeitlimit pro Karte. Bewertungen beeinflussen den Algorithmus nicht.';
-      default:
-        return 'Spaced Repetition zeigt nur fällige Karten entsprechend deinem Lernfortschritt an.';
+    if (mode === 'typing') {
+      return t(
+        useSpaced
+          ? 'flashcardsPage.description.typingSpaced'
+          : 'flashcardsPage.description.typing'
+      );
     }
-  }, [mode, useSpaced]);
+    if (mode === 'timed') {
+      return t(
+        useSpaced
+          ? 'flashcardsPage.description.timedSpaced'
+          : 'flashcardsPage.description.timed'
+      );
+    }
+    return t(`flashcardsPage.description.${mode}`);
+  }, [mode, useSpaced, t]);
   const handleModeChange = (
     value: 'spaced' | 'training' | 'random' | 'typing' | 'timed'
   ) => {
@@ -349,9 +333,17 @@ const FlashcardsPage: React.FC = () => {
               <div className="mt-2">
                 <div className="flex items-center justify-between mb-1">
                   <span className="text-xs text-muted-foreground">
-                    Karte {index + 1} / {sessionTotalCards}
+                    {t('flashcardsPage.cardProgress', {
+                      number: index + 1,
+                      total: sessionTotalCards
+                    })}
                     {trainingMode && (
-                      <> ({overallCardNumber} / {overallTotalCards})</>
+                      <> (
+                        {t('flashcardsPage.cardProgress', {
+                          number: overallCardNumber,
+                          total: overallTotalCards
+                        })}
+                      )</>
                     )}
                   </span>
                   <span className="text-xs text-muted-foreground">
@@ -368,12 +360,20 @@ const FlashcardsPage: React.FC = () => {
                     {Math.max(timeLeft, 0)}
                   </div>
                   {timerPaused ? (
-                    <Button size="sm" variant="outline" onClick={() => setTimerPaused(false)}>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setTimerPaused(false)}
+                    >
                       {t('flashcardsPage.continue')}
                     </Button>
                   ) : (
-                    <Button size="sm" variant="outline" onClick={() => setTimerPaused(true)}>
-                      Pause
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setTimerPaused(true)}
+                    >
+                      {t('flashcardsPage.pause')}
                     </Button>
                   )}
                 </div>

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -76,7 +76,9 @@ const Statistics = () => {
             </CardHeader>
             <CardContent>
               <div className="text-lg sm:text-2xl font-bold text-accent">{stats.completedTasks}</div>
-              <p className="text-xs text-muted-foreground">{completionRate}% der Tasks</p>
+              <p className="text-xs text-muted-foreground">
+                {completionRate}% {t('statistics.ofTasks')}
+              </p>
             </CardContent>
           </Card>
 

--- a/src/pages/TimeBlocking.tsx
+++ b/src/pages/TimeBlocking.tsx
@@ -501,7 +501,9 @@ const TimeBlockingPage = () => {
                       ))}
                       {getTasksFor(d).length > 3 && (
                         <div className="text-muted-foreground">
-                          +{getTasksFor(d).length - 3} mehr
+                          {t('timeBlocking.more', {
+                            count: getTasksFor(d).length - 3
+                          })}
                         </div>
                       )}
                     </>


### PR DESCRIPTION
## Summary
- translate progress counters in deck detail view and flashcard manager
- localize flashcard UI strings
- add translation for time blocking hint and statistics label
- show localized days in flashcard statistics
- update translation files

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ff9d5a294832a978af98e59c938a4