### PR TITLE
Improve task detail design

### DIFF
--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -538,7 +538,11 @@
     "title": "Task",
     "created": "Erstellt:",
     "updated": "Zuletzt geändert:",
-    "due": "Fällig am:"
+    "due": "Fällig am:",
+    "path": "Pfad:",
+    "statsStatus": "Statusübersicht",
+    "statsPriority": "Prioritäten",
+    "statsTrend": "Erstellt vs. erledigt"
   },
   "task": {
     "created": "Task erstellt",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -538,7 +538,11 @@
     "title": "Task",
     "created": "Created:",
     "updated": "Last updated:",
-    "due": "Due on:"
+    "due": "Due on:",
+    "path": "Path:",
+    "statsStatus": "Status Overview",
+    "statsPriority": "Priorities",
+    "statsTrend": "Created vs Completed"
   },
   "task": {
     "created": "Task created",


### PR DESCRIPTION
## Summary
- redesign task header with colored background and breadcrumbs
- add quick action buttons with tooltips
- show subtask statistics with pie charts and a trend line
- add missing translations for new elements

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68583a9b32f8832a9fc168b54a204b1b