### PR TITLE
Implement missing i18n strings

### DIFF
--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Category, Task } from '@/types';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -23,6 +24,7 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
   onDelete,
   onViewTasks
 }) => {
+  const { t } = useTranslation();
   const totalTasks = tasks.length;
   const completedTasks = tasks.filter(task => {
     const progress = getTaskProgress(task);
@@ -76,7 +78,7 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
                   e.stopPropagation();
                   onDelete(category.id);
                 }}
-                title="Löschen (rückgängig möglich)"
+                title={t('categoryCard.deleteTooltip')}
                 className="h-8 w-8 p-0 text-destructive hover:text-destructive/80"
               >
                 <Trash2 className="h-4 w-4" />
@@ -100,7 +102,7 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
               <DropdownMenuContent align="end" className="bg-background z-50">
                 <DropdownMenuItem onClick={() => onEdit(category)}>
                   <Edit className="h-4 w-4 mr-2" />
-                  Bearbeiten
+                  {t('common.edit')}
                 </DropdownMenuItem>
                 {category.id !== 'default' && (
                   <DropdownMenuItem
@@ -108,7 +110,7 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
                     className="text-destructive"
                   >
                     <Trash2 className="h-4 w-4 mr-2" />
-                    Löschen (Undo möglich)
+                    {t('categoryCard.deleteMenu')}
                   </DropdownMenuItem>
                 )}
               </DropdownMenuContent>
@@ -123,7 +125,7 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
             <div className="flex items-center space-x-2">
               <FolderOpen className="h-4 w-4 text-muted-foreground flex-shrink-0" />
               <span className="text-xs sm:text-sm text-muted-foreground">
-                {totalTasks} Task{totalTasks !== 1 ? 's' : ''}
+                {t('dashboard.tasksBadge', { count: totalTasks })}
               </span>
             </div>
             <Badge 
@@ -135,7 +137,7 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
                 borderColor: `${category.color}40`
               }}
             >
-              {Math.round(completionPercentage)}% erledigt
+              {t('categoryCard.percentDone', { percent: Math.round(completionPercentage) })}
             </Badge>
           </div>
           
@@ -150,7 +152,7 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
           </div>
           
           <div className="text-xs text-muted-foreground text-center">
