### PR TITLE
Fix translation gaps

### DIFF
--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import {
@@ -68,6 +69,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   rows = 5,
   className,
 }) => {
+  const { t } = useTranslation();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const previewRef = useRef<HTMLDivElement>(null);
   const [cursorPosition, setCursorPosition] = useState<number | null>(null);
@@ -265,7 +267,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
               <Bold />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Bold</TooltipContent>
+          <TooltipContent>{t('markdownEditor.bold')}</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -278,7 +280,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
               <Italic />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Italic</TooltipContent>
+          <TooltipContent>{t('markdownEditor.italic')}</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -291,7 +293,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
               <Strikethrough />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Strikethrough</TooltipContent>
+          <TooltipContent>{t('markdownEditor.strikethrough')}</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -304,7 +306,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
               <Heading1 />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Heading 1</TooltipContent>
+          <TooltipContent>{t('markdownEditor.heading1')}</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -317,7 +319,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
               <Heading2 />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Heading 2</TooltipContent>
+          <TooltipContent>{t('markdownEditor.heading2')}</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -330,7 +332,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
               <Heading3 />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Heading 3</TooltipContent>
+          <TooltipContent>{t('markdownEditor.heading3')}</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -343,7 +345,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
               <LinkIcon />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Link</TooltipContent>
+          <TooltipContent>{t('markdownEditor.link')}</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -356,7 +358,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
               <ImageIcon />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Image</TooltipContent>
+          <TooltipContent>{t('markdownEditor.image')}</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -369,7 +371,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
               <List />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Bullet List</TooltipContent>
+          <TooltipContent>{t('markdownEditor.bulletList')}</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -382,7 +384,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
               <ListOrdered />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Numbered List</TooltipContent>
+          <TooltipContent>{t('markdownEditor.numberedList')}</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -395,7 +397,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
               <Quote />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Quote</TooltipContent>
+          <TooltipContent>{t('markdownEditor.quote')}</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -408,7 +410,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
               <Code />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Inline Code</TooltipContent>
+          <TooltipContent>{t('markdownEditor.inlineCode')}</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -421,7 +423,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
               <Code2 />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Code Block</TooltipContent>
+          <TooltipContent>{t('markdownEditor.codeBlock')}</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -434,7 +436,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
               <Minus />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Horizontal Rule</TooltipContent>
+          <TooltipContent>{t('markdownEditor.horizontalRule')}</TooltipContent>
         </Tooltip>
       </div>
       <div className="relative">

--- a/src/components/ReleaseNotesModal.tsx
+++ b/src/components/ReleaseNotesModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Dialog,
   DialogContent,
@@ -8,6 +9,7 @@ import {
 import ReactMarkdown from 'react-markdown';
 
 const ReleaseNotesModal: React.FC = () => {
+  const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const [notes, setNotes] = useState('');
 
@@ -36,7 +38,7 @@ const ReleaseNotesModal: React.FC = () => {
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent className="max-w-xl">
         <DialogHeader>
-          <DialogTitle>Neu in Version {__APP_VERSION__}</DialogTitle>
+          <DialogTitle>{t('releaseNotes.modalTitle', { version: __APP_VERSION__ })}</DialogTitle>
         </DialogHeader>
         <div className="prose dark:prose-invert max-h-[60vh] overflow-y-auto">
           <ReactMarkdown>{notes}</ReactMarkdown>

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -171,7 +171,24 @@
   },
   "releaseNotes": {
     "title": "Release Notes",
-    "none": "Keine Release Notes gefunden."
+    "none": "Keine Release Notes gefunden.",
+    "modalTitle": "Neu in Version {{version}}"
+  },
+  "markdownEditor": {
+    "bold": "Fett",
+    "italic": "Kursiv",
+    "strikethrough": "Durchgestrichen",
+    "heading1": "Überschrift 1",
+    "heading2": "Überschrift 2",
+    "heading3": "Überschrift 3",
+    "link": "Link",
+    "image": "Bild",
+    "bulletList": "Aufzählung",
+    "numberedList": "Nummerierte Liste",
+    "quote": "Zitat",
+    "inlineCode": "Inline-Code",
+    "codeBlock": "Code-Block",
+    "horizontalRule": "Trennlinie"
   },
   "flashcardManager": {
     "title": "Decks",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -171,7 +171,24 @@
   },
   "releaseNotes": {
     "title": "Release Notes",
-    "none": "No release notes found."
+    "none": "No release notes found.",
+    "modalTitle": "New in version {{version}}"
+  },
+  "markdownEditor": {
+    "bold": "Bold",
+    "italic": "Italic",
+    "strikethrough": "Strikethrough",
+    "heading1": "Heading 1",
+    "heading2": "Heading 2",
+    "heading3": "Heading 3",
+    "link": "Link",
+    "image": "Image",
+    "bulletList": "Bullet List",
+    "numberedList": "Numbered List",
+    "quote": "Quote",
+    "inlineCode": "Inline Code",
+    "codeBlock": "Code Block",
+    "horizontalRule": "Horizontal Rule"
   },
   "flashcardManager": {
     "title": "Decks",


### PR DESCRIPTION
## Summary
- ensure release notes modal uses translations
- add missing translations for Markdown editor tooltips
- update English and German locale files

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685003a61c50832a8b1185a83d20e06a