### PR TITLE
Fix pip title translation

### DIFF
--- a/src/components/PomodoroTimer.tsx
+++ b/src/components/PomodoroTimer.tsx
@@ -228,7 +228,7 @@ const PomodoroTimer: React.FC<PomodoroTimerProps> = ({ compact, size = 80, float
         pip.document.write('<!DOCTYPE html><html><head></head><body></body></html>');
         pip.document.close();
       }
-      pip.document.title = 'Pomodoro';
+        pip.document.title = t('navbar.pomodoro');
       pip.document.documentElement.className = document.documentElement.className;
       document.querySelectorAll('style, link[rel="stylesheet"]').forEach(el => {
         const clone = el.cloneNode(true) as HTMLElement;


### PR DESCRIPTION
## Summary
- update Pomodoro PiP window title to use translation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685028dfa8c0832a925eb80039fe6ad3