### PR TITLE
Implement completed task filtering

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -9,7 +9,9 @@ import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
 import { useSettings } from '@/hooks/useSettings';
+import { calculateTaskCompletion } from '@/utils/taskUtils';
 import {
   Plus,
   Search,
@@ -76,6 +78,7 @@ const Dashboard: React.FC = () => {
   const [filterPriority, setFilterPriority] = useState<string>('all');
   const [filterColor, setFilterColor] = useState<string>('all');
   const [taskLayout, setTaskLayout] = useState<'list' | 'grid'>('list');
+  const [showCompleted, setShowCompleted] = useState<boolean>(true);
 
 
   useEffect(() => {
@@ -142,7 +145,13 @@ const Dashboard: React.FC = () => {
           filterPriority === 'all' || task.priority === filterPriority;
         const matchesColor =
           filterColor === 'all' || task.color === Number(filterColor);
-        return matchesSearch && matchesPriority && matchesColor;
+        const matchesCompleted = showCompleted || !calculateTaskCompletion(task);
+        return (
+          matchesSearch &&
+          matchesPriority &&
+          matchesColor &&
+          matchesCompleted
+        );
       })
     : [];
 
@@ -251,6 +260,16 @@ const Dashboard: React.FC = () => {
         ? t('dashboard.taskCompletedDesc', { title: task?.title })
         : t('dashboard.taskReactivatedDesc', { title: task?.title })
     });
+    if (completed && task) {
+      setTimeout(() => {
+        const tasksInCategory = getTasksByCategory(task.categoryId);
+        const index = tasksInCategory.findIndex(t => t.id === taskId);
+        const lastIndex = tasksInCategory.length - 1;
+        if (index !== -1 && index !== lastIndex) {
+          reorderTasks(task.categoryId, index, lastIndex);
+        }
+      }, 1000);
+    }
   };
 
   const handleCreateCategory = (categoryData: CategoryFormData) => {
@@ -584,6 +603,18 @@ const Dashboard: React.FC = () => {
                     ))}
                   </SelectContent>
                 </Select>
+              </div>
+              <div className="flex items-center gap-1">
+                <Checkbox
+                  id="showCompleted"
+                  checked={showCompleted}
+                  onCheckedChange={checked =>
+                    setShowCompleted(Boolean(checked))
+                  }
+                />
+                <Label htmlFor="showCompleted" className="text-sm">
+                  {t('dashboard.showCompleted')}
+                </Label>
               </div>
               <div className="flex items-center gap-1">
                 <Label className="text-sm">{t('dashboard.viewLabel')}</Label>

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -441,6 +441,7 @@
     "sortLabel": "Sortierung:",
     "priorityLabel": "Priorität:",
     "colorLabel": "Farbe:",
+    "showCompleted": "Abgeschlossene anzeigen",
     "viewLabel": "Ansicht:",
     "listView": "Liste",
     "gridView": "Raster",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -441,6 +441,7 @@
     "sortLabel": "Sort by:",
     "priorityLabel": "Priority:",
     "colorLabel": "Color:",
+    "showCompleted": "Show completed",
     "viewLabel": "View:",
     "listView": "List",
     "gridView": "Grid",


### PR DESCRIPTION
## Summary
- move completed tasks to bottom after a short delay
- optionally hide finished tasks via checkbox
- add i18n strings for the filter

## Testing
- `npx vitest run` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685685a65194832aa26f4a3066e794cf