### PR TITLE
Improve i18n coverage

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   CommandDialog,
   CommandInput,
@@ -36,6 +37,7 @@ const CommandPalette: React.FC = () => {
   const { flashcards, decks, addFlashcard } = useFlashcardStore()
   const { shortcuts, defaultTaskPriority } = useSettings()
   const { toast } = useToast()
+  const { t } = useTranslation()
   const { currentCategoryId, setCurrentCategoryId } = useCurrentCategory()
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
@@ -111,14 +113,14 @@ const CommandPalette: React.FC = () => {
         categoryId: currentCategoryId || 'default',
         isRecurring: false
       })
-      toast({ description: 'Task erstellt' })
+      toast({ description: t('commandPalette.taskCreated') })
     } else if (mode === 'note') {
       addNote({ title, text: '', color: '#F59E0B' })
-      toast({ description: 'Notiz erstellt' })
+      toast({ description: t('commandPalette.noteCreated') })
     } else if (mode === 'flashcard') {
       if (decks.length > 0) {
         addFlashcard({ front: title, back: '', deckId: decks[0].id })
-        toast({ description: 'Karte erstellt' })
+        toast({ description: t('commandPalette.cardCreated') })
       }
     }
     setValue('')
@@ -130,10 +132,10 @@ const CommandPalette: React.FC = () => {
       <CommandInput
         placeholder={
           mode === 'task'
-            ? 'Task-Titel eingeben...'
+            ? t('commandPalette.placeholderTask')
             : mode === 'note'
-              ? 'Notiz-Titel eingeben...'
-              : 'Vorderseite eingeben...'
+              ? t('commandPalette.placeholderNote')
+              : t('commandPalette.placeholderCard')
         }
         value={value}
         onValueChange={setValue}
@@ -146,7 +148,7 @@ const CommandPalette: React.FC = () => {
       />
       <CommandList>
         {filteredTasks.length > 0 && (
-          <CommandGroup heading="Tasks">
+          <CommandGroup heading={t('commandPalette.tasks')}>
             {filteredTasks.map(item => (
               <CommandItem
                 key={`task-${item.task.id}`}
@@ -165,7 +167,7 @@ const CommandPalette: React.FC = () => {
           </CommandGroup>
         )}
         {filteredNotes.length > 0 && (
-          <CommandGroup heading="Notizen">
+          <CommandGroup heading={t('commandPalette.notes')}>
             {filteredNotes.map(note => (
               <CommandItem
                 key={`note-${note.id}`}
@@ -181,7 +183,7 @@ const CommandPalette: React.FC = () => {
           </CommandGroup>
         )}
         {filteredCards.length > 0 && (
-          <CommandGroup heading="Karten">
+          <CommandGroup heading={t('commandPalette.cards')}>
             {filteredCards.map(card => {
               const deck = decks.find(d => d.id === card.deckId)
               return (
@@ -201,7 +203,7 @@ const CommandPalette: React.FC = () => {
         )}
         {filteredTasks.length === 0 &&
           filteredNotes.length === 0 &&
-          filteredCards.length === 0 && <CommandEmpty>Keine Ergebnisse</CommandEmpty>}
+          filteredCards.length === 0 && <CommandEmpty>{t('commandPalette.noResults')}</CommandEmpty>}
       </CommandList>
     </CommandDialog>
   )

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState, useMemo, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Task, Category, TaskFormData, CategoryFormData, Note } from '@/types';
 import { useTaskStore } from '@/hooks/useTaskStore';
 import { useCurrentCategory } from '@/hooks/useCurrentCategory';
@@ -40,6 +41,7 @@ import Navbar from './Navbar';
 import { usePomodoroStore } from './PomodoroTimer';
 
 const Dashboard: React.FC = () => {
+  const { t } = useTranslation();
   const {
     tasks,
     categories,
@@ -367,7 +369,7 @@ const Dashboard: React.FC = () => {
         <div className="grid grid-cols-1 sm:grid-cols-4 gap-4 sm:gap-6 mb-6 sm:mb-8">
           <Card>
             <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground">Gesamt Tasks</CardTitle>
+              <CardTitle className="text-sm font-medium text-muted-foreground">{t('dashboard.totalTasks')}</CardTitle>
             </CardHeader>
             <CardContent>
               <div className="text-xl sm:text-2xl font-bold text-foreground">{totalTasks}</div>
@@ -375,18 +377,18 @@ const Dashboard: React.FC = () => {
           </Card>
           <Card>
             <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground">Abgeschlossen</CardTitle>
+              <CardTitle className="text-sm font-medium text-muted-foreground">{t('dashboard.completed')}</CardTitle>
             </CardHeader>
             <CardContent>
               <div className="text-xl sm:text-2xl font-bold text-accent">{completedTasks}</div>
               <div className="text-xs sm:text-sm text-muted-foreground">
-                {totalTasks > 0 ? Math.round((completedTasks / totalTasks) * 100) : 0}% erledigt
+                {totalTasks > 0 ? Math.round((completedTasks / totalTasks) * 100) : 0}% {t('statistics.ofTasks')}
               </div>
             </CardContent>
           </Card>
           <Card>
             <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground">Offen</CardTitle>
+              <CardTitle className="text-sm font-medium text-muted-foreground">{t('dashboard.pending')}</CardTitle>
             </CardHeader>
             <CardContent>
               <div className="text-xl sm:text-2xl font-bold text-primary">{pendingTasks}</div>
@@ -394,7 +396,7 @@ const Dashboard: React.FC = () => {
           </Card>
           <Card>
             <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground">Kategorien</CardTitle>
+              <CardTitle className="text-sm font-medium text-muted-foreground">{t('dashboard.categories')}</CardTitle>
             </CardHeader>
             <CardContent>
               <div className="text-xl sm:text-2xl font-bold text-primary">{totalCategories}</div>
@@ -407,14 +409,14 @@ const Dashboard: React.FC = () => {
         {viewMode === 'categories' ? (
           <div>
             <div className="flex items-center justify-between mb-4 sm:mb-6">
-              <h2 className="text-lg sm:text-xl font-semibold text-foreground">Kategorien</h2>
-              <Badge variant="secondary">{filteredCategories.length} Kategorien</Badge>
+              <h2 className="text-lg sm:text-xl font-semibold text-foreground">{t('dashboard.categories')}</h2>
+              <Badge variant="secondary">{t('dashboard.categoriesBadge', { count: filteredCategories.length })}</Badge>
             </div>
             <div className="flex items-center gap-2 mb-4 sm:mb-6">
               <div className="relative flex-1 sm:max-w-xs">
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
                 <Input
-                  placeholder="Kategorien suchen..."
+                  placeholder={t('dashboard.searchCategories')}
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
                   className="pl-10 w-full"
@@ -437,7 +439,7 @@ const Dashboard: React.FC = () => {
               </div>
               <Button onClick={() => setIsCategoryModalOpen(true)} size="sm">
                 <Plus className="h-4 w-4 mr-2" />
-                Kategorie
+                {t('taskModal.category')}
               </Button>
             </div>
             
@@ -446,18 +448,17 @@ const Dashboard: React.FC = () => {
                 <CardContent>
                   <LayoutGrid className="h-10 w-10 sm:h-12 sm:w-12 text-gray-400 mx-auto mb-4" />
                   <h3 className="text-base sm:text-lg font-medium text-gray-900 mb-2">
-                    {searchTerm ? 'Keine Kategorien gefunden' : 'Keine Kategorien vorhanden'}
+                    {searchTerm ? t('dashboard.noCategoriesFound') : t('dashboard.noCategories')}
                   </h3>
                   <p className="text-sm sm:text-base text-gray-600 mb-4">
-                    {searchTerm 
-                      ? 'Versuchen Sie einen anderen Suchbegriff.'
-                      : 'Erstellen Sie Ihre erste Kategorie, um mit der Organisation Ihrer Tasks zu beginnen.'
-                    }
+                    {searchTerm
+                      ? t('dashboard.trySearch')
+                      : t('dashboard.createFirstCategory')}
                   </p>
                   {!searchTerm && (
                     <Button onClick={() => setIsCategoryModalOpen(true)} size="sm">
                       <Plus className="h-4 w-4 mr-2" />
-                      Erste Kategorie erstellen
+                      {t('dashboard.firstCategoryButton')}
                     </Button>
                   )}
                 </CardContent>
@@ -507,15 +508,15 @@ const Dashboard: React.FC = () => {
                 >
                   <ArrowLeft className="h-4 w-4" />
                 </Button>
-                <h2 className="text-lg sm:text-xl font-semibold text-foreground">Tasks</h2>
+                <h2 className="text-lg sm:text-xl font-semibold text-foreground">{t('dashboard.tasksTitle')}</h2>
               </div>
-              <Badge variant="secondary">{filteredTasks.length} Tasks</Badge>
+              <Badge variant="secondary">{t('dashboard.tasksBadge', { count: filteredTasks.length })}</Badge>
             </div>
             <div className="flex items-center gap-2 mb-4 sm:mb-6">
               <div className="relative flex-1 sm:max-w-xs">
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
                 <Input
-                  placeholder="Tasks suchen..."
+                  placeholder={t('dashboard.searchTasks')}
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
                   className="pl-10 w-full"
@@ -578,7 +579,7 @@ const Dashboard: React.FC = () => {
               </div>
               <Button onClick={() => setIsTaskModalOpen(true)} size="sm">
                 <Plus className="h-4 w-4 mr-2" />
-                Task
+                {t('taskModal.newTitle')}
               </Button>
             </div>
             
@@ -587,18 +588,17 @@ const Dashboard: React.FC = () => {
                 <CardContent>
                   <List className="h-10 w-10 sm:h-12 sm:w-12 text-gray-400 mx-auto mb-4" />
                   <h3 className="text-base sm:text-lg font-medium text-gray-900 mb-2">
-                    {searchTerm ? 'Keine Tasks gefunden' : 'Keine Tasks vorhanden'}
+                    {searchTerm ? t('dashboard.noTasksFound') : t('dashboard.noTasks')}
                   </h3>
                   <p className="text-sm sm:text-base text-gray-600 mb-4">
-                    {searchTerm 
-                      ? 'Versuchen Sie einen anderen Suchbegriff.'
-                      : `Erstellen Sie Ihre erste Task in der Kategorie "${selectedCategory?.name}".`
-                    }
+                    {searchTerm
+                      ? t('dashboard.trySearch')
+                      : t('dashboard.createFirstTask', { category: selectedCategory?.name })}
                   </p>
                   {!searchTerm && (
                     <Button onClick={() => setIsTaskModalOpen(true)} size="sm">
                       <Plus className="h-4 w-4 mr-2" />
-                      Erste Task erstellen
+                      {t('dashboard.firstTaskButton')}
                     </Button>
                   )}
                 </CardContent>

--- a/src/components/TaskDetailModal.tsx
+++ b/src/components/TaskDetailModal.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Task, Category } from '@/types';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
@@ -50,6 +51,7 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
   onBack
 }) => {
   if (!task) return null;
+  const { t } = useTranslation();
 
   const { updateTask } = useTaskStore();
 
@@ -208,7 +210,7 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
 
             {task.subtasks.length === 0 && (
               <div className="text-center py-8 text-gray-500">
-                <p>Keine Unteraufgaben vorhanden.</p>
+                <p>{t('taskDetail.noSubtasks')}</p>
                 <Button
                   variant="outline"
                   size="sm"

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -34,7 +34,15 @@
     },
     "languageLabel": "Sprache der Anwendung",
     "english": "Englisch",
-    "german": "Deutsch"
+    "german": "Deutsch",
+    "version": "Version",
+    "serverInfo": {
+      "title": "Server Info",
+      "port": "Port",
+      "ips": "IPs",
+      "urls": "URLs",
+      "loading": "Lade..."
+    }
   },
   "noteModal": {
     "editTitle": "Notiz bearbeiten",
@@ -274,5 +282,40 @@
     "evening": "Abend",
     "night": "Nacht",
     "timesOfDayTotal": "Tageszeiten (Gesamt)"
+  },
+  "commandPalette": {
+    "taskCreated": "Task erstellt",
+    "noteCreated": "Notiz erstellt",
+    "cardCreated": "Karte erstellt",
+    "placeholderTask": "Task-Titel eingeben...",
+    "placeholderNote": "Notiz-Titel eingeben...",
+    "placeholderCard": "Vorderseite eingeben...",
+    "tasks": "Tasks",
+    "notes": "Notizen",
+    "cards": "Karten",
+    "noResults": "Keine Ergebnisse"
+  },
+  "dashboard": {
+    "totalTasks": "Gesamt Tasks",
+    "completed": "Abgeschlossen",
+    "pending": "Offen",
+    "categories": "Kategorien",
+    "categoriesBadge": "{{count}} Kategorien",
+    "tasksTitle": "Tasks",
+    "tasksBadge": "{{count}} Tasks",
+    "searchCategories": "Kategorien suchen...",
+    "searchTasks": "Tasks suchen...",
+    "noCategories": "Keine Kategorien vorhanden",
+    "noCategoriesFound": "Keine Kategorien gefunden",
+    "trySearch": "Versuchen Sie einen anderen Suchbegriff.",
+    "createFirstCategory": "Erstellen Sie Ihre erste Kategorie, um mit der Organisation Ihrer Tasks zu beginnen.",
+    "firstCategoryButton": "Erste Kategorie erstellen",
+    "noTasks": "Keine Tasks vorhanden",
+    "noTasksFound": "Keine Tasks gefunden",
+    "createFirstTask": "Erstellen Sie Ihre erste Task in der Kategorie \"{{category}}\".",
+    "firstTaskButton": "Erste Task erstellen"
+  },
+  "taskDetail": {
+    "noSubtasks": "Keine Unteraufgaben vorhanden."
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -34,7 +34,15 @@
     },
     "languageLabel": "App Language",
     "english": "English",
-    "german": "German"
+    "german": "German",
+    "version": "Version",
+    "serverInfo": {
+      "title": "Server Info",
+      "port": "Port",
+      "ips": "IPs",
+      "urls": "URLs",
+      "loading": "Loading..."
+    }
   },
   "noteModal": {
     "editTitle": "Edit Note",
@@ -274,5 +282,40 @@
     "evening": "Evening",
     "night": "Night",
     "timesOfDayTotal": "Times of Day (Total)"
+  },
+  "commandPalette": {
+    "taskCreated": "Task created",
+    "noteCreated": "Note created",
+    "cardCreated": "Card created",
+    "placeholderTask": "Enter task title...",
+    "placeholderNote": "Enter note title...",
+    "placeholderCard": "Enter front text...",
+    "tasks": "Tasks",
+    "notes": "Notes",
+    "cards": "Cards",
+    "noResults": "No results"
+  },
+  "dashboard": {
+    "totalTasks": "Total Tasks",
+    "completed": "Completed",
+    "pending": "Open",
+    "categories": "Categories",
+    "categoriesBadge": "{{count}} Categories",
+    "tasksTitle": "Tasks",
+    "tasksBadge": "{{count}} Tasks",
+    "searchCategories": "Search categories...",
+    "searchTasks": "Search tasks...",
+    "noCategories": "No categories available",
+    "noCategoriesFound": "No categories found",
+    "trySearch": "Try another search term.",
+    "createFirstCategory": "Create your first category to start organizing your tasks.",
+    "firstCategoryButton": "Create First Category",
+    "noTasks": "No tasks available",
+    "noTasksFound": "No tasks found",
+    "createFirstTask": "Create your first task in the \"{{category}}\" category.",
+    "firstTaskButton": "Create First Task"
+  },
+  "taskDetail": {
+    "noSubtasks": "No subtasks available."
   }
 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -653,12 +653,12 @@ const SettingsPage: React.FC = () => {
             </div>
           </TabsContent>
           <TabsContent value="server" className="space-y-4">
-            <h2 className="font-semibold">Server Info</h2>
+            <h2 className="font-semibold">{t('settings.serverInfo.title')}</h2>
             {serverInfo ? (
               <div className="space-y-2">
-                <p>Port: {serverInfo.port}</p>
+                <p>{t('settings.serverInfo.port')}: {serverInfo.port}</p>
                 <div>
-                  <p className="font-medium">IPs</p>
+                  <p className="font-medium">{t('settings.serverInfo.ips')}</p>
                   <ul className="list-disc list-inside space-y-1">
                     {serverInfo.ips.map(ip => (
                       <li key={ip}>{ip}</li>
@@ -666,7 +666,7 @@ const SettingsPage: React.FC = () => {
                   </ul>
                 </div>
                 <div>
-                  <p className="font-medium">URLs</p>
+                  <p className="font-medium">{t('settings.serverInfo.urls')}</p>
                   <ul className="list-disc list-inside space-y-1">
                     {serverInfo.urls.map(url => (
                       <li key={url}>{url}</li>
@@ -675,7 +675,7 @@ const SettingsPage: React.FC = () => {
                 </div>
               </div>
             ) : (
-              <p>Lade...</p>
+              <p>{t('settings.serverInfo.loading')}</p>
             )}
           </TabsContent>
           <TabsContent value="info" className="space-y-4">
@@ -683,17 +683,17 @@ const SettingsPage: React.FC = () => {
               <ReactMarkdown>{readme}</ReactMarkdown>
             </div>
             <p className="text-sm text-muted-foreground">
-              Version {__APP_VERSION__}{' '}
+              {t('settings.version')} {__APP_VERSION__}{' '}
               <Link to="/release-notes" className="underline">
-                Release Notes
+                {t('releaseNotes.title')}
               </Link>
             </p>
           </TabsContent>
         </Tabs>
         <p className="text-xs text-muted-foreground mt-4">
-          Version {__APP_VERSION__}{' '}
+          {t('settings.version')} {__APP_VERSION__}{' '}
           <Link to="/release-notes" className="underline">
-            Release Notes
+            {t('releaseNotes.title')}
           </Link>
         </p>
       </div>


### PR DESCRIPTION
## Summary
- add missing English and German translations
- use `useTranslation` in CommandPalette, Dashboard, TaskDetailModal, and Settings
- replace hard coded strings with translation keys

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ffcb6f9b4832aac22ccdaec818987