### PR TITLE
Add i18n key consistency test

### DIFF
--- a/tests/i18n/keys.test.ts
+++ b/tests/i18n/keys.test.ts
@@ -2,11 +2,11 @@ import en from '@/locales/en/translation.json';
 import de from '@/locales/de/translation.json';
 import { describe, it, expect } from 'vitest';
 
-function collectKeys(obj: Record<string, any>, prefix = ''): string[] {
+function collectKeys(obj: Record<string, unknown>, prefix = ''): string[] {
   return Object.entries(obj).flatMap(([key, value]) => {
     const newKey = prefix ? `${prefix}.${key}` : key;
     if (value && typeof value === 'object' && !Array.isArray(value)) {
-      return collectKeys(value, newKey);
+      return collectKeys(value as Record<string, unknown>, newKey);
     }
     return [newKey];
   });

--- a/tests/i18n/keys.test.ts
+++ b/tests/i18n/keys.test.ts
@@ -1,0 +1,21 @@
+import en from '@/locales/en/translation.json';
+import de from '@/locales/de/translation.json';
+import { describe, it, expect } from 'vitest';
+
+function collectKeys(obj: Record<string, any>, prefix = ''): string[] {
+  return Object.entries(obj).flatMap(([key, value]) => {
+    const newKey = prefix ? `${prefix}.${key}` : key;
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      return collectKeys(value, newKey);
+    }
+    return [newKey];
+  });
+}
+
+describe('i18n key consistency', () => {
+  it('en and de translations have the same keys', () => {
+    const enKeys = collectKeys(en).sort();
+    const deKeys = collectKeys(de).sort();
+    expect(deKeys).toEqual(enKeys);
+  });
+});


### PR DESCRIPTION
## Summary
- add `tests/i18n/keys.test.ts` to verify both translation files contain the same keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855b642f004832aa21b315b21a34dcf