### PR TITLE
Fix pomodoro history persistence and add session editor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import SettingsPage from "./pages/Settings";
 import ReleaseNotesPage from "./pages/ReleaseNotes";
 import NotFound from "./pages/NotFound";
 import PomodoroPage from "./pages/Pomodoro";
+import PomodoroHistoryPage from "./pages/PomodoroHistory";
 import PomodoroTimer from "@/components/PomodoroTimer";
 import PomodoroTicker from "@/components/PomodoroTicker";
 import { PomodoroHistoryProvider } from "@/hooks/usePomodoroHistory.tsx";
@@ -65,6 +66,7 @@ const App = () => (
               <Route path="/settings" element={<SettingsPage />} />
               <Route path="/release-notes" element={<ReleaseNotesPage />} />
               <Route path="/pomodoro" element={<PomodoroPage />} />
+              <Route path="/pomodoro/history" element={<PomodoroHistoryPage />} />
               <Route path="/surprise" element={<SurprisePage />} />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
               <Route path="*" element={<NotFound />} />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -163,6 +163,11 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
+                  <Link to="/pomodoro/history" className="flex items-center">
+                    <Timer className="h-4 w-4 mr-2" /> {t('navbar.pomodoroSessions')}
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
                   <Link to="/flashcards/stats" className="flex items-center">
                     <BarChart3 className="h-4 w-4 mr-2" /> {t('navbar.cardStatistics')}
                   </Link>
@@ -238,6 +243,12 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                   <Button variant="outline" size="sm" className="w-full">
                     <Timer className="h-4 w-4 mr-2" />
                     {t('navbar.pomodoro')}
+                  </Button>
+                </Link>
+                <Link to="/pomodoro/history" className="flex-1">
+                  <Button variant="outline" size="sm" className="w-full">
+                    <Timer className="h-4 w-4 mr-2" />
+                    {t('navbar.pomodoroSessions')}
                   </Button>
                 </Link>
                 <Link to="/flashcards/stats" className="flex-1">

--- a/src/hooks/usePomodoroHistory.tsx
+++ b/src/hooks/usePomodoroHistory.tsx
@@ -5,6 +5,7 @@ const API_URL = '/api/pomodoro-sessions'
 
 const usePomodoroHistoryImpl = () => {
   const [sessions, setSessions] = useState<PomodoroSession[]>([])
+  const [loaded, setLoaded] = useState(false)
 
   useEffect(() => {
     const load = async () => {
@@ -16,12 +17,15 @@ const usePomodoroHistoryImpl = () => {
         }
       } catch (err) {
         console.error('Error loading Pomodoro sessions', err)
+      } finally {
+        setLoaded(true)
       }
     }
     load()
   }, [])
 
   useEffect(() => {
+    if (!loaded) return
     const save = async () => {
       try {
         await fetch(API_URL, {
@@ -34,7 +38,7 @@ const usePomodoroHistoryImpl = () => {
       }
     }
     save()
-  }, [sessions])
+  }, [sessions, loaded])
 
   const addSession = (start: number, end: number) => {
     setSessions(prev => [...prev, { start, end }])
@@ -49,7 +53,20 @@ const usePomodoroHistoryImpl = () => {
     })
   }
 
-  return { sessions, addSession, endBreak }
+  const updateSession = (
+    index: number,
+    data: Partial<PomodoroSession>
+  ) => {
+    setSessions(prev =>
+      prev.map((s, i) => (i === index ? { ...s, ...data } : s))
+    )
+  }
+
+  const deleteSession = (index: number) => {
+    setSessions(prev => prev.filter((_, i) => i !== index))
+  }
+
+  return { sessions, addSession, endBreak, updateSession, deleteSession }
 }
 
 type Store = ReturnType<typeof usePomodoroHistoryImpl>

