### PR TITLE
Add common translation keys and refactor Dashboard

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -208,7 +208,7 @@ const Dashboard: React.FC = () => {
       completed: false
     });
     toast({
-      title: t('dashboard.taskCreated'),
+      title: t('task.created'),
       description: t('dashboard.taskCreatedDesc', { title: taskData.title })
     });
     setParentTask(null);
@@ -221,7 +221,7 @@ const Dashboard: React.FC = () => {
         completed: editingTask.completed
       });
       toast({
-        title: t('dashboard.taskUpdated'),
+        title: t('task.updated'),
         description: t('dashboard.taskUpdatedDesc', { title: taskData.title })
       });
       setEditingTask(null);
@@ -230,10 +230,10 @@ const Dashboard: React.FC = () => {
 
   const handleDeleteTask = (taskId: string) => {
     const task = findTaskById(taskId);
-    if (task && window.confirm(t('dashboard.taskDeleteConfirm', { title: task.title }))) {
+    if (task && window.confirm(t('task.deleteConfirm', { title: task.title }))) {
       deleteTask(taskId);
       toast({
-        title: t('dashboard.taskDeleted'),
+        title: t('task.deleted'),
         description: t('dashboard.taskDeletedDesc')
       });
     }
@@ -243,7 +243,7 @@ const Dashboard: React.FC = () => {
     updateTask(taskId, { completed });
     const task = findTaskById(taskId);
     toast({
-      title: completed ? t('dashboard.taskCompleted') : t('dashboard.taskReactivated'),
+      title: completed ? t('task.completed') : t('task.reactivated'),
       description: completed
         ? t('dashboard.taskCompletedDesc', { title: task?.title })
         : t('dashboard.taskReactivatedDesc', { title: task?.title })
@@ -253,7 +253,7 @@ const Dashboard: React.FC = () => {
   const handleCreateCategory = (categoryData: CategoryFormData) => {
     addCategory(categoryData);
     toast({
-      title: t('dashboard.categoryCreated'),
+      title: t('category.created'),
       description: t('dashboard.categoryCreatedDesc', { name: categoryData.name })
     });
   };
@@ -262,7 +262,7 @@ const Dashboard: React.FC = () => {
     if (editingCategory) {
       updateCategory(editingCategory.id, categoryData);
       toast({
-        title: t('dashboard.categoryUpdated'),
+        title: t('category.updated'),
         description: t('dashboard.categoryUpdatedDesc', { name: categoryData.name })
       });
       setEditingCategory(null);
@@ -276,17 +276,17 @@ const Dashboard: React.FC = () => {
     const nonDefaultCount = categories.filter(c => c.id !== 'default').length;
     const confirmText =
       nonDefaultCount === 1 && category.id !== 'default'
-        ? t('dashboard.categoryDeleteLastConfirm', { name: category.name })
-        : t('dashboard.categoryDeleteConfirm', { name: category.name });
+        ? t('category.deleteLastConfirm', { name: category.name })
+        : t('category.deleteConfirm', { name: category.name });
 
     if (window.confirm(confirmText)) {
       deleteCategory(categoryId);
       toast({
-        title: t('dashboard.categoryDeleted'),
+        title: t('category.deleted'),
         description: t('dashboard.categoryDeletedDesc'),
         action: (
           <ToastAction altText="Undo" onClick={() => undoDeleteCategory(categoryId)}>
-            {t('dashboard.undo')}
+            {t('common.undo')}
           </ToastAction>
         )
       });

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -103,7 +103,8 @@
     "create": "Erstellen",
     "edit": "Bearbeiten",
     "delete": "Löschen",
-    "back": "Zurück"
+    "back": "Zurück",
+    "undo": "Rückgängig"
   },
   "noteDetail": {
     "notFound": "Notiz nicht gefunden.",
@@ -450,5 +451,20 @@
     "created": "Erstellt:",
     "updated": "Zuletzt geändert:",
     "due": "Fällig am:"
+  },
+  "task": {
+    "created": "Task erstellt",
+    "updated": "Task aktualisiert",
+    "deleted": "Task gelöscht",
+    "completed": "Task abgeschlossen",
+    "reactivated": "Task reaktiviert",
+    "deleteConfirm": "Sind Sie sicher, dass Sie \"{{title}}\" löschen möchten?"
+  },
+  "category": {
+    "created": "Kategorie erstellt",
+    "updated": "Kategorie aktualisiert",
+    "deleted": "Kategorie gelöscht",
+    "deleteConfirm": "Sind Sie sicher, dass Sie \"{{name}}\" löschen möchten?",
+    "deleteLastConfirm": "Sie sind dabei, die letzte verbleibende Kategorie zu löschen. \"{{name}}\" wirklich löschen?"
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -103,7 +103,8 @@
     "create": "Create",
     "edit": "Edit",
     "delete": "Delete",
-    "back": "Back"
+    "back": "Back",
+    "undo": "Undo"
   },
   "noteDetail": {
     "notFound": "Note not found.",
@@ -450,5 +451,20 @@
     "created": "Created:",
     "updated": "Last updated:",
     "due": "Due on:"
+  },
+  "task": {
+    "created": "Task created",
+    "updated": "Task updated",
+    "deleted": "Task deleted",
+    "completed": "Task completed",
+    "reactivated": "Task reactivated",
+    "deleteConfirm": "Are you sure you want to delete \"{{title}}\"?"
+  },
+  "category": {
+    "created": "Category created",
+    "updated": "Category updated",
+    "deleted": "Category deleted",
+    "deleteConfirm": "Are you sure you want to delete \"{{name}}\"?",
+    "deleteLastConfirm": "You are about to delete the last remaining category. Delete \"{{name}}\"?"
   }
 }


### PR DESCRIPTION
## Summary
- add `task` and `category` action keys and `common.undo` translations
- use these translation keys in `Dashboard` toast messages and confirmations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685013666288832aa15d80922547745a