### PR TITLE
Fix document language sync

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,15 @@
 
 <!DOCTYPE html>
-<html lang="de">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Total-Task-Tracker - Moderne Aufgabenverwaltung</title>
-    <meta name="description" content="Moderner Total-Task-Tracker mit Kategorien und rekursiven Unteraufgaben" />
+    <title>Total-Task-Tracker</title>
+    <meta name="description" content="Local task and learning manager" />
     <meta name="author" content="Total-Task-Tracker App" />
 
-    <meta property="og:title" content="Total-Task-Tracker - Moderne Aufgabenverwaltung" />
-    <meta property="og:description" content="Moderner Total-Task-Tracker mit Kategorien und rekursiven Unteraufgaben" />
+    <meta property="og:title" content="Total-Task-Tracker" />
+    <meta property="og:description" content="Local task and learning manager" />
     <meta property="og:type" content="website" />
 
     <meta name="twitter:card" content="summary_large_image" />

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -332,6 +332,10 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     }
   }, [theme, themeName])
 
+  useEffect(() => {
+    document.documentElement.lang = language
+  }, [language])
+
   const updateShortcut = (key: keyof ShortcutKeys, value: string) => {
     setShortcuts(prev => ({ ...prev, [key]: value.toLowerCase() }))
   }


### PR DESCRIPTION
## Summary
- set neutral language and meta text in `index.html`
- keep `<html>` language updated when settings change

## Testing
- `npm run lint` *(fails: 32 errors, 28 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685016a2dca4832a887858e44b736975