### PR TITLE
Show server WiFi IP in settings

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -680,17 +680,23 @@ const server = http.createServer((req, res) => {
   if (parsed.pathname === '/api/server-info') {
     const ips = [];
     const ifaces = os.networkInterfaces();
-    Object.values(ifaces).forEach(list => {
+    let wifiIp = null;
+    Object.entries(ifaces).forEach(([name, list]) => {
       for (const iface of list || []) {
         if (iface.family === 'IPv4' && !iface.internal) {
           ips.push(iface.address);
+          if (!wifiIp && /^wl|wlan|wi-?fi/i.test(name)) {
+            wifiIp = iface.address;
+          }
         }
       }
     });
     const info = {
       ips,
       port,
-      urls: ips.map(ip => `http://${ip}:${port}/`)
+      urls: ips.map(ip => `http://${ip}:${port}/`),
+      wifiIp,
+      wifiUrl: wifiIp ? `http://${wifiIp}:${port}/` : null
     };
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify(info));

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -49,7 +49,8 @@
       "port": "Port",
       "ips": "IPs",
       "urls": "URLs",
-      "loading": "Lade..."
+      "loading": "Lade...",
+      "wifiIp": "WLAN-IP"
     }
   },
   "settingsPage": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -49,7 +49,8 @@
       "port": "Port",
       "ips": "IPs",
       "urls": "URLs",
-      "loading": "Loading..."
+      "loading": "Loading...",
+      "wifiIp": "WiFi IP"
     }
   },
   "settingsPage": {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -40,6 +40,8 @@ interface ServerInfo {
   ips: string[]
   port: number
   urls: string[]
+  wifiIp: string | null
+  wifiUrl: string | null
 }
 
 const SettingsPage: React.FC = () => {
@@ -735,6 +737,12 @@ const SettingsPage: React.FC = () => {
                   </SelectContent>
                 </Select>
               </div>
+              {syncRole === 'server' && serverInfo?.wifiUrl && (
+                <div className="space-y-2">
+                  <p className="font-medium">{t('settings.serverInfo.wifiIp')}</p>
+                  <p className="text-sm break-all">{serverInfo.wifiUrl}</p>
+                </div>
+              )}
               {syncRole === 'client' && (
                 <div className="space-y-2">
                   <p className="font-medium">{t('settingsPage.serverUrl')}</p>
@@ -832,6 +840,12 @@ const SettingsPage: React.FC = () => {
                       ))}
                     </ul>
                   </div>
+                  {serverInfo.wifiUrl && (
+                    <div>
+                      <p className="font-medium">{t('settings.serverInfo.wifiIp')}</p>
+                      <p className="text-sm break-all">{serverInfo.wifiUrl}</p>
+                    </div>
+                  )}
                   {syncRole === 'server' && syncLog && (
                     <div>
                       <p className="font-medium">{t('settingsPage.syncLog')}</p>


### PR DESCRIPTION
## Summary
- add WiFi IP and URL to server-info endpoint
- expose WiFi IP on data sync screen and in server info tab
- localize WiFi IP label

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6851776377bc832ab283dbe6638b4e7a