### PR TITLE
Fix language coverage

### DIFF
--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -327,7 +327,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
                 type="number"
                 value={formData.dueAfterDays ?? ''}
                 onChange={(e) => handleChange('dueAfterDays', e.target.value ? Number(e.target.value) : undefined)}
-                placeholder="z.B. 3"
+                placeholder={t('taskModal.placeholderExample')}
               />
             )}
           </div>
@@ -387,7 +387,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
                   onChange={(e) =>
                     handleChange('customIntervalDays', e.target.value ? Number(e.target.value) : undefined)
                   }
-                  placeholder="z.B. 3"
+                  placeholder={t('taskModal.placeholderExample')}
                 />
               </div>
               <div className="mt-2">
@@ -412,13 +412,13 @@ const TaskModal: React.FC<TaskModalProps> = ({
                       <SelectValue placeholder={t('taskModal.weekday')} />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="0">Sonntag</SelectItem>
-                      <SelectItem value="1">Montag</SelectItem>
-                      <SelectItem value="2">Dienstag</SelectItem>
-                      <SelectItem value="3">Mittwoch</SelectItem>
-                      <SelectItem value="4">Donnerstag</SelectItem>
-                      <SelectItem value="5">Freitag</SelectItem>
-                      <SelectItem value="6">Samstag</SelectItem>
+                      <SelectItem value="0">{t('weekdays.sunday')}</SelectItem>
+                      <SelectItem value="1">{t('weekdays.monday')}</SelectItem>
+                      <SelectItem value="2">{t('weekdays.tuesday')}</SelectItem>
+                      <SelectItem value="3">{t('weekdays.wednesday')}</SelectItem>
+                      <SelectItem value="4">{t('weekdays.thursday')}</SelectItem>
+                      <SelectItem value="5">{t('weekdays.friday')}</SelectItem>
+                      <SelectItem value="6">{t('weekdays.saturday')}</SelectItem>
                     </SelectContent>
                   </Select>
                 )}

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,8 +1,9 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { ChevronRight, MoreHorizontal } from "lucide-react"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { ChevronRight, MoreHorizontal } from "lucide-react";
+import { useTranslation } from 'react-i18next';
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const Breadcrumb = React.forwardRef<
   HTMLElement,
