### PR TITLE
Use i18n for default task category

### DIFF
--- a/src/hooks/useTaskStore.tsx
+++ b/src/hooks/useTaskStore.tsx
@@ -103,8 +103,8 @@ const useTaskStoreImpl = () => {
           // Create default category if none exist
           const defaultCategory: Category = {
             id: 'default',
-            name: 'Allgemein',
-            description: 'Standard Kategorie für alle Tasks',
+            name: i18n.t('taskStore.defaultCategoryName'),
+            description: i18n.t('taskStore.defaultCategoryDescription'),
             color: '#3B82F6',
             createdAt: new Date(),
             updatedAt: new Date()
@@ -475,8 +475,8 @@ const useTaskStoreImpl = () => {
       if (remaining.length === 0) {
         const defaultCategory: Category = {
           id: 'default',
-          name: 'Allgemein',
-          description: 'Standard Kategorie für alle Tasks',
+          name: i18n.t('taskStore.defaultCategoryName'),
+          description: i18n.t('taskStore.defaultCategoryDescription'),
           color: '#3B82F6',
           createdAt: new Date(),
           updatedAt: new Date(),

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -466,5 +466,9 @@
     "deleted": "Kategorie gelöscht",
     "deleteConfirm": "Sind Sie sicher, dass Sie \"{{name}}\" löschen möchten?",
     "deleteLastConfirm": "Sie sind dabei, die letzte verbleibende Kategorie zu löschen. \"{{name}}\" wirklich löschen?"
+  },
+  "taskStore": {
+    "defaultCategoryName": "Allgemein",
+    "defaultCategoryDescription": "Standard Kategorie für alle Tasks"
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -466,5 +466,9 @@
     "deleted": "Category deleted",
     "deleteConfirm": "Are you sure you want to delete \"{{name}}\"?",
     "deleteLastConfirm": "You are about to delete the last remaining category. Delete \"{{name}}\"?"
+  },
+  "taskStore": {
+    "defaultCategoryName": "General",
+    "defaultCategoryDescription": "Default category for all tasks"
   }
 }


### PR DESCRIPTION
## Summary
- reference translation keys for the default task category
- add English and German translations for these keys

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685017fc5fa4832a91927675bc791714