### PR TITLE
Add color customization for home page cards

### DIFF
--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -258,6 +258,14 @@ export const themePresets: Record<string, { theme: typeof defaultTheme; colorPal
   }
 }
 
+export const defaultHomeSectionColors: Record<string, number> = allHomeSections.reduce(
+  (acc, sec, idx) => {
+    acc[sec.key] = idx % defaultColorPalette.length
+    return acc
+  },
+  {} as Record<string, number>
+)
+
 interface SettingsContextValue {
   shortcuts: ShortcutKeys
   updateShortcut: (key: keyof ShortcutKeys, value: string) => void
@@ -271,6 +279,8 @@ interface SettingsContextValue {
   updateThemeName: (name: string) => void
   colorPalette: string[]
   updatePaletteColor: (index: number, value: string) => void
+  homeSectionColors: Record<string, number>
+  updateHomeSectionColor: (section: string, color: number) => void
   homeSections: string[]
   homeSectionOrder: string[]
   toggleHomeSection: (section: string) => void
@@ -321,6 +331,9 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const [theme, setTheme] = useState(defaultTheme)
   const [themeName, setThemeName] = useState('light')
   const [colorPalette, setColorPalette] = useState<string[]>(defaultColorPalette)
+  const [homeSectionColors, setHomeSectionColors] = useState<Record<string, number>>(
+    { ...defaultHomeSectionColors }
+  )
   const [homeSectionOrder, setHomeSectionOrder] = useState<string[]>(
     allHomeSections.map(s => s.key)
   )
@@ -393,6 +406,12 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
             )
             setHomeSections(data.homeSections)
           }
+          if (data.homeSectionColors && typeof data.homeSectionColors === 'object') {
+            setHomeSectionColors({
+              ...defaultHomeSectionColors,
+              ...data.homeSectionColors
+            })
+          }
           if (Array.isArray(data.homeSections)) {
             setHomeSections(data.homeSections)
           }
@@ -453,6 +472,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
             theme,
             themeName,
             colorPalette,
+            homeSectionColors,
             homeSections,
             homeSectionOrder,
             showPinnedTasks,
@@ -482,6 +502,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     theme,
     themeName,
     colorPalette,
+    homeSectionColors,
     homeSections,
     homeSectionOrder,
     showPinnedTasks,
@@ -545,6 +566,10 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
       return arr
     })
     setThemeName('custom')
+  }
+
+  const updateHomeSectionColor = (section: string, color: number) => {
+    setHomeSectionColors(prev => ({ ...prev, [section]: color }))
   }
 
   const updateFlashcardTimer = (value: number) => {
@@ -626,6 +651,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         updateThemeName,
         colorPalette,
         updatePaletteColor,
+        homeSectionColors,
+        updateHomeSectionColor,
         homeSections,
         homeSectionOrder,
         toggleHomeSection,

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import Navbar from '@/components/Navbar';
 import { Card, CardContent, CardTitle } from '@/components/ui/card';
 import { useSettings } from '@/hooks/useSettings';
+import { isColorDark, adjustColor } from '@/utils/color';
 import { allHomeSections, HomeSection } from '@/utils/homeSections';
 import TaskCard from '@/components/TaskCard';
 import { useTaskStore } from '@/hooks/useTaskStore';
@@ -16,6 +17,8 @@ const Home: React.FC = () => {
   const {
     homeSections,
     homeSectionOrder,
+    homeSectionColors,
+    colorPalette,
     showPinnedTasks,
     showPinnedNotes
   } = useSettings();
@@ -42,18 +45,33 @@ const Home: React.FC = () => {
       <Navbar />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
-          {orderedSections.map(sec => (
-            <div key={sec.key}>
-              <Link to={sec.path}>
-                <Card className="hover:shadow-md transition-all text-center">
-                  <CardContent className="py-8">
-                    <sec.icon className="h-8 w-8 mx-auto mb-2" />
-                    <CardTitle>{t(sec.labelKey)}</CardTitle>
-                  </CardContent>
-                </Card>
-              </Link>
-            </div>
-          ))}
+          {orderedSections.map(sec => {
+            const idx = homeSectionColors[sec.key] ?? 0
+            const base = colorPalette[idx] ?? colorPalette[0]
+            const text = isColorDark(base) ? '#fff' : '#000'
+            const hover = isColorDark(base)
+              ? adjustColor(base, 10)
+              : adjustColor(base, -10)
+            return (
+              <div key={sec.key}>
+                <Link to={sec.path}>
+                  <Card
+                    className="hover:shadow-md transition-all text-center hover:[background-color:var(--hover-color)]"
+                    style={{
+                      backgroundColor: base,
+                      color: text,
+                      '--hover-color': hover
+                    } as React.CSSProperties}
+                  >
+                    <CardContent className="py-8">
+                      <sec.icon className="h-8 w-8 mx-auto mb-2" />
+                      <CardTitle>{t(sec.labelKey)}</CardTitle>
+                    </CardContent>
+                  </Card>
+                </Link>
+              </div>
+            )
+          })}
         </div>
         {showPinnedTasks && pinnedTasks.length > 0 && (
           <div className="mb-6">

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -83,7 +83,9 @@ const SettingsPage: React.FC = () => {
     language,
     updateLanguage,
     colorPalette,
-    updatePaletteColor
+    updatePaletteColor,
+    homeSectionColors,
+    updateHomeSectionColor
   } = useSettings()
 
   const { t } = useTranslation()
@@ -585,6 +587,21 @@ const SettingsPage: React.FC = () => {
                                     onCheckedChange={() => toggleHomeSection(sec.key)}
                                   />
                                   <Label htmlFor={sec.key}>{t(sec.labelKey)}</Label>
+                                  <div className="flex ml-2 space-x-1">
+                                    {colorPalette.map((c, idx) => (
+                                      <button
+                                        key={idx}
+                                        type="button"
+                                        className={`w-4 h-4 rounded-full border-2 transition-all ${
+                                          homeSectionColors[sec.key] === idx
+                                            ? 'border-foreground scale-110'
+                                            : 'border-gray-300 hover:scale-105'
+                                        }`}
+                                        style={{ backgroundColor: c }}
+                                        onClick={() => updateHomeSectionColor(sec.key, idx)}
+                                      />
+                                    ))}
+                                  </div>
                                 </div>
                                 <GripVertical className="h-4 w-4 text-muted-foreground" />
                               </div>


### PR DESCRIPTION
## Summary
- allow choosing colors for home screen cards
- save the colors in settings
- style home cards using the selected palette

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68588ce6731c832abf108777214d6fee