### PR TITLE
Improve dashboard translations

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -285,8 +285,11 @@ const Dashboard: React.FC = () => {
         title: t('category.deleted'),
         description: t('dashboard.categoryDeletedDesc'),
         action: (
-          <ToastAction altText="Undo" onClick={() => undoDeleteCategory(categoryId)}>
-            {t('common.undo')}
+          <ToastAction
+            altText={t('dashboard.undo')}
+            onClick={() => undoDeleteCategory(categoryId)}
+          >
+            {t('dashboard.undo')}
           </ToastAction>
         )
       });


### PR DESCRIPTION
## Summary
- add translation for dashboard undo toast button

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685014eaf828832a8ad7015c76256344