### PR TITLE
Implement sorting in Kanban

### DIFF
--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -384,6 +384,18 @@
     "colorLabel": "Farbe:",
     "categoryLabel": "Kategorie:",
     "pinnedLabel": "Gepinnt:",
+    "sortLabel": "Sortierung:",
+    "sort": {
+      "manual": "Manuell",
+      "createdDesc": "Neueste zuerst",
+      "createdAsc": "Älteste zuerst",
+      "titleAsc": "Titel A-Z",
+      "titleDesc": "Titel Z-A",
+      "priorityAsc": "Priorität ↑",
+      "priorityDesc": "Priorität ↓",
+      "dueAsc": "Fälligkeitsdatum ↑",
+      "dueDesc": "Fälligkeitsdatum ↓"
+    },
     "filter": {
       "all": "Alle",
       "high": "Hoch",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -384,6 +384,18 @@
     "colorLabel": "Color:",
     "categoryLabel": "Category:",
     "pinnedLabel": "Pinned:",
+    "sortLabel": "Sort by:",
+    "sort": {
+      "manual": "Manual",
+      "createdDesc": "Newest first",
+      "createdAsc": "Oldest first",
+      "titleAsc": "Title A-Z",
+      "titleDesc": "Title Z-A",
+      "priorityAsc": "Priority ↑",
+      "priorityDesc": "Priority ↓",
+      "dueAsc": "Due date ↑",
+      "dueDesc": "Due date ↓"
+    },
     "filter": {
       "all": "All",
       "high": "High",


### PR DESCRIPTION
## Summary
- add sorting state to Kanban
- sort kanban tasks with various criteria
- expose dropdown for sorting
- update i18n keys for kanban sorting

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68571f3d298c832a97debe429b5224ca