### PR TITLE
Fix progress bar colors and add grid view

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -75,6 +75,7 @@ const Dashboard: React.FC = () => {
 
   const [filterPriority, setFilterPriority] = useState<string>('all');
   const [filterColor, setFilterColor] = useState<string>('all');
+  const [taskLayout, setTaskLayout] = useState<'list' | 'grid'>('list');
 
 
   useEffect(() => {
@@ -242,7 +243,7 @@ const Dashboard: React.FC = () => {
   };
 
   const handleToggleTaskComplete = (taskId: string, completed: boolean) => {
-    updateTask(taskId, { completed });
+    updateTask(taskId, { completed, status: completed ? 'done' : 'todo' });
     const task = findTaskById(taskId);
     toast({
       title: completed ? t('task.completed') : t('task.reactivated'),
@@ -584,6 +585,25 @@ const Dashboard: React.FC = () => {
                   </SelectContent>
                 </Select>
               </div>
+              <div className="flex items-center gap-1">
+                <Label className="text-sm">{t('dashboard.viewLabel')}</Label>
+                <Button
+                  variant={taskLayout === 'list' ? 'secondary' : 'ghost'}
+                  size="icon"
+                  onClick={() => setTaskLayout('list')}
+                >
+                  <List className="h-4 w-4" />
+                  <span className="sr-only">{t('dashboard.listView')}</span>
+                </Button>
+                <Button
+                  variant={taskLayout === 'grid' ? 'secondary' : 'ghost'}
+                  size="icon"
+                  onClick={() => setTaskLayout('grid')}
+                >
+                  <LayoutGrid className="h-4 w-4" />
+                  <span className="sr-only">{t('dashboard.gridView')}</span>
+                </Button>
+              </div>
               <Button onClick={() => setIsTaskModalOpen(true)} size="sm">
                 <Plus className="h-4 w-4 mr-2" />
                 {t('taskModal.newTitle')}
@@ -615,14 +635,23 @@ const Dashboard: React.FC = () => {
                 <Droppable droppableId="tasks" isCombineEnabled>
                   {provided => (
                     <div
-                      className="space-y-3 sm:space-y-4"
+                      className={
+                        taskLayout === 'grid'
+                          ? 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4'
+                          : 'space-y-3 sm:space-y-4'
+                      }
                       ref={provided.innerRef}
                       {...provided.droppableProps}
                     >
                       {sortedTasks.map((task, index) => (
                         <Draggable key={task.id} draggableId={task.id} index={index}>
                           {prov => (
-                            <div ref={prov.innerRef} {...prov.draggableProps} {...prov.dragHandleProps}>
+                            <div
+                              ref={prov.innerRef}
+                              {...prov.draggableProps}
+                              {...prov.dragHandleProps}
+                              className={taskLayout === 'grid' ? 'h-full' : ''}
+                            >
                               <TaskCard
                                 task={task}
                                 onEdit={handleEditTask}
@@ -630,6 +659,7 @@ const Dashboard: React.FC = () => {
                                 onAddSubtask={handleAddSubtask}
                                 onToggleComplete={handleToggleTaskComplete}
                                 onViewDetails={handleViewTaskDetails}
+                                isGrid={taskLayout === 'grid'}
                               />
                             </div>
                           )}

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -12,7 +12,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { useSettings } from '@/hooks/useSettings';
-import { isColorDark, adjustColor, complementaryColor } from '@/utils/color';
+import { isColorDark, adjustColor, complementaryColor, hslToHex } from '@/utils/color';
 import {
   Edit,
   Trash2,
@@ -40,6 +40,8 @@ interface TaskCardProps {
   parentPathTitles?: string[];
   /** Whether to render subtasks recursively */
   showSubtasks?: boolean;
+  /** Display card optimized for grid layout */
+  isGrid?: boolean;
 }
 
 const TaskCard: React.FC<TaskCardProps> = ({
@@ -51,7 +53,8 @@ const TaskCard: React.FC<TaskCardProps> = ({
   onViewDetails,
   depth = 0,
   parentPathTitles = [],
-  showSubtasks = true
+  showSubtasks = true,
+  isGrid = false
 }) => {
   const isCompleted = calculateTaskCompletion(task);
   const progress = getTaskProgress(task);
@@ -73,10 +76,11 @@ const TaskCard: React.FC<TaskCardProps> = ({
     ? adjustColor(baseColor, isColorDark(baseColor) ? depthOffset : -depthOffset)
     : baseColor;
   const headerTextColor = complementaryColor(displayColor);
-  const progressBg = isColorDark(displayColor)
-    ? adjustColor(displayColor, 50)
-    : adjustColor(displayColor, -20);
-  const progressColor = complementaryColor(displayColor);
+  const cardHex = hslToHex(theme.card);
+  const progressBg = isColorDark(cardHex)
+    ? adjustColor(cardHex, 50)
+    : adjustColor(cardHex, -20);
+  const progressColor = complementaryColor(cardHex);
 
   const handleTogglePinned = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -105,10 +109,10 @@ const TaskCard: React.FC<TaskCardProps> = ({
       level > 0
         ? adjustColor(base, isColorDark(base) ? offset : -offset)
         : base;
-    const progressBg = isColorDark(color)
-      ? adjustColor(color, 50)
-      : adjustColor(color, -20);
-    const progressColor = complementaryColor(color);
+    const progressBg = isColorDark(cardHex)
+      ? adjustColor(cardHex, 50)
+      : adjustColor(cardHex, -20);
+    const progressColor = complementaryColor(cardHex);
 
     return (
       <div
@@ -208,7 +212,9 @@ const TaskCard: React.FC<TaskCardProps> = ({
 
   return (
     <Card
-      className={`mb-3 sm:mb-4 rounded-xl ${depth > 0 ? 'ml-3 sm:ml-6' : ''}`}
+      className={`${isGrid ? 'h-full' : 'mb-3 sm:mb-4'} rounded-xl ${
+        depth > 0 ? 'ml-3 sm:ml-6' : ''
+      }`}
       style={{ boxShadow: '0 1px 4px rgba(0,0,0,0.08)' }}
     >
       <div

--- a/src/components/TaskDetailModal.tsx
+++ b/src/components/TaskDetailModal.tsx
@@ -8,7 +8,7 @@ import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useSettings } from '@/hooks/useSettings';
-import { complementaryColor, adjustColor, isColorDark } from '@/utils/color';
+import { complementaryColor, adjustColor, isColorDark, hslToHex } from '@/utils/color';
 import {
   Edit,
   Plus,
@@ -54,7 +54,7 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
 }) => {
   const { t, i18n } = useTranslation();
   const { updateTask } = useTaskStore();
-  const { colorPalette } = useSettings();
+  const { colorPalette, theme } = useSettings();
   if (!task) return null;
 
   const isCompleted = calculateTaskCompletion(task);
@@ -63,8 +63,9 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({
   const priorityClasses = getPriorityColor(task.priority);
   const priorityIcon = getPriorityIcon(task.priority);
   const baseColor = colorPalette[task.color];
-  const progressBg = isColorDark(baseColor) ? adjustColor(baseColor, 50) : adjustColor(baseColor, -20);
-  const progressColor = complementaryColor(baseColor);
+  const cardHex = hslToHex(theme.card);
+  const progressBg = isColorDark(cardHex) ? adjustColor(cardHex, 50) : adjustColor(cardHex, -20);
+  const progressColor = complementaryColor(cardHex);
 
   const handleTogglePinned = () => {
     updateTask(task.id, { pinned: !task.pinned });

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -439,6 +439,9 @@
     "sortLabel": "Sortierung:",
     "priorityLabel": "Priorität:",
     "colorLabel": "Farbe:",
+    "viewLabel": "Ansicht:",
+    "listView": "Liste",
+    "gridView": "Raster",
     "sort": {
       "manual": "Manuell",
       "createdDesc": "Neueste zuerst",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -439,6 +439,9 @@
     "sortLabel": "Sort by:",
     "priorityLabel": "Priority:",
     "colorLabel": "Color:",
+    "viewLabel": "View:",
+    "listView": "List",
+    "gridView": "Grid",
     "sort": {
       "manual": "Manual",
       "createdDesc": "Newest first",

--- a/src/pages/Kanban.tsx
+++ b/src/pages/Kanban.tsx
@@ -86,7 +86,7 @@ const Kanban: React.FC = () => {
   };
 
   const handleToggleTaskComplete = (taskId: string, completed: boolean) => {
-    updateTask(taskId, { completed });
+    updateTask(taskId, { completed, status: completed ? 'done' : 'todo' });
     const task = findTaskById(taskId);
     toast({
       title: completed ? t('kanban.completed') : t('kanban.reactivated'),


### PR DESCRIPTION
## Summary
- compute progress bar colors based on card background
- switch Kanban status to `done` when a task is completed
- allow switching task list between list and grid layouts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685552e6658c832ab24143dbb793ebaf