### PR TITLE
Add placeholder translation key for dynamic task titles

### DIFF
--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -437,7 +437,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
                   id="titleTemplate"
                   value={formData.titleTemplate || ''}
                   onChange={(e) => handleChange('titleTemplate', e.target.value)}
-                  placeholder="{date} / {counter}"
+                  placeholder={t('taskModal.titleTemplatePlaceholder')}
                 />
               </div>
                 </div>

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -161,6 +161,7 @@
     "weekday": "Wochentag",
     "date": "Festes Datum",
     "titleTemplate": "Dynamischer Titel",
+    "titleTemplatePlaceholder": "{date} / {counter}",
     "color": "Farbe",
     "placeholderExample": "z.B. 3"
   },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -161,6 +161,7 @@
     "weekday": "Weekday",
     "date": "Fixed date",
     "titleTemplate": "Dynamic Title",
+    "titleTemplatePlaceholder": "{date} / {counter}",
     "color": "Color",
     "placeholderExample": "e.g. 3"
   },


### PR DESCRIPTION
## Summary
- add a `titleTemplatePlaceholder` translation for en/de
- use translated placeholder in `TaskModal`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685027b2d52c832aa40aca4472d1c587