-            {completedTasks} von {totalTasks} abgeschlossen
+            {t('categoryCard.completedOfTotal', { completed: completedTasks, total: totalTasks })}
           </div>
         </div>
       </CardContent>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -423,17 +423,17 @@ const Dashboard: React.FC = () => {
                 />
               </div>
               <div className="flex items-center gap-1">
-                <Label className="text-sm">Sortierung:</Label>
+                <Label className="text-sm">{t('dashboard.sortLabel')}</Label>
                 <Select value={sortCriteria} onValueChange={setSortCriteria}>
                   <SelectTrigger className="w-32">
-                    <SelectValue placeholder="Sortierung" />
+                    <SelectValue placeholder={t('dashboard.sortLabel')} />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="order">Manuell</SelectItem>
-                    <SelectItem value="created-desc">Neueste zuerst</SelectItem>
-                    <SelectItem value="created-asc">Älteste zuerst</SelectItem>
-                    <SelectItem value="title-asc">Titel A-Z</SelectItem>
-                    <SelectItem value="title-desc">Titel Z-A</SelectItem>
+                    <SelectItem value="order">{t('dashboard.sort.manual')}</SelectItem>
+                    <SelectItem value="created-desc">{t('dashboard.sort.createdDesc')}</SelectItem>
+                    <SelectItem value="created-asc">{t('dashboard.sort.createdAsc')}</SelectItem>
+                    <SelectItem value="title-asc">{t('dashboard.sort.titleAsc')}</SelectItem>
+                    <SelectItem value="title-desc">{t('dashboard.sort.titleDesc')}</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
@@ -523,46 +523,46 @@ const Dashboard: React.FC = () => {
                 />
               </div>
               <div className="flex items-center gap-1">
-                <Label className="text-sm">Sortierung:</Label>
+                <Label className="text-sm">{t('dashboard.sortLabel')}</Label>
                 <Select value={sortCriteria} onValueChange={setSortCriteria}>
                   <SelectTrigger className="w-36">
-                    <SelectValue placeholder="Sortierung" />
+                    <SelectValue placeholder={t('dashboard.sortLabel')} />
                   </SelectTrigger>
                 <SelectContent>
-                    <SelectItem value="order">Manuell</SelectItem>
-                    <SelectItem value="created-desc">Neueste zuerst</SelectItem>
-                    <SelectItem value="created-asc">Älteste zuerst</SelectItem>
-                    <SelectItem value="title-asc">Titel A-Z</SelectItem>
-                    <SelectItem value="title-desc">Titel Z-A</SelectItem>
-                    <SelectItem value="priority-asc">Priorität ↑</SelectItem>
-                    <SelectItem value="priority-desc">Priorität ↓</SelectItem>
-                    <SelectItem value="due-asc">Fälligkeitsdatum ↑</SelectItem>
-                    <SelectItem value="due-desc">Fälligkeitsdatum ↓</SelectItem>
+                    <SelectItem value="order">{t('dashboard.sort.manual')}</SelectItem>
+                    <SelectItem value="created-desc">{t('dashboard.sort.createdDesc')}</SelectItem>
+                    <SelectItem value="created-asc">{t('dashboard.sort.createdAsc')}</SelectItem>
+                    <SelectItem value="title-asc">{t('dashboard.sort.titleAsc')}</SelectItem>
+                    <SelectItem value="title-desc">{t('dashboard.sort.titleDesc')}</SelectItem>
+                    <SelectItem value="priority-asc">{t('dashboard.sort.priorityAsc')}</SelectItem>
+                    <SelectItem value="priority-desc">{t('dashboard.sort.priorityDesc')}</SelectItem>
+                    <SelectItem value="due-asc">{t('dashboard.sort.dueAsc')}</SelectItem>
+                    <SelectItem value="due-desc">{t('dashboard.sort.dueDesc')}</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
               <div className="flex items-center gap-1">
-                <Label className="text-sm">Priorität:</Label>
+                <Label className="text-sm">{t('dashboard.priorityLabel')}</Label>
                 <Select value={filterPriority} onValueChange={setFilterPriority}>
                   <SelectTrigger className="w-32">
-                    <SelectValue placeholder="Priorität" />
+                    <SelectValue placeholder={t('dashboard.priorityLabel')} />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">Alle</SelectItem>
-                    <SelectItem value="high">Hoch</SelectItem>
-                    <SelectItem value="medium">Mittel</SelectItem>
-                    <SelectItem value="low">Niedrig</SelectItem>
+                    <SelectItem value="all">{t('dashboard.filter.all')}</SelectItem>
+                    <SelectItem value="high">{t('dashboard.filter.high')}</SelectItem>
+                    <SelectItem value="medium">{t('dashboard.filter.medium')}</SelectItem>
+                    <SelectItem value="low">{t('dashboard.filter.low')}</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
               <div className="flex items-center gap-1">
-                <Label className="text-sm">Farbe:</Label>
+                <Label className="text-sm">{t('dashboard.colorLabel')}</Label>
                 <Select value={filterColor} onValueChange={setFilterColor}>
                   <SelectTrigger className="w-32">
-                    <SelectValue placeholder="Farbe" />
+                    <SelectValue placeholder={t('dashboard.colorLabel')} />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">Alle</SelectItem>
+                    <SelectItem value="all">{t('dashboard.filter.all')}</SelectItem>
                     {colorOptions.map(color => (
                       <SelectItem key={color} value={color}>
                         <div className="flex items-center space-x-2">

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Task } from '@/types';
 import { calculateTaskCompletion, getTaskProgress, getPriorityColor, getPriorityIcon } from '@/utils/taskUtils';
 import { Button } from '@/components/ui/button';
@@ -49,6 +50,7 @@ const TaskCard: React.FC<TaskCardProps> = ({
   const priorityClasses = getPriorityColor(task.priority);
   const priorityIcon = getPriorityIcon(task.priority);
   const { updateTask } = useTaskStore();
+  const { t, i18n } = useTranslation();
 
   const handleTogglePinned = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -123,7 +125,7 @@ const TaskCard: React.FC<TaskCardProps> = ({
                         : 'text-muted-foreground'
                     }`}
                   >
-                    Fällig am {new Date(task.dueDate).toLocaleDateString('de-DE')}
+                    {t('taskCard.due', { date: new Date(task.dueDate).toLocaleDateString(i18n.language) })}
                     {task.startTime && (
                       <> {task.startTime}-{task.endTime || ''}</>
                     )}
@@ -196,26 +198,26 @@ const TaskCard: React.FC<TaskCardProps> = ({
               ) : (
                 <StarOff className="h-4 w-4 mr-2" />
               )}
-              {task.pinned ? 'Lösen' : 'Anheften'}
+              {task.pinned ? t('taskDetail.unpin') : t('taskDetail.pin')}
             </DropdownMenuItem>
             <DropdownMenuItem onClick={() => onViewDetails(task)}>
               <FolderOpen className="h-4 w-4 mr-2" />
-              Details anzeigen
+              {t('taskCard.viewDetails')}
             </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => onAddSubtask(task)}>
                   <Plus className="h-4 w-4 mr-2" />
-                  Unteraufgabe hinzufügen
+                  {t('taskCard.addSubtask')}
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => onEdit(task)}>
                   <Edit className="h-4 w-4 mr-2" />
-                  Bearbeiten
+                  {t('common.edit')}
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() => onDelete(task.id)}
                   className="text-destructive"
                 >
                   <Trash2 className="h-4 w-4 mr-2" />
-                  Löschen
+                  {t('common.delete')}
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -233,7 +235,7 @@ const TaskCard: React.FC<TaskCardProps> = ({
             <div className="space-y-3">
               <div className="flex items-center justify-between">
                 <span className="text-xs sm:text-sm font-medium text-gray-700">
-                  Fortschritt: {progress.completed}/{progress.total} Unteraufgaben
+                  {t('taskCard.progress', { completed: progress.completed, total: progress.total })}
                 </span>
                 <span className="text-xs sm:text-sm text-gray-500">
                   {Math.round(progressPercentage)}%

--- a/src/components/TaskDetailModal.tsx
+++ b/src/components/TaskDetailModal.tsx
@@ -51,7 +51,7 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
   onBack
 }) => {
   if (!task) return null;
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const { updateTask } = useTaskStore();
 
@@ -104,7 +104,7 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
                       style={{ backgroundColor: task.color }}
                     />
                     <span className="text-sm text-gray-600">
-                      {category?.name || 'Unbekannte Kategorie'}
+                      {category?.name || t('taskDetail.unknownCategory')}
                     </span>
                   </div>
                 </div>
@@ -121,7 +121,7 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
                 ) : (
                   <StarOff className="h-4 w-4 mr-2" />
                 )}
-                {task.pinned ? 'Lösen' : 'Anheften'}
+                {task.pinned ? t('taskDetail.unpin') : t('taskDetail.pin')}
               </Button>
               <Button
                 variant="outline"
@@ -129,7 +129,7 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
                 onClick={() => onAddSubtask(task)}
               >
                 <Plus className="h-4 w-4 mr-2" />
-                Unteraufgabe
+                {t('taskDetail.addSubtask')}
               </Button>
               <Button
                 variant="outline"
@@ -137,7 +137,7 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
                 onClick={() => onEdit(task)}
               >
                 <Edit className="h-4 w-4 mr-2" />
-                Bearbeiten
+                {t('common.edit')}
               </Button>
               <Button
                 variant="outline"
@@ -145,7 +145,7 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
                 onClick={() => onStartPomodoro(task)}
               >
                 <Timer className="h-4 w-4 mr-2" />
-                Pomodoro
+                {t('navbar.pomodoro')}
               </Button>
               <Button
                 variant="outline"
@@ -157,7 +157,7 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
                 className="text-destructive hover:text-destructive/80"
               >
                 <Trash2 className="h-4 w-4 mr-2" />
-                Löschen
+                {t('common.delete')}
               </Button>
             </div>
           </div>
@@ -167,7 +167,7 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
           <div className="space-y-6">
             {task.description && (
               <div>
-                <h3 className="font-semibold text-gray-900 mb-2">Beschreibung</h3>
+                <h3 className="font-semibold text-gray-900 mb-2">{t('taskDetail.description')}</h3>
                 <p className="text-gray-700 leading-relaxed">{task.description}</p>
               </div>
             )}
@@ -176,16 +176,16 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
               <div>
                 <div className="flex items-center justify-between mb-4">
                   <h3 className="font-semibold text-gray-900">
-                    Unteraufgaben ({task.subtasks.length})
+                    {t('taskDetail.subtasks', { count: task.subtasks.length })}
                   </h3>
                   <div className="text-sm text-gray-600">
-                    {progress.completed} von {progress.total} abgeschlossen
+                    {t('taskDetail.progressInfo', { completed: progress.completed, total: progress.total })}
                   </div>
                 </div>
                 
                 <div className="mb-4">
                   <div className="flex items-center justify-between mb-2">
-                    <span className="text-sm font-medium text-gray-700">Gesamtfortschritt</span>
+                    <span className="text-sm font-medium text-gray-700">{t('taskDetail.totalProgress')}</span>
                     <span className="text-sm text-gray-500">{Math.round(progressPercentage)}%</span>
                   </div>
                   <Progress value={progressPercentage} className="h-3" />
@@ -218,7 +218,7 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
                   className="mt-2"
                 >
                   <Plus className="h-4 w-4 mr-2" />
-                  Erste Unteraufgabe hinzufügen
+                  {t('taskDetail.addFirst')}
                 </Button>
               </div>
             )}
@@ -226,17 +226,17 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
             <div className="pt-4 border-t border-gray-200">
               <div className="grid grid-cols-2 gap-4 text-sm text-gray-500">
                 <div>
-                  <span className="font-medium">Erstellt:</span>{' '}
-                  {new Date(task.createdAt).toLocaleDateString('de-DE')}
+                  <span className="font-medium">{t('taskDetail.created')}</span>{' '}
+                  {new Date(task.createdAt).toLocaleDateString(i18n.language)}
                 </div>
                 <div>
-                  <span className="font-medium">Zuletzt geändert:</span>{' '}
-                  {new Date(task.updatedAt).toLocaleDateString('de-DE')}
+                  <span className="font-medium">{t('taskDetail.updated')}</span>{' '}
+                  {new Date(task.updatedAt).toLocaleDateString(i18n.language)}
                 </div>
                 {task.dueDate && (
                   <div>
-                    <span className="font-medium">Fällig am:</span>{' '}
-                    {new Date(task.dueDate).toLocaleDateString('de-DE')}
+                    <span className="font-medium">{t('taskDetail.due')}</span>{' '}
+                    {new Date(task.dueDate).toLocaleDateString(i18n.language)}
                   </div>
                 )}
               </div>

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -313,9 +313,53 @@
     "noTasks": "Keine Tasks vorhanden",
     "noTasksFound": "Keine Tasks gefunden",
     "createFirstTask": "Erstellen Sie Ihre erste Task in der Kategorie \"{{category}}\".",
-    "firstTaskButton": "Erste Task erstellen"
+    "firstTaskButton": "Erste Task erstellen",
+    "sortLabel": "Sortierung:",
+    "priorityLabel": "Priorität:",
+    "colorLabel": "Farbe:",
+    "sort": {
+      "manual": "Manuell",
+      "createdDesc": "Neueste zuerst",
+      "createdAsc": "Älteste zuerst",
+      "titleAsc": "Titel A-Z",
+      "titleDesc": "Titel Z-A",
+      "priorityAsc": "Priorität ↑",
+      "priorityDesc": "Priorität ↓",
+      "dueAsc": "Fälligkeitsdatum ↑",
+      "dueDesc": "Fälligkeitsdatum ↓"
+    },
+    "filter": {
+      "all": "Alle",
+      "high": "Hoch",
+      "medium": "Mittel",
+      "low": "Niedrig"
+    }
+  },
+  "categoryCard": {
+    "deleteTooltip": "Löschen (rückgängig möglich)",
+    "deleteMenu": "Löschen (Undo möglich)",
+    "percentDone": "{{percent}}% erledigt",
+    "completedOfTotal": "{{completed}} von {{total}} abgeschlossen"
+  },
+  "taskCard": {
+    "viewDetails": "Details anzeigen",
+    "addSubtask": "Unteraufgabe hinzufügen",
+    "progress": "Fortschritt: {{completed}}/{{total}} Unteraufgaben",
+    "due": "Fällig am {{date}}"
   },
   "taskDetail": {
-    "noSubtasks": "Keine Unteraufgaben vorhanden."
+    "noSubtasks": "Keine Unteraufgaben vorhanden.",
+    "unknownCategory": "Unbekannte Kategorie",
+    "unpin": "Lösen",
+    "pin": "Anheften",
+    "addSubtask": "Unteraufgabe",
+    "description": "Beschreibung",
+    "subtasks": "Unteraufgaben ({{count}})",
+    "progressInfo": "{{completed}} von {{total}} abgeschlossen",
+    "totalProgress": "Gesamtfortschritt",
+    "addFirst": "Erste Unteraufgabe hinzufügen",
+    "created": "Erstellt:",
+    "updated": "Zuletzt geändert:",
+    "due": "Fällig am:"
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -313,9 +313,53 @@
     "noTasks": "No tasks available",
     "noTasksFound": "No tasks found",
     "createFirstTask": "Create your first task in the \"{{category}}\" category.",
-    "firstTaskButton": "Create First Task"
+    "firstTaskButton": "Create First Task",
+    "sortLabel": "Sort by:",
+    "priorityLabel": "Priority:",
+    "colorLabel": "Color:",
+    "sort": {
+      "manual": "Manual",
+      "createdDesc": "Newest first",
+      "createdAsc": "Oldest first",
+      "titleAsc": "Title A-Z",
+      "titleDesc": "Title Z-A",
+      "priorityAsc": "Priority ↑",
+      "priorityDesc": "Priority ↓",
+      "dueAsc": "Due date ↑",
+      "dueDesc": "Due date ↓"
+    },
+    "filter": {
+      "all": "All",
+      "high": "High",
+      "medium": "Medium",
+      "low": "Low"
+    }
+  },
+  "categoryCard": {
+    "deleteTooltip": "Delete (undo possible)",
+    "deleteMenu": "Delete (undo possible)",
+    "percentDone": "{{percent}}% done",
+    "completedOfTotal": "{{completed}} of {{total}} completed"
+  },
+  "taskCard": {
+    "viewDetails": "View details",
+    "addSubtask": "Add subtask",
+    "progress": "Progress: {{completed}}/{{total}} subtasks",
+    "due": "Due on {{date}}"
   },
   "taskDetail": {
-    "noSubtasks": "No subtasks available."
+    "noSubtasks": "No subtasks available.",
+    "unknownCategory": "Unknown category",
+    "unpin": "Unpin",
+    "pin": "Pin",
+    "addSubtask": "Add subtask",
+    "description": "Description",
+    "subtasks": "Subtasks ({{count}})",
+    "progressInfo": "{{completed}} of {{total}} completed",
+    "totalProgress": "Total progress",
+    "addFirst": "Add first subtask",
+    "created": "Created:",
+    "updated": "Last updated:",
+    "due": "Due on:"
   }
 }


### PR DESCRIPTION
## Summary
- add translation keys for category, task cards and dashboard
- replace hardcoded strings in task-related components with i18n translations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685000fa4ed4832a9596fee8e24c67d1