### PR TITLE
Improve sync with SSE and deletion tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ npm start    # startet die gebaute App auf Port 3002
   Der Server listet seine IP-Adressen auf und führt ein Log über eingehende
   Anfragen. Fällt der Server aus, speichern Clients lokal weiter und gleichen
   die Daten ab, sobald der Server wieder erreichbar ist.
+- Live-Updates per Server-Sent Events halten geöffnete Clients automatisch auf dem neuesten Stand.
+- Gelöschte Einträge werden über ein Deletion-Log abgeglichen und tauchen nicht wieder auf.
 - Standard-Priorität für neue Tasks einstellbar
 - Mehrsprachige Oberfläche (Deutsch, Englisch) auswählbar
 - Mehrere Theme-Voreinstellungen (light, dark, ocean, dark-red, hacker,

--- a/src/hooks/useTaskStore.tsx
+++ b/src/hooks/useTaskStore.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, createContext, useContext } from 'react';
-import { Task, Category, Note } from '@/types';
+import { Task, Category, Note, Deletion } from '@/types';
 import i18n from '@/lib/i18n';
 
 const API_URL = '/api/data';
@@ -20,13 +20,12 @@ const useTaskStoreImpl = () => {
   const [categories, setCategories] = useState<Category[]>([]);
   const [notes, setNotes] = useState<Note[]>([]);
   const [recurring, setRecurring] = useState<Task[]>([]);
+  const [deletions, setDeletions] = useState<Deletion[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [recentlyDeletedCategories, setRecentlyDeletedCategories] =
     useState<{ category: Category; taskIds: string[] }[]>([]);
 
-  // Load data from the server on mount
-  useEffect(() => {
-    const loadData = async () => {
+  const fetchData = async () => {
       try {
         const res = await fetch(API_URL);
         if (!res.ok) throw new Error('Server error');
@@ -34,12 +33,24 @@ const useTaskStoreImpl = () => {
           tasks: savedTasks,
           categories: savedCategories,
           notes: savedNotes,
-          recurring: savedRecurring
+          recurring: savedRecurring,
+          deletions: savedDeletions
         } = await res.json();
+        setDeletions(
+          (savedDeletions || []).map((d: any) => ({
+            ...d,
+            deletedAt: new Date(d.deletedAt)
+          }))
+        );
+
+        const isDeleted = (type: string, id: string) =>
+          savedDeletions?.some((d: any) => d.type === type && d.id === id);
 
         if (savedTasks) {
             setTasks(
-              savedTasks.map((task: Task, idx: number) => ({
+              savedTasks
+                .filter((t: Task) => !isDeleted('task', t.id))
+                .map((task: Task, idx: number) => ({
               ...task,
               createdAt: new Date(task.createdAt),
               updatedAt: new Date(task.updatedAt),
@@ -59,7 +70,9 @@ const useTaskStoreImpl = () => {
         if (savedNotes) {
           setNotes(
               sortNotes(
-                savedNotes.map((note: Note, idx: number) => ({
+                savedNotes
+                  .filter((n: Note) => !isDeleted('note', n.id))
+                  .map((note: Note, idx: number) => ({
                 ...note,
                 createdAt: new Date(note.createdAt),
                 updatedAt: new Date(note.updatedAt),
@@ -72,7 +85,9 @@ const useTaskStoreImpl = () => {
 
         if (savedRecurring) {
             setRecurring(
-              savedRecurring.map((t: Task, idx: number) => ({
+              savedRecurring
+                .filter((t: Task) => !isDeleted('recurring', t.id))
+                .map((t: Task, idx: number) => ({
               ...t,
               createdAt: new Date(t.createdAt),
               updatedAt: new Date(t.updatedAt),
@@ -92,7 +107,9 @@ const useTaskStoreImpl = () => {
 
         if (savedCategories && savedCategories.length) {
             setCategories(
-              savedCategories.map((category: Category, idx: number) => ({
+              savedCategories
+                .filter((c: Category) => !isDeleted('category', c.id))
+                .map((category: Category, idx: number) => ({
               ...category,
               createdAt: new Date(category.createdAt),
               updatedAt: new Date(category.updatedAt),
@@ -118,7 +135,7 @@ const useTaskStoreImpl = () => {
       }
     };
 
-    loadData();
+    fetchData();
   }, []);
 
   useEffect(() => {
@@ -130,6 +147,12 @@ const useTaskStoreImpl = () => {
     return () => clearInterval(interval);
   }, []);
 
+  useEffect(() => {
+    const es = new EventSource('/api/updates');
+    es.onmessage = () => fetchData();
+    return () => es.close();
+  }, []);
+
   // Save to server whenever data changes after initial load
   useEffect(() => {
     if (!loaded) return;
@@ -138,7 +161,7 @@ const useTaskStoreImpl = () => {
         await fetch(API_URL, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ tasks, categories, notes, recurring })
+          body: JSON.stringify({ tasks, categories, notes, recurring, deletions })
         });
       } catch (error) {
         console.error('Error saving data:', error);
@@ -313,6 +336,7 @@ const useTaskStoreImpl = () => {
       );
       return [...reorderedMain, ...subs];
     });
+    setDeletions(prev => [...prev, { id: taskId, type: 'task', deletedAt: new Date() }]);
   };
 
   const addRecurringTask = (
@@ -381,6 +405,7 @@ const useTaskStoreImpl = () => {
 
   const deleteRecurringTask = (id: string) => {
     setRecurring(prev => prev.filter(t => t.id !== id));
+    setDeletions(prev => [...prev, { id, type: 'recurring', deletedAt: new Date() }]);
   };
 
   const generateTitle = (t: Task): string => {
@@ -491,6 +516,7 @@ const useTaskStoreImpl = () => {
       ...prev,
       { category: categoryToDelete, taskIds: affectedTaskIds }
     ]);
+    setDeletions(prev => [...prev, { id: categoryId, type: 'category', deletedAt: new Date() }]);
   };
 
   const undoDeleteCategory = (categoryId: string) => {
@@ -621,6 +647,7 @@ const useTaskStoreImpl = () => {
 
   const deleteNote = (noteId: string) => {
     setNotes(prev => sortNotes(prev.filter(n => n.id !== noteId)));
+    setDeletions(prev => [...prev, { id: noteId, type: 'note', deletedAt: new Date() }]);
   };
 
   const reorderNotes = (startIndex: number, endIndex: number) => {
@@ -658,6 +685,7 @@ const useTaskStoreImpl = () => {
     categories,
     notes,
     recentlyDeletedCategories,
+    deletions,
     addTask,
     updateTask,
     deleteTask,

--- a/src/hooks/useTaskStore.tsx
+++ b/src/hooks/useTaskStore.tsx
@@ -36,15 +36,19 @@ const useTaskStoreImpl = () => {
           recurring: savedRecurring,
           deletions: savedDeletions
         } = await res.json();
+        const serverDeletions: (Omit<Deletion, 'deletedAt'> & {
+          deletedAt: string;
+        })[] = savedDeletions || [];
+
         setDeletions(
-          (savedDeletions || []).map((d: any) => ({
+          serverDeletions.map(d => ({
             ...d,
             deletedAt: new Date(d.deletedAt)
           }))
         );
 
-        const isDeleted = (type: string, id: string) =>
-          savedDeletions?.some((d: any) => d.type === type && d.id === id);
+        const isDeleted = (type: Deletion['type'], id: string) =>
+          serverDeletions.some(d => d.type === type && d.id === id);
 
         if (savedTasks) {
             setTasks(

--- a/src/hooks/useTaskStore.tsx
+++ b/src/hooks/useTaskStore.tsx
@@ -26,7 +26,7 @@ const useTaskStoreImpl = () => {
     useState<{ category: Category; taskIds: string[] }[]>([]);
 
   const fetchData = async () => {
-      try {
+    try {
         const res = await fetch(API_URL);
         if (!res.ok) throw new Error('Server error');
         const {
@@ -135,6 +135,7 @@ const useTaskStoreImpl = () => {
       }
     };
 
+  useEffect(() => {
     fetchData();
   }, []);
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -118,6 +118,18 @@ export interface Deck {
   name: string;
 }
 
+export interface Deletion {
+  id: string;
+  type:
+    | 'task'
+    | 'category'
+    | 'note'
+    | 'recurring'
+    | 'flashcard'
+    | 'deck';
+  deletedAt: Date;
+}
+
 export interface TaskStats {
   totalTasks: number;
   completedTasks: number;


### PR DESCRIPTION
## Summary
- add deletion log table and SSE support on backend
- provide `/api/updates` endpoint to push change events
- apply deletion filter during sync and persist deletion info
- listen to SSE on client and reload data
- track deletions in task store
- document new live-sync features

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518978ec94832aaed0a119f97806c5