### PR TITLE
Update card colors

### DIFF
--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -9,6 +9,7 @@ import { Edit, Trash2, FolderOpen, MoreVertical } from 'lucide-react';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { getTaskProgress } from '@/utils/taskUtils';
 import { useSettings } from '@/hooks/useSettings';
+import { isColorDark } from '@/utils/color';
 
 interface CategoryCardProps {
   category: Category;
@@ -36,17 +37,19 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
   const completionPercentage = totalTasks > 0 ? (completedTasks / totalTasks) * 100 : 0;
 
   return (
-    <Card className="h-full transition-all duration-200 hover:shadow-lg hover:scale-105 cursor-pointer group">
+    <Card
+      className="h-full transition-all duration-200 hover:shadow-lg cursor-pointer group"
+      style={{
+        backgroundColor: colorPalette[category.color],
+        color: isColorDark(colorPalette[category.color]) ? '#fff' : '#000'
+      }}
+    >
       <CardHeader 
         className="pb-2 sm:pb-3"
         onClick={() => onViewTasks(category)}
       >
         <div className="flex items-start justify-between">
-          <div className="flex items-start space-x-2 sm:space-x-3 flex-1 min-w-0">
-            <div
-              className="w-5 h-5 sm:w-6 sm:h-6 rounded-full border-2 border-muted flex-shrink-0 mt-1"
-              style={{ backgroundColor: colorPalette[category.color] }}
-            />
+          <div className="flex items-start flex-1 min-w-0">
             <div className="flex-1 min-w-0">
               <CardTitle className="text-base sm:text-lg font-semibold group-hover:text-primary transition-colors break-words">
                 {category.name}

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Star, StarOff } from 'lucide-react';
 import { useTaskStore } from '@/hooks/useTaskStore';
 import { useSettings } from '@/hooks/useSettings';
+import { isColorDark } from '@/utils/color';
 
 interface NoteCardProps {
   note: Note;
@@ -23,13 +24,13 @@ const NoteCard: React.FC<NoteCardProps> = ({ note, onClick }) => {
   return (
     <Card
       className="cursor-pointer hover:shadow-md transition-all h-full flex flex-col"
+      style={{
+        backgroundColor: colorPalette[note.color],
+        color: isColorDark(colorPalette[note.color]) ? '#fff' : '#000'
+      }}
       onClick={onClick}
     >
-      <CardHeader className="pb-2 flex items-center space-x-2">
-        <div
-          className="w-4 h-4 rounded-full flex-shrink-0"
-          style={{ backgroundColor: colorPalette[note.color] }}
-        />
+      <CardHeader className="pb-2 flex items-center">
         <CardTitle className="text-base font-medium truncate flex-1">
           {note.title}
         </CardTitle>

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { useSettings } from '@/hooks/useSettings';
+import { isColorDark } from '@/utils/color';
 import {
   Edit,
   Trash2,
@@ -66,15 +67,19 @@ const TaskCard: React.FC<TaskCardProps> = ({
   };
 
   return (
-    <Card 
+    <Card
       className={`mb-3 sm:mb-4 transition-all duration-200 hover:shadow-md ${
         depth > 0 ? 'ml-3 sm:ml-6 border-l-4' : ''
-      } ${isCompleted ? 'bg-green-50 border-green-200' : ''}`}
-      style={{ borderLeftColor: depth > 0 ? colorPalette[task.color] : undefined }}
+      }`}
+      style={{
+        backgroundColor: colorPalette[task.color],
+        color: isColorDark(colorPalette[task.color]) ? '#fff' : '#000',
+        borderLeftColor: depth > 0 ? colorPalette[task.color] : undefined
+      }}
     >
       <CardHeader className="pb-2 sm:pb-3">
         <div className="flex items-start justify-between">
-          <div className="flex items-start space-x-2 sm:space-x-3 flex-1 min-w-0">
+          <div className="flex items-start flex-1 min-w-0">
             {task.subtasks.length === 0 && (
               <input
                 type="checkbox"
@@ -102,10 +107,6 @@ const TaskCard: React.FC<TaskCardProps> = ({
                   <span className="hidden sm:inline">{priorityIcon} </span>
                   {task.priority.toUpperCase()}
                 </Badge>
-                <div
-                  className="w-4 h-4 rounded-full border-2 border-gray-300 flex-shrink-0"
-                  style={{ backgroundColor: colorPalette[task.color] }}
-                />
                 {task.isRecurring && (
                   <Badge
                     variant="outline"

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -54,3 +54,13 @@ export const hslToHex = (hsl: string): string => {
   const toHex = (x: number) => Math.round(x * 255).toString(16).padStart(2, '0');
   return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
 };
+
+export const isColorDark = (hex: string): boolean => {
+  let h = hex.replace('#', '');
+  if (h.length === 3) h = h.split('').map(c => c + c).join('');
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  const yiq = (r * 299 + g * 587 + b * 114) / 1000;
+  return yiq < 128;
+};


### PR DESCRIPTION
## Summary
- fill cards using selected palette color
- remove color dot from each card
- compute light/dark text color automatically

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68548f33f758832a859ad217018e2ed5