@@ -91,17 +92,20 @@ BreadcrumbSeparator.displayName = "BreadcrumbSeparator"
 const BreadcrumbEllipsis = ({
   className,
   ...props
-}: React.ComponentProps<"span">) => (
-  <span
-    role="presentation"
-    aria-hidden="true"
-    className={cn("flex h-9 w-9 items-center justify-center", className)}
-    {...props}
-  >
-    <MoreHorizontal className="h-4 w-4" />
-    <span className="sr-only">More</span>
-  </span>
-)
+}: React.ComponentProps<"span">) => {
+  const { t } = useTranslation()
+  return (
+    <span
+      role="presentation"
+      aria-hidden="true"
+      className={cn("flex h-9 w-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontal className="h-4 w-4" />
+      <span className="sr-only">{t('ui.more')}</span>
+    </span>
+  )
+}
 BreadcrumbEllipsis.displayName = "BreadcrumbElipssis"
 
 export {

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,11 +1,13 @@
-import * as React from "react"
+import * as React from "react";
 import useEmblaCarousel, {
   type UseEmblaCarouselType,
 } from "embla-carousel-react"
 import { ArrowLeft, ArrowRight } from "lucide-react"
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
+import { useTranslation } from 'react-i18next';
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 
 type CarouselApi = UseEmblaCarouselType[1]
 type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
@@ -197,6 +199,7 @@ const CarouselPrevious = React.forwardRef<
   React.ComponentProps<typeof Button>
 >(({ className, variant = "outline", size = "icon", ...props }, ref) => {
   const { orientation, scrollPrev, canScrollPrev } = useCarousel()
+  const { t } = useTranslation()
 
   return (
     <Button
@@ -215,7 +218,7 @@ const CarouselPrevious = React.forwardRef<
       {...props}
     >
       <ArrowLeft className="h-4 w-4" />
-      <span className="sr-only">Previous slide</span>
+      <span className="sr-only">{t('ui.previousSlide')}</span>
     </Button>
   )
 })
@@ -226,6 +229,7 @@ const CarouselNext = React.forwardRef<
   React.ComponentProps<typeof Button>
 >(({ className, variant = "outline", size = "icon", ...props }, ref) => {
   const { orientation, scrollNext, canScrollNext } = useCarousel()
+  const { t } = useTranslation()
 
   return (
     <Button
@@ -244,7 +248,7 @@ const CarouselNext = React.forwardRef<
       {...props}
     >
       <ArrowRight className="h-4 w-4" />
-      <span className="sr-only">Next slide</span>
+      <span className="sr-only">{t('ui.nextSlide')}</span>
     </Button>
   )
 })

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,8 +1,9 @@
-import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { X } from "lucide-react"
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { useTranslation } from 'react-i18next';
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const Dialog = DialogPrimitive.Root
 
@@ -30,7 +31,9 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+>(({ className, children, ...props }, ref) => {
+  const { t } = useTranslation();
+  return (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -44,11 +47,11 @@ const DialogContent = React.forwardRef<
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        <span className="sr-only">{t('ui.close')}</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
-))
+)})
 DialogContent.displayName = DialogPrimitive.Content.displayName
 
 const DialogHeader = ({

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,8 +1,9 @@
-import * as React from "react"
-import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react"
+import * as React from "react";
+import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react";
+import { useTranslation } from 'react-i18next';
 
-import { cn } from "@/lib/utils"
-import { ButtonProps, buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils";
+import { ButtonProps, buttonVariants } from "@/components/ui/button";
 
 const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
   <nav
@@ -62,48 +63,57 @@ PaginationLink.displayName = "PaginationLink"
 const PaginationPrevious = ({
   className,
   ...props
-}: React.ComponentProps<typeof PaginationLink>) => (
-  <PaginationLink
-    aria-label="Go to previous page"
-    size="default"
-    className={cn("gap-1 pl-2.5", className)}
-    {...props}
-  >
-    <ChevronLeft className="h-4 w-4" />
-    <span>Previous</span>
-  </PaginationLink>
-)
+}: React.ComponentProps<typeof PaginationLink>) => {
+  const { t } = useTranslation()
+  return (
+    <PaginationLink
+      aria-label={t('ui.goPrevAria')}
+      size="default"
+      className={cn("gap-1 pl-2.5", className)}
+      {...props}
+    >
+      <ChevronLeft className="h-4 w-4" />
+      <span>{t('ui.previous')}</span>
+    </PaginationLink>
+  )
+}
 PaginationPrevious.displayName = "PaginationPrevious"
 
 const PaginationNext = ({
   className,
   ...props
-}: React.ComponentProps<typeof PaginationLink>) => (
-  <PaginationLink
-    aria-label="Go to next page"
-    size="default"
-    className={cn("gap-1 pr-2.5", className)}
-    {...props}
-  >
-    <span>Next</span>
-    <ChevronRight className="h-4 w-4" />
-  </PaginationLink>
-)
+}: React.ComponentProps<typeof PaginationLink>) => {
+  const { t } = useTranslation()
+  return (
+    <PaginationLink
+      aria-label={t('ui.goNextAria')}
+      size="default"
+      className={cn("gap-1 pr-2.5", className)}
+      {...props}
+    >
+      <span>{t('ui.next')}</span>
+      <ChevronRight className="h-4 w-4" />
+    </PaginationLink>
+  )
+}
 PaginationNext.displayName = "PaginationNext"
 
 const PaginationEllipsis = ({
   className,
   ...props
-}: React.ComponentProps<"span">) => (
-  <span
-    aria-hidden
-    className={cn("flex h-9 w-9 items-center justify-center", className)}
-    {...props}
-  >
-    <MoreHorizontal className="h-4 w-4" />
-    <span className="sr-only">More pages</span>
-  </span>
-)
+}: React.ComponentProps<"span">) => {
+  const { t } = useTranslation()
+  return (
+    <span
+      aria-hidden
+      className={cn("flex h-9 w-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontal className="h-4 w-4" />
+      <span className="sr-only">{t('ui.morePages')}</span>
+    </span>
+  )
+}
 PaginationEllipsis.displayName = "PaginationEllipsis"
 
 export {

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,7 +1,8 @@
-import * as SheetPrimitive from "@radix-ui/react-dialog"
-import { cva, type VariantProps } from "class-variance-authority"
-import { X } from "lucide-react"
-import * as React from "react"
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
+import * as React from "react";
+import { useTranslation } from 'react-i18next';
 
 import { cn } from "@/lib/utils"
 
@@ -54,7 +55,9 @@ interface SheetContentProps
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
+>(({ side = "right", className, children, ...props }, ref) => {
+  const { t } = useTranslation()
+  return (
   <SheetPortal>
     <SheetOverlay />
     <SheetPrimitive.Content
@@ -65,11 +68,11 @@ const SheetContent = React.forwardRef<
       {children}
       <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
         <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        <span className="sr-only">{t('ui.close')}</span>
       </SheetPrimitive.Close>
     </SheetPrimitive.Content>
   </SheetPortal>
-))
+)})
 SheetContent.displayName = SheetPrimitive.Content.displayName
 
 const SheetHeader = ({

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import * as React from "react";
 import { Slot } from "@radix-ui/react-slot"
 import { VariantProps, cva } from "class-variance-authority"
 import { PanelLeft } from "lucide-react"
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Separator } from "@/components/ui/separator"
+import { useTranslation } from 'react-i18next';
 import { Sheet, SheetContent } from "@/components/ui/sheet"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
@@ -262,6 +263,7 @@ const SidebarTrigger = React.forwardRef<
   React.ComponentProps<typeof Button>
 >(({ className, onClick, ...props }, ref) => {
   const { toggleSidebar } = useSidebar()
+  const { t } = useTranslation()
 
   return (
     <Button
@@ -277,7 +279,7 @@ const SidebarTrigger = React.forwardRef<
       {...props}
     >
       <PanelLeft />
-      <span className="sr-only">Toggle Sidebar</span>
+      <span className="sr-only">{t('ui.toggleSidebar')}</span>
     </Button>
   )
 })
@@ -288,15 +290,16 @@ const SidebarRail = React.forwardRef<
   React.ComponentProps<"button">
 >(({ className, ...props }, ref) => {
   const { toggleSidebar } = useSidebar()
+  const { t } = useTranslation()
 
   return (
     <button
       ref={ref}
       data-sidebar="rail"
-      aria-label="Toggle Sidebar"
+      aria-label={t('ui.toggleSidebar')}
       tabIndex={-1}
       onClick={toggleSidebar}
-      title="Toggle Sidebar"
+      title={t('ui.toggleSidebar')}
       className={cn(
         "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
         "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -161,7 +161,8 @@
     "weekday": "Wochentag",
     "date": "Festes Datum",
     "titleTemplate": "Dynamischer Titel",
-    "color": "Farbe"
+    "color": "Farbe",
+    "placeholderExample": "z.B. 3"
   },
   "deckModal": {
     "editTitle": "Deck bearbeiten",
@@ -472,5 +473,26 @@
   "taskStore": {
     "defaultCategoryName": "Allgemein",
     "defaultCategoryDescription": "Standard Kategorie für alle Tasks"
+  },
+  "weekdays": {
+    "sunday": "Sonntag",
+    "monday": "Montag",
+    "tuesday": "Dienstag",
+    "wednesday": "Mittwoch",
+    "thursday": "Donnerstag",
+    "friday": "Freitag",
+    "saturday": "Samstag"
+  },
+  "ui": {
+    "previous": "Zurück",
+    "next": "Weiter",
+    "morePages": "Weitere Seiten",
+    "previousSlide": "Vorherige Folie",
+    "nextSlide": "Nächste Folie",
+    "close": "Schließen",
+    "toggleSidebar": "Sidebar umschalten",
+    "more": "Mehr",
+    "goPrevAria": "Zur vorherigen Seite",
+    "goNextAria": "Zur nächsten Seite"
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -161,7 +161,8 @@
     "weekday": "Weekday",
     "date": "Fixed date",
     "titleTemplate": "Dynamic Title",
-    "color": "Color"
+    "color": "Color",
+    "placeholderExample": "e.g. 3"
   },
   "deckModal": {
     "editTitle": "Edit Deck",
@@ -472,5 +473,26 @@
   "taskStore": {
     "defaultCategoryName": "General",
     "defaultCategoryDescription": "Default category for all tasks"
+  },
+  "weekdays": {
+    "sunday": "Sunday",
+    "monday": "Monday",
+    "tuesday": "Tuesday",
+    "wednesday": "Wednesday",
+    "thursday": "Thursday",
+    "friday": "Friday",
+    "saturday": "Saturday"
+  },
+  "ui": {
+    "previous": "Previous",
+    "next": "Next",
+    "morePages": "More pages",
+    "previousSlide": "Previous slide",
+    "nextSlide": "Next slide",
+    "close": "Close",
+    "toggleSidebar": "Toggle Sidebar",
+    "more": "More",
+    "goPrevAria": "Go to previous page",
+    "goNextAria": "Go to next page"
   }
 }


### PR DESCRIPTION
## Summary
- add translation keys for weekdays and UI components
- internationalize TaskModal placeholders and weekday options
- use `react-i18next` for pagination, carousel, sheet, dialog, sidebar and breadcrumb

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6850225b0e80832a9a79290dce068c36