### PR TITLE
Make task and note colors customizable

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -35,7 +35,7 @@ const isMatching = (e: KeyboardEvent, shortcut: string) => {
 const CommandPalette: React.FC = () => {
   const { addTask, addNote, tasks, notes } = useTaskStore()
   const { flashcards, decks, addFlashcard } = useFlashcardStore()
-  const { shortcuts, defaultTaskPriority } = useSettings()
+  const { shortcuts, defaultTaskPriority, colorPalette } = useSettings()
   const { toast } = useToast()
   const { t } = useTranslation()
   const { currentCategoryId, setCurrentCategoryId } = useCurrentCategory()
@@ -109,13 +109,13 @@ const CommandPalette: React.FC = () => {
         title,
         description: '',
         priority: defaultTaskPriority,
-        color: '#3B82F6',
+        color: colorPalette[0] || '#3B82F6',
         categoryId: currentCategoryId || 'default',
         isRecurring: false
       })
       toast({ description: t('commandPalette.taskCreated') })
     } else if (mode === 'note') {
-      addNote({ title, text: '', color: '#F59E0B' })
+      addNote({ title, text: '', color: colorPalette[3] || '#F59E0B' })
       toast({ description: t('commandPalette.noteCreated') })
     } else if (mode === 'flashcard') {
       if (decks.length > 0) {

--- a/src/components/NoteModal.tsx
+++ b/src/components/NoteModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Note } from '@/types';
+import { useSettings } from '@/hooks/useSettings';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -18,25 +19,23 @@ interface NoteModalProps {
 
 const NoteModal: React.FC<NoteModalProps> = ({ isOpen, onClose, onSave, note }) => {
   const { t } = useTranslation();
+  const { colorPalette } = useSettings();
   const [formData, setFormData] = useState({
     title: '',
     text: '',
-    color: '#F59E0B'
+    color: colorPalette[3] || '#F59E0B'
   });
 
-  const colorOptions = [
-    '#3B82F6', '#EF4444', '#10B981', '#F59E0B',
-    '#8B5CF6', '#F97316', '#06B6D4', '#84CC16'
-  ];
+  const colorOptions = colorPalette;
 
   useEffect(() => {
     if (!isOpen) return;
     if (note) {
       setFormData({ title: note.title, text: note.text, color: note.color });
     } else {
-      setFormData({ title: '', text: '', color: '#F59E0B' });
+      setFormData({ title: '', text: '', color: colorPalette[3] || '#F59E0B' });
     }
-  }, [isOpen, note]);
+  }, [isOpen, note, colorPalette]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -65,12 +65,12 @@ const TaskModal: React.FC<TaskModalProps> = ({
   defaultEndTime
 }) => {
   const { t } = useTranslation();
-  const { defaultTaskPriority } = useSettings()
+  const { defaultTaskPriority, colorPalette } = useSettings()
   const [formData, setFormData] = useState<TaskFormData>({
     title: '',
     description: '',
     priority: defaultTaskPriority,
-    color: '#3B82F6',
+    color: colorPalette[0] || '#3B82F6',
     categoryId: '',
     parentId: parentTask?.id,
     dueDate: undefined,
@@ -88,10 +88,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
     template: false
   });
 
-  const colorOptions = [
-    '#3B82F6', '#EF4444', '#10B981', '#F59E0B', 
-    '#8B5CF6', '#F97316', '#06B6D4', '#84CC16'
-  ];
+  const colorOptions = colorPalette
 
   useEffect(() => {
     if (!isOpen) return;
@@ -123,7 +120,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
         title: '',
         description: '',
         priority: defaultTaskPriority,
-        color: '#3B82F6',
+        color: colorPalette[0] || '#3B82F6',
         categoryId:
           defaultCategoryId || parentTask?.categoryId || categories[0]?.id || '',
         parentId: parentTask?.id,
@@ -153,7 +150,8 @@ const TaskModal: React.FC<TaskModalProps> = ({
     defaultIsRecurring,
     allowRecurring,
     defaultStartTime,
-    defaultEndTime
+    defaultEndTime,
+    colorPalette
   ]);
 
   const handleSubmit = (e: React.FormEvent) => {

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -48,6 +48,17 @@ const defaultTheme = {
   'pomodoro-break-ring': '212 100% 47%'
 }
 
+const defaultColorPalette = [
+  '#3B82F6',
+  '#EF4444',
+  '#10B981',
+  '#F59E0B',
+  '#8B5CF6',
+  '#F97316',
+  '#06B6D4',
+  '#84CC16'
+]
+
 export const themePresets: Record<string, typeof defaultTheme> = {
   light: { ...defaultTheme },
   dark: {
@@ -138,6 +149,8 @@ interface SettingsContextValue {
   updateTheme: (key: keyof typeof defaultTheme, value: string) => void
   themeName: string
   updateThemeName: (name: string) => void
+  colorPalette: string[]
+  updatePaletteColor: (index: number, value: string) => void
   homeSections: string[]
   homeSectionOrder: string[]
   toggleHomeSection: (section: string) => void
@@ -185,6 +198,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   )
   const [theme, setTheme] = useState(defaultTheme)
   const [themeName, setThemeName] = useState('light')
+  const [colorPalette, setColorPalette] = useState<string[]>(defaultColorPalette)
   const [homeSectionOrder, setHomeSectionOrder] = useState<string[]>(
     allHomeSections.map(s => s.key)
   )
@@ -225,6 +239,9 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
             if (themePresets[data.themeName]) {
               setTheme(themePresets[data.themeName])
             }
+          }
+          if (Array.isArray(data.colorPalette)) {
+            setColorPalette(data.colorPalette)
           }
           if (Array.isArray(data.homeSectionOrder)) {
             const order = data.homeSectionOrder as string[]
@@ -301,6 +318,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
             defaultTaskPriority: priority,
             theme,
             themeName,
+            colorPalette,
             homeSections,
             homeSectionOrder,
             showPinnedTasks,
@@ -328,6 +346,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     priority,
     theme,
     themeName,
+    colorPalette,
     homeSections,
     homeSectionOrder,
     showPinnedTasks,
@@ -379,6 +398,14 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     if (themePresets[name]) {
       setTheme(themePresets[name])
     }
+  }
+
+  const updatePaletteColor = (index: number, value: string) => {
+    setColorPalette(prev => {
+      const arr = [...prev]
+      arr[index] = value
+      return arr
+    })
   }
 
   const updateFlashcardTimer = (value: number) => {
@@ -454,6 +481,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         updateTheme,
         themeName,
         updateThemeName,
+        colorPalette,
+        updatePaletteColor,
         homeSections,
         homeSectionOrder,
         toggleHomeSection,

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -87,6 +87,7 @@
     "kanbanDone": "Kanban Erledigt",
     "workRing": "Pomodoro Arbeit",
     "breakRing": "Pomodoro Pause",
+    "taskColors": "Task- und Notizfarben",
     "dataTitle": "Datenexport / -import",
     "syncRole": "Sync-Rolle",
     "roleServer": "Server",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -87,6 +87,7 @@
     "kanbanDone": "Kanban Done",
     "workRing": "Pomodoro Work",
     "breakRing": "Pomodoro Break",
+    "taskColors": "Task & Note colors",
     "dataTitle": "Data export / import",
     "syncRole": "Sync role",
     "roleServer": "Server",

--- a/src/pages/NoteDetail.tsx
+++ b/src/pages/NoteDetail.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useParams, useNavigate } from 'react-router-dom';
 import Navbar from '@/components/Navbar';
 import { useTaskStore } from '@/hooks/useTaskStore';
+import { useSettings } from '@/hooks/useSettings';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft } from 'lucide-react';
 import { Input } from '@/components/ui/input';
@@ -14,21 +15,23 @@ const NoteDetailPage: React.FC = () => {
   const navigate = useNavigate();
   const { t } = useTranslation();
   const { notes, updateNote, deleteNote } = useTaskStore();
+  const { colorPalette } = useSettings();
   const note = notes.find(n => n.id === id);
 
   const [isEditing, setIsEditing] = useState(false);
-  const [formData, setFormData] = useState({ title: '', text: '', color: '#F59E0B' });
+  const [formData, setFormData] = useState({
+    title: '',
+    text: '',
+    color: colorPalette[3] || '#F59E0B'
+  });
 
-  const colorOptions = [
-    '#3B82F6', '#EF4444', '#10B981', '#F59E0B',
-    '#8B5CF6', '#F97316', '#06B6D4', '#84CC16'
-  ];
+  const colorOptions = colorPalette;
 
   useEffect(() => {
     if (note) {
       setFormData({ title: note.title, text: note.text, color: note.color });
     }
-  }, [note]);
+  }, [note, colorPalette]);
 
   const handleChange = (field: 'title' | 'text' | 'color', value: string) => {
     setFormData(prev => ({ ...prev, [field]: value }));

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -79,7 +79,9 @@ const SettingsPage: React.FC = () => {
     syncEnabled,
     updateSyncEnabled,
     language,
-    updateLanguage
+    updateLanguage,
+    colorPalette,
+    updatePaletteColor
   } = useSettings()
 
   const { t } = useTranslation()
@@ -690,6 +692,20 @@ const SettingsPage: React.FC = () => {
                   value={hslToHex(theme['pomodoro-break-ring'])}
                   onChange={e => updateTheme('pomodoro-break-ring', hexToHsl(e.target.value))}
                 />
+              </div>
+              <div className="space-y-2">
+                <Label>{t('settingsPage.taskColors')}</Label>
+                <div className="flex flex-wrap gap-2">
+                  {colorPalette.map((c, idx) => (
+                    <Input
+                      key={idx}
+                      type="color"
+                      value={c}
+                      onChange={e => updatePaletteColor(idx, e.target.value)}
+                      className="w-10 h-10 p-0 border-none"
+                    />
+                  ))}
+                </div>
               </div>
             </TabsContent>
             <TabsContent value="language" className="space-y-4">


### PR DESCRIPTION
## Summary
- allow theme settings to customize color palette
- use palette for task and note modals and command palette
- update settings context and translations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852aecdfb54832a8ead8f328e34bec8