### PR TITLE
Fix error message language in hooks

### DIFF
--- a/src/hooks/useFlashcardStore.tsx
+++ b/src/hooks/useFlashcardStore.tsx
@@ -27,7 +27,7 @@ const useFlashcardStoreImpl = () => {
           );
         }
       } catch (err) {
-        console.error('Fehler beim Laden der Karten', err);
+        console.error('Error loading flashcards', err);
       }
     };
 
@@ -43,7 +43,7 @@ const useFlashcardStoreImpl = () => {
           setDecks(data || []);
         }
       } catch (err) {
-        console.error('Fehler beim Laden der Decks', err);
+        console.error('Error loading decks', err);
       }
     };
 
@@ -59,7 +59,7 @@ const useFlashcardStoreImpl = () => {
           body: JSON.stringify(flashcards)
         });
       } catch (err) {
-        console.error('Fehler beim Speichern der Karten', err);
+        console.error('Error saving flashcards', err);
       }
     };
 
@@ -75,7 +75,7 @@ const useFlashcardStoreImpl = () => {
           body: JSON.stringify(decks)
         });
       } catch (err) {
-        console.error('Fehler beim Speichern der Decks', err);
+        console.error('Error saving decks', err);
       }
     };
 

--- a/src/hooks/usePomodoroHistory.tsx
+++ b/src/hooks/usePomodoroHistory.tsx
@@ -15,7 +15,7 @@ const usePomodoroHistoryImpl = () => {
           setSessions(data || [])
         }
       } catch (err) {
-        console.error('Fehler beim Laden der Pomodoro-Sessions', err)
+        console.error('Error loading Pomodoro sessions', err)
       }
     }
     load()
@@ -30,7 +30,7 @@ const usePomodoroHistoryImpl = () => {
           body: JSON.stringify(sessions)
         })
       } catch (err) {
-        console.error('Fehler beim Speichern der Pomodoro-Sessions', err)
+        console.error('Error saving Pomodoro sessions', err)
       }
     }
     save()

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -267,7 +267,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
           }
         }
       } catch (err) {
-        console.error('Fehler beim Laden der Einstellungen', err)
+        console.error('Error loading settings', err)
       }
     }
     load()
@@ -298,7 +298,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         })
       })
       } catch (err) {
-        console.error('Fehler beim Speichern der Einstellungen', err)
+        console.error('Error saving settings', err)
       }
     }
 

--- a/src/hooks/useTaskStore.tsx
+++ b/src/hooks/useTaskStore.tsx
@@ -29,7 +29,7 @@ const useTaskStoreImpl = () => {
     const loadData = async () => {
       try {
         const res = await fetch(API_URL);
-        if (!res.ok) throw new Error('Serverfehler');
+        if (!res.ok) throw new Error('Server error');
         const {
           tasks: savedTasks,
           categories: savedCategories,
@@ -113,7 +113,7 @@ const useTaskStoreImpl = () => {
         }
         setLoaded(true);
       } catch (error) {
-        console.error('Fehler beim Laden der Daten:', error);
+        console.error('Error loading data:', error);
         setLoaded(true);
       }
     };
@@ -141,7 +141,7 @@ const useTaskStoreImpl = () => {
           body: JSON.stringify({ tasks, categories, notes, recurring })
         });
       } catch (error) {
-        console.error('Fehler beim Speichern der Daten:', error);
+        console.error('Error saving data:', error);
       }
     };
 


### PR DESCRIPTION
## Summary
- update server error and console messages to English in hooks

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' or other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68501ade8a30832aa1dc693212491b9f