### PR TITLE
Fix sync URL handling and support public IP override

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Die Anwendung legt ihre SQLite-Daten standardmäßig im Volume `total-task-track
 docker run -d --name total-task-tracker -p 3002:3002 -v ./server/data:/app/server/data ghcr.io/timbornemann/total-task-tracker:latest
 ```
 
+Soll in den Einstellungen eine bestimmte IP angezeigt werden (etwa bei der Docker-Nutzung), kannst du die Umgebungsvariable `SERVER_PUBLIC_IP` setzen. Dieser Wert wird unter "Server Info" zusätzlich ausgegeben.
+
 ## Docker-Compose: Image selbst bauen
 
 Die Anwendung kann auch komplett über `docker-compose` ausgeführt werden. Dabei wird automatisch ein Produktionsbuild erstellt.

--- a/server/index.js
+++ b/server/index.js
@@ -379,7 +379,10 @@ function setSyncRole(role) {
 }
 
 function setSyncServerUrl(url) {
-  syncServerUrl = url || '';
+  if (url && !/^https?:\/\//i.test(url)) {
+    url = 'http://' + url;
+  }
+  syncServerUrl = url ? url.replace(/\/$/, '') : '';
   startSyncTimer();
 }
 
@@ -691,6 +694,10 @@ const server = http.createServer((req, res) => {
         }
       }
     });
+    if (publicIp && !ips.includes(publicIp)) {
+      ips.push(publicIp);
+      if (!wifiIp) wifiIp = publicIp;
+    }
     const info = {
       ips,
       port,
@@ -725,6 +732,7 @@ const server = http.createServer((req, res) => {
 });
 
 const port = process.env.PORT || 3002;
+const publicIp = process.env.SERVER_PUBLIC_IP || null;
 server.listen(port, () => {
   console.log('Server listening on port', port);
 });


### PR DESCRIPTION
## Summary
- sanitize sync server URLs to avoid "Failed to parse" errors
- allow overriding the reported server IP via `SERVER_PUBLIC_IP`
- document the new environment variable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68517a74f064832a90dd01da251891ea