### PR TITLE
Add sync folder placeholder translations

### DIFF
--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -83,6 +83,7 @@
     "dataTitle": "Datenexport / -import",
     "syncFolder": "Sync-Ordner",
     "selectFolder": "Ordner wählen",
+    "syncFolderPlaceholder": "/Pfad/zum/Ordner",
     "syncInterval": "Sync-Intervall (Minuten)",
     "tasksAndCategories": "Tasks & Kategorien",
     "notes": "Notizen",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -83,6 +83,7 @@
     "dataTitle": "Data export / import",
     "syncFolder": "Sync folder",
     "selectFolder": "Choose folder",
+    "syncFolderPlaceholder": "/path/to/folder",
     "syncInterval": "Sync interval (minutes)",
     "tasksAndCategories": "Tasks & Categories",
     "notes": "Notes",

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -609,7 +609,7 @@ const SettingsPage: React.FC = () => {
                 <Input
                   value={syncFolder}
                   onChange={e => updateSyncFolder(e.target.value)}
-                  placeholder="/Pfad/zum/Ordner"
+                  placeholder={t('settingsPage.syncFolderPlaceholder')}
                 />
                 <Button variant="outline" onClick={selectFolder}>{t('settingsPage.selectFolder')}</Button>
               </div>


### PR DESCRIPTION
## Summary
- add `syncFolderPlaceholder` translation for English and German
- use the translation in the settings form

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685019815a58832a8f3e793f1e40877d