### PR TITLE
Add recurring label translation

### DIFF
--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -110,7 +110,7 @@ const TaskCard: React.FC<TaskCardProps> = ({
                     className="text-xs flex-shrink-0 text-center leading-snug"
                   >
                     <span className="hidden sm:block">
-                      Wiederholt
+                      {t('taskCard.recurring')}
                       <br />
                       {task.recurrencePattern}
                     </span>

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -413,6 +413,7 @@
     "viewDetails": "Details anzeigen",
     "addSubtask": "Unteraufgabe hinzufügen",
     "progress": "Fortschritt: {{completed}}/{{total}} Unteraufgaben",
+    "recurring": "Wiederholt",
     "due": "Fällig am {{date}}"
   },
   "taskDetail": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -413,6 +413,7 @@
     "viewDetails": "View details",
     "addSubtask": "Add subtask",
     "progress": "Progress: {{completed}}/{{total}} subtasks",
+    "recurring": "Recurring",
     "due": "Due on {{date}}"
   },
   "taskDetail": {


### PR DESCRIPTION
## Summary
- add `taskCard.recurring` key to English and German locales
- use the translation in `TaskCard`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685010296820832a91329b69c7b188e5