### PR TITLE
Move pomodoro sessions link

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -163,11 +163,6 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
-                  <Link to="/pomodoro/history" className="flex items-center">
-                    <Timer className="h-4 w-4 mr-2" /> {t('navbar.pomodoroSessions')}
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem asChild>
                   <Link to="/flashcards/stats" className="flex items-center">
                     <BarChart3 className="h-4 w-4 mr-2" /> {t('navbar.cardStatistics')}
                   </Link>
@@ -243,12 +238,6 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                   <Button variant="outline" size="sm" className="w-full">
                     <Timer className="h-4 w-4 mr-2" />
                     {t('navbar.pomodoro')}
-                  </Button>
-                </Link>
-                <Link to="/pomodoro/history" className="flex-1">
-                  <Button variant="outline" size="sm" className="w-full">
-                    <Timer className="h-4 w-4 mr-2" />
-                    {t('navbar.pomodoroSessions')}
                   </Button>
                 </Link>
                 <Link to="/flashcards/stats" className="flex-1">

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -10,7 +10,6 @@
     "cards": "Karten",
     "decks": "Decks",
     "pomodoro": "Pomodoro",
-    "pomodoroSessions": "Einheiten",
     "cardStatistics": "Statistiken",
     "notes": "Notizen",
     "settings": "Einstellungen",
@@ -438,6 +437,9 @@
     "end": "Ende",
     "delete": "Löschen",
     "none": "Keine Einheiten aufgezeichnet."
+  },
+  "pomodoroPage": {
+    "viewSessions": "Einheiten anzeigen"
   },
   "commandPalette": {
     "title": "Command Palette",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -10,7 +10,6 @@
     "cards": "Cards",
     "decks": "Decks",
     "pomodoro": "Pomodoro",
-    "pomodoroSessions": "Sessions",
     "cardStatistics": "Statistics",
     "notes": "Notes",
     "settings": "Settings",
@@ -438,6 +437,9 @@
     "end": "End",
     "delete": "Delete",
     "none": "No sessions recorded."
+  },
+  "pomodoroPage": {
+    "viewSessions": "View Sessions"
   },
   "commandPalette": {
     "title": "Command Palette",

--- a/src/pages/Pomodoro.tsx
+++ b/src/pages/Pomodoro.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 import Navbar from '@/components/Navbar';
 import PomodoroTimer from '@/components/PomodoroTimer';
 import PomodoroStats from '@/components/PomodoroStats';
+import { Button } from '@/components/ui/button';
 
 const PomodoroPage: React.FC = () => {
   const { t } = useTranslation();
@@ -11,6 +13,11 @@ const PomodoroPage: React.FC = () => {
       <Navbar title={t('navbar.pomodoro')} />
       <div className="flex-grow p-4 space-y-6 flex flex-col items-center">
         <PomodoroTimer size={150} />
+        <Link to="/pomodoro/history">
+          <Button variant="outline" size="sm">
+            {t('pomodoroPage.viewSessions')}
+          </Button>
+        </Link>
         <div className="w-full max-w-4xl"><PomodoroStats /></div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove pomodoro sessions from navbar
- link to sessions from pomodoro page
- update translations

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6858772d1730832a93b0d44f6729c1af