### PR TITLE
Improve task card grid style and overdue highlighting

### DIFF
--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -82,6 +82,13 @@ const TaskCard: React.FC<TaskCardProps> = ({
     : adjustColor(cardHex, -20);
   const progressColor = complementaryColor(cardHex);
 
+  const isOverdue = React.useMemo(() => {
+    if (!task.dueDate || task.completed) return false;
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return new Date(task.dueDate) < today;
+  }, [task.dueDate, task.completed]);
+
   const handleTogglePinned = (e: React.MouseEvent) => {
     e.stopPropagation();
     updateTask(task.id, { pinned: !task.pinned });
@@ -212,7 +219,7 @@ const TaskCard: React.FC<TaskCardProps> = ({
 
   return (
     <Card
-      className={`${isGrid ? 'h-full' : 'mb-3 sm:mb-4'} rounded-xl ${
+      className={`${isGrid ? 'h-full flex flex-col' : 'mb-3 sm:mb-4'} rounded-xl ${
         depth > 0 ? 'ml-3 sm:ml-6' : ''
       }`}
       style={{ boxShadow: '0 1px 4px rgba(0,0,0,0.08)' }}
@@ -278,9 +285,11 @@ const TaskCard: React.FC<TaskCardProps> = ({
       </div>
 
       {(task.description || (showSubtasks && task.subtasks.length > 0)) && (
-        <CardContent className="pt-3">
+        <CardContent className={`pt-3 ${isGrid ? 'flex-1' : ''}`}>
           {task.description && (
-            <p className="text-sm text-muted-foreground mb-3 break-words">
+            <p className={`text-sm text-muted-foreground mb-3 break-words ${
+              isGrid ? 'line-clamp-3' : ''
+            }`}>
               {task.description}
             </p>
           )}
@@ -325,12 +334,17 @@ const TaskCard: React.FC<TaskCardProps> = ({
         </CardContent>
       )}
 
+      {!task.description && (!showSubtasks || task.subtasks.length === 0) &&
+        isGrid && <div className="flex-1" />}
+
       <div className="border-t px-4 py-2 flex items-center justify-between text-xs">
         <div className="flex items-center gap-1 text-muted-foreground">
           {task.dueDate && (
             <>
               <CalendarIcon className="h-4 w-4" />
-              <span>
+              <span
+                style={{ color: isOverdue ? 'hsl(var(--task-overdue))' : undefined }}
+              >
                 {new Date(task.dueDate).toLocaleDateString(i18n.language, {
                   month: 'short',
                   day: 'numeric'

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -54,7 +54,8 @@ const defaultTheme = {
   'kanban-inprogress': '215 28% 80%',
   'kanban-done': '158 55% 52%',
   'pomodoro-work-ring': '222.2 47.4% 11.2%',
-  'pomodoro-break-ring': '212 100% 47%'
+  'pomodoro-break-ring': '212 100% 47%',
+  'task-overdue': '0 84.2% 60.2%'
 }
 
 export const defaultColorPalette = [
@@ -93,7 +94,8 @@ export const themePresets: Record<string, { theme: typeof defaultTheme; colorPal
       'kanban-inprogress': '217 91% 60%',
       'kanban-done': '158 64% 52%',
       'pomodoro-work-ring': '210 40% 98%',
-      'pomodoro-break-ring': '217 91% 60%'
+      'pomodoro-break-ring': '217 91% 60%',
+      'task-overdue': '0 62.8% 30.6%'
     },
     colorPalette: [
       '#60A5FA',
@@ -129,7 +131,8 @@ export const themePresets: Record<string, { theme: typeof defaultTheme; colorPal
       'kanban-inprogress': '210 80% 85%',
       'kanban-done': '199 94% 48%',
       'pomodoro-work-ring': '199 94% 48%',
-      'pomodoro-break-ring': '210 40% 96.1%'
+      'pomodoro-break-ring': '210 40% 96.1%',
+      'task-overdue': '0 84.2% 60.2%'
     },
     colorPalette: [
       '#0EA5E9',
@@ -165,7 +168,8 @@ export const themePresets: Record<string, { theme: typeof defaultTheme; colorPal
       'kanban-inprogress': '0 72% 51%',
       'kanban-done': '0 72% 51%',
       'pomodoro-work-ring': '0 0% 98%',
-      'pomodoro-break-ring': '0 72% 51%'
+      'pomodoro-break-ring': '0 72% 51%',
+      'task-overdue': '0 72% 51%'
     },
     colorPalette: [
       '#F87171',
@@ -201,7 +205,8 @@ export const themePresets: Record<string, { theme: typeof defaultTheme; colorPal
       'kanban-inprogress': '120 40% 30%',
       'kanban-done': '120 70% 40%',
       'pomodoro-work-ring': '120 100% 80%',
-      'pomodoro-break-ring': '120 70% 40%'
+      'pomodoro-break-ring': '120 70% 40%',
+      'task-overdue': '0 62.8% 30.6%'
     },
     colorPalette: [
       '#22C55E',
@@ -237,7 +242,8 @@ export const themePresets: Record<string, { theme: typeof defaultTheme; colorPal
       'kanban-inprogress': '30 100% 50%',
       'kanban-done': '88 50% 50%',
       'pomodoro-work-ring': '20 90% 10%',
-      'pomodoro-break-ring': '30 100% 50%'
+      'pomodoro-break-ring': '30 100% 50%',
+      'task-overdue': '0 84.2% 60.2%'
     },
     colorPalette: [
       '#F97316',

--- a/src/index.css
+++ b/src/index.css
@@ -57,6 +57,7 @@
     --kanban-done: var(--accent);
     --pomodoro-work-ring: var(--primary);
     --pomodoro-break-ring: var(--accent);
+    --task-overdue: var(--destructive);
   }
 
   .dark {
@@ -103,6 +104,7 @@
     --kanban-done: var(--accent);
     --pomodoro-work-ring: var(--primary);
     --pomodoro-break-ring: var(--accent);
+    --task-overdue: var(--destructive);
   }
 }
 

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -94,6 +94,7 @@
     "kanbanDone": "Kanban Erledigt",
     "workRing": "Pomodoro Arbeit",
     "breakRing": "Pomodoro Pause",
+    "taskOverdue": "Überfällig Farbe",
     "taskColors": "Kategorie, Task & Notizfarben",
     "bgColorDesc": "Hintergrund der Anwendung",
     "fgColorDesc": "Standard Textfarbe",
@@ -114,6 +115,7 @@
     "kanbanDoneDesc": "Kanban-Spalte Erledigt",
     "workRingDesc": "Pomodoro Arbeitsring",
     "breakRingDesc": "Pomodoro Pausenring",
+    "taskOverdueDesc": "Farbe für überfällige Termine",
     "taskColorsDesc": "Palette für Tasks, Kategorien und Notizen",
     "themeGroups": {
       "core": "Grundfarben",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -94,6 +94,7 @@
     "kanbanDone": "Kanban Done",
     "workRing": "Pomodoro Work",
     "breakRing": "Pomodoro Break",
+    "taskOverdue": "Overdue date",
     "taskColors": "Category, Task & Note colors",
     "bgColorDesc": "Main application background",
     "fgColorDesc": "Default text color",
@@ -114,6 +115,7 @@
     "kanbanDoneDesc": "Kanban column Done",
     "workRingDesc": "Pomodoro work ring",
     "breakRingDesc": "Pomodoro break ring",
+    "taskOverdueDesc": "Highlight color for overdue dates",
     "taskColorsDesc": "Palette for tasks, categories and notes",
     "themeGroups": {
       "core": "Core Colors",

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -101,7 +101,8 @@ const SettingsPage: React.FC = () => {
     { key: 'muted-foreground', label: 'mutedFgColor', desc: 'mutedFgColorDesc' },
     { key: 'card', label: 'cardBgColor', desc: 'cardBgColorDesc' },
     { key: 'card-foreground', label: 'cardFgColor', desc: 'cardFgColorDesc' },
-    { key: 'popover', label: 'popoverColor', desc: 'popoverColorDesc' }
+    { key: 'popover', label: 'popoverColor', desc: 'popoverColorDesc' },
+    { key: 'task-overdue', label: 'taskOverdue', desc: 'taskOverdueDesc' }
   ] as const
 
   const statsKanbanColors = [


### PR DESCRIPTION
## Summary
- allow customizing color for overdue tasks
- show grid cards with consistent height and truncated description
- keep card footer at bottom
- highlight overdue dates

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68567ff7fe38832a998920a65e2cd5d4