--- a/src/hooks/usePomodoroStats.ts
+++ b/src/hooks/usePomodoroStats.ts
@@ -36,11 +36,11 @@ export const usePomodoroStats = (): PomodoroStats => {
     const month = sessions.filter(s => s.start >= monthStart.getTime());
     const year = sessions.filter(s => s.start >= yearStart.getTime());
 
+    const fmt = (t: number) =>
+      new Date(t).toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit' })
+
     const todayData = today.map(s => ({
-      time: new Date(s.start).toLocaleTimeString(locale, {
-        hour: '2-digit',
-        minute: '2-digit'
-      }),
+      time: `${fmt(s.start)}-${fmt(s.end)}`,
       work: minutes(s.start, s.end),
       break: minutes(s.end, s.breakEnd ?? s.end)
     }));

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -10,6 +10,7 @@
     "cards": "Karten",
     "decks": "Decks",
     "pomodoro": "Pomodoro",
+    "pomodoroSessions": "Einheiten",
     "cardStatistics": "Statistiken",
     "notes": "Notizen",
     "settings": "Einstellungen",
@@ -430,6 +431,13 @@
     "evening": "Abend",
     "night": "Nacht",
     "timesOfDayTotal": "Tageszeiten (Gesamt)"
+  },
+  "pomodoroSessions": {
+    "title": "Pomodoro-Einheiten",
+    "start": "Start",
+    "end": "Ende",
+    "delete": "Löschen",
+    "none": "Keine Einheiten aufgezeichnet."
   },
   "commandPalette": {
     "title": "Command Palette",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -10,6 +10,7 @@
     "cards": "Cards",
     "decks": "Decks",
     "pomodoro": "Pomodoro",
+    "pomodoroSessions": "Sessions",
     "cardStatistics": "Statistics",
     "notes": "Notes",
     "settings": "Settings",
@@ -430,6 +431,13 @@
     "evening": "Evening",
     "night": "Night",
     "timesOfDayTotal": "Times of Day (Total)"
+  },
+  "pomodoroSessions": {
+    "title": "Pomodoro Sessions",
+    "start": "Start",
+    "end": "End",
+    "delete": "Delete",
+    "none": "No sessions recorded."
   },
   "commandPalette": {
     "title": "Command Palette",

--- a/src/pages/PomodoroHistory.tsx
+++ b/src/pages/PomodoroHistory.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { usePomodoroHistory } from '@/hooks/usePomodoroHistory.tsx'
+import Navbar from '@/components/Navbar'
+import { useTranslation } from 'react-i18next'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+const PomodoroHistoryPage: React.FC = () => {
+  const { sessions, updateSession, deleteSession } = usePomodoroHistory()
+  const { t } = useTranslation()
+
+  const handleChange = (
+    index: number,
+    field: 'start' | 'end',
+    value: string
+  ) => {
+    const time = new Date(value).getTime()
+    if (!isNaN(time)) {
+      updateSession(index, { [field]: time } as any)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-background flex flex-col">
+      <Navbar title={t('pomodoroSessions.title')} />
+      <div className="flex-grow p-4 flex flex-col items-center">
+        {sessions.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            {t('pomodoroSessions.none')}
+          </p>
+        ) : (
+          <table className="w-full max-w-xl text-sm border-collapse">
+            <thead>
+              <tr>
+                <th className="text-left p-2">{t('pomodoroSessions.start')}</th>
+                <th className="text-left p-2">{t('pomodoroSessions.end')}</th>
+                <th className="p-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {sessions.map((s, i) => (
+                <tr key={i} className="border-t">
+                  <td className="p-2">
+                    <Input
+                      type="datetime-local"
+                      value={new Date(s.start).toISOString().slice(0, 16)}
+                      onChange={e => handleChange(i, 'start', e.target.value)}
+                    />
+                  </td>
+                  <td className="p-2">
+                    <Input
+                      type="datetime-local"
+                      value={new Date(s.end).toISOString().slice(0, 16)}
+                      onChange={e => handleChange(i, 'end', e.target.value)}
+                    />
+                  </td>
+                  <td className="p-2 text-right">
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => deleteSession(i)}
+                    >
+                      {t('pomodoroSessions.delete')}
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default PomodoroHistoryPage


### PR DESCRIPTION
## Summary
- keep existing pomodoro sessions when page reloads
- allow updating and deleting stored sessions
- show start and end time in today's pomodoro stats
- add Pomodoro history editor page and routing
- expose history editor in navigation
- update English and German translations

## Testing
- `npm install`
- `npm test` (all tests pass)


------
https://chatgpt.com/codex/tasks/task_e_68583bd59d80832a8cab4d4b17e95e61