### PR TITLE
Implement Kanban filters and search

### DIFF
--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -378,7 +378,20 @@
     "deleted": "Task gelöscht",
     "completed": "Task abgeschlossen",
     "reactivated": "Task reaktiviert",
-    "deleteConfirm": "Sind Sie sicher, dass Sie \"{{title}}\" löschen möchten?"
+    "deleteConfirm": "Sind Sie sicher, dass Sie \"{{title}}\" löschen möchten?",
+    "search": "Suchen...",
+    "priorityLabel": "Priorität:",
+    "colorLabel": "Farbe:",
+    "categoryLabel": "Kategorie:",
+    "pinnedLabel": "Gepinnt:",
+    "filter": {
+      "all": "Alle",
+      "high": "Hoch",
+      "medium": "Mittel",
+      "low": "Niedrig",
+      "pinned": "Gepinnt",
+      "unpinned": "Nicht gepinnt"
+    }
   },
   "pomodoroTimer": {
     "start": "Start",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -378,7 +378,20 @@
     "deleted": "Task deleted",
     "completed": "Task completed",
     "reactivated": "Task reactivated",
-    "deleteConfirm": "Are you sure you want to delete \"{{title}}\"?"
+    "deleteConfirm": "Are you sure you want to delete \"{{title}}\"?",
+    "search": "Search...",
+    "priorityLabel": "Priority:",
+    "colorLabel": "Color:",
+    "categoryLabel": "Category:",
+    "pinnedLabel": "Pinned:",
+    "filter": {
+      "all": "All",
+      "high": "High",
+      "medium": "Medium",
+      "low": "Low",
+      "pinned": "Pinned",
+      "unpinned": "Unpinned"
+    }
   },
   "pomodoroTimer": {
     "start": "Start",


### PR DESCRIPTION
## Summary
- add filter options and column search to Kanban page
- update i18n strings for new Kanban labels in English and German

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856866b638c832abb15106bdec80bec