### PR TITLE
Handle invalid color values gracefully

### DIFF
--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -37,7 +37,7 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
   const completionPercentage =
     totalTasks > 0 ? (completedTasks / totalTasks) * 100 : 0;
 
-  const baseColor = colorPalette[category.color];
+  const baseColor = colorPalette[category.color] ?? colorPalette[0];
   const textColor = isColorDark(baseColor) ? '#fff' : '#000';
   const hoverColor = isColorDark(baseColor)
     ? adjustColor(baseColor, 10)

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -15,7 +15,7 @@ interface NoteCardProps {
 const NoteCard: React.FC<NoteCardProps> = ({ note, onClick }) => {
   const { updateNote } = useTaskStore();
   const { colorPalette } = useSettings();
-  const baseColor = colorPalette[note.color];
+  const baseColor = colorPalette[note.color] ?? colorPalette[0];
   const textColor = isColorDark(baseColor) ? '#fff' : '#000';
   const hoverColor = isColorDark(baseColor)
     ? adjustColor(baseColor, 10)

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -67,7 +67,7 @@ const TaskCard: React.FC<TaskCardProps> = ({
     setCollapsed(collapseSubtasksByDefault);
   }, [collapseSubtasksByDefault]);
 
-  const baseColor = colorPalette[task.color];
+  const baseColor = colorPalette[task.color] ?? colorPalette[0];
   const depthOffset = depth * 8;
   const displayColor = depth > 0
     ? adjustColor(baseColor, isColorDark(baseColor) ? depthOffset : -depthOffset)
@@ -99,7 +99,7 @@ const TaskCard: React.FC<TaskCardProps> = ({
     const progress = getTaskProgress(st);
     const percentage =
       progress.total > 0 ? (progress.completed / progress.total) * 100 : 0;
-    const base = colorPalette[st.color];
+    const base = colorPalette[st.color] ?? colorPalette[0];
     const offset = level * 8;
     const color =
       level > 0

--- a/src/hooks/useTaskStore.tsx
+++ b/src/hooks/useTaskStore.tsx
@@ -54,7 +54,9 @@ const useTaskStoreImpl = () => {
         serverDeletions.some(d => d.type === type && d.id === id);
 
       const mapColor = (c: unknown): number => {
-        if (typeof c === 'number') return c;
+        if (typeof c === 'number') {
+          return c >= 0 && c < colorPalette.length ? c : 0;
+        }
         if (typeof c === 'string') {
           const idx = colorPalette.indexOf(c);
           if (idx !== -1) return idx;

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,6 +1,12 @@
-export const hexToHsl = (hex: string): string => {
+const sanitizeHex = (hex?: string): string | null => {
+  if (!hex) return null;
   let h = hex.replace('#', '');
   if (h.length === 3) h = h.split('').map(c => c + c).join('');
+  return h.length === 6 ? h : null;
+};
+
+export const hexToHsl = (hex: string): string => {
+  const h = sanitizeHex(hex) || '000000';
   const r = parseInt(h.slice(0, 2), 16) / 255;
   const g = parseInt(h.slice(2, 4), 16) / 255;
   const b = parseInt(h.slice(4, 6), 16) / 255;
@@ -56,8 +62,8 @@ export const hslToHex = (hsl: string): string => {
 };
 
 export const isColorDark = (hex: string): boolean => {
-  let h = hex.replace('#', '');
-  if (h.length === 3) h = h.split('').map(c => c + c).join('');
+  const h = sanitizeHex(hex);
+  if (!h) return false;
   const r = parseInt(h.slice(0, 2), 16);
   const g = parseInt(h.slice(2, 4), 16);
   const b = parseInt(h.slice(4, 6), 16);
@@ -66,24 +72,23 @@ export const isColorDark = (hex: string): boolean => {
 };
 
 export const adjustColor = (hex: string, percent: number): string => {
-  let h = hex.replace('#', '')
-  if (h.length === 3) h = h.split('').map(c => c + c).join('')
-  let r = parseInt(h.slice(0, 2), 16)
-  let g = parseInt(h.slice(2, 4), 16)
-  let b = parseInt(h.slice(4, 6), 16)
-  const amt = Math.round(2.55 * percent)
-  r = Math.min(255, Math.max(0, r + amt))
-  g = Math.min(255, Math.max(0, g + amt))
-  b = Math.min(255, Math.max(0, b + amt))
-  const toHex = (x: number) => x.toString(16).padStart(2, '0')
-  return `#${toHex(r)}${toHex(g)}${toHex(b)}`
-}
+  const h = sanitizeHex(hex) || '000000';
+  let r = parseInt(h.slice(0, 2), 16);
+  let g = parseInt(h.slice(2, 4), 16);
+  let b = parseInt(h.slice(4, 6), 16);
+  const amt = Math.round(2.55 * percent);
+  r = Math.min(255, Math.max(0, r + amt));
+  g = Math.min(255, Math.max(0, g + amt));
+  b = Math.min(255, Math.max(0, b + amt));
+  const toHex = (x: number) => x.toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+};
 
 export const complementaryColor = (hex: string): string => {
-  const [hStr, sStr, lStr] = hexToHsl(hex).split(/\s+/)
-  const h = (parseFloat(hStr) + 180) % 360
-  const s = parseFloat(sStr)
-  let l = parseFloat(lStr)
-  l = isColorDark(hex) ? Math.min(100, l + 40) : Math.max(0, l - 40)
-  return hslToHex(`${h} ${s}% ${l}%`)
-}
+  const [hStr, sStr, lStr] = hexToHsl(hex).split(/\s+/);
+  const h = (parseFloat(hStr) + 180) % 360;
+  const s = parseFloat(sStr);
+  let l = parseFloat(lStr);
+  l = isColorDark(hex) ? Math.min(100, l + 40) : Math.max(0, l - 40);
+  return hslToHex(`${h} ${s}% ${l}%`);
+};


### PR DESCRIPTION
## Summary
- guard against invalid hex codes in color utilities
- clamp color index when loading data
- fall back to default palette color in task, category and note cards

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68554f98e2fc832a852b1cf8d0af9404