### PR TITLE
Add 'statistics.created' translation

### DIFF
--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -198,6 +198,7 @@
     "overdue": "Überfällig",
     "completed7Days": "Erledigt 7 Tage",
     "recurring": "Wiederkehrend",
+    "created": "Erstellt",
     "created7Days": "Erstellt 7 Tage",
     "priorityDistribution": "Tasks nach Priorität",
     "categoryProgress": "Fortschritt nach Kategorie",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -198,6 +198,7 @@
     "overdue": "Overdue",
     "completed7Days": "Completed 7 Days",
     "recurring": "Recurring",
+    "created": "Created",
     "created7Days": "Created 7 Days",
     "priorityDistribution": "Tasks by Priority",
     "categoryProgress": "Progress by Category",

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -253,7 +253,7 @@ const Statistics = () => {
                       dataKey="created"
                       stroke="hsl(var(--primary))"
                       strokeWidth={2}
-                      name="Erstellt"
+                      name={t('statistics.created')}
                     />
                   </LineChart>
                 </ResponsiveContainer>


### PR DESCRIPTION
## Summary
- add `statistics.created` key to English and German translations
- use the new translation key in the statistics page

## Testing
- `npm run lint` *(fails: multiple existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68501d6ddfc8832a84e0ccc9684898b3