### PR TITLE
Add pinned category support

### DIFF
--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -5,7 +5,7 @@ import { Category, Task } from '@/types';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Edit, Trash2, FolderOpen, MoreVertical } from 'lucide-react';
+import { Edit, Trash2, FolderOpen, MoreVertical, Star, StarOff } from 'lucide-react';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { getTaskProgress } from '@/utils/taskUtils';
 import { useSettings } from '@/hooks/useSettings';
@@ -22,6 +22,7 @@ interface CategoryCardProps {
   onEdit: (category: Category) => void;
   onDelete: (categoryId: string) => void;
   onViewTasks: (category: Category) => void;
+  onTogglePinned: (categoryId: string, pinned: boolean) => void;
 }
 
 const CategoryCard: React.FC<CategoryCardProps> = ({
@@ -29,7 +30,8 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
   tasks,
   onEdit,
   onDelete,
-  onViewTasks
+  onViewTasks,
+  onTogglePinned
 }) => {
   const { t } = useTranslation();
   const { colorPalette, theme } = useSettings();
@@ -104,6 +106,21 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
             <Button
               variant="ghost"
               size="sm"
+              onClick={e => {
+                e.stopPropagation();
+                onTogglePinned(category.id, !category.pinned);
+              }}
+              className="h-8 w-8 p-0"
+            >
+              {category.pinned ? (
+                <Star className="h-4 w-4" />
+              ) : (
+                <StarOff className="h-4 w-4" />
+              )}
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={(e) => {
                 e.stopPropagation();
                 onEdit(category);
@@ -146,6 +163,16 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="bg-background z-50">
+                <DropdownMenuItem
+                  onClick={() => onTogglePinned(category.id, !category.pinned)}
+                >
+                  {category.pinned ? (
+                    <Star className="h-4 w-4 mr-2" />
+                  ) : (
+                    <StarOff className="h-4 w-4 mr-2" />
+                  )}
+                  {category.pinned ? t('taskDetail.unpin') : t('taskDetail.pin')}
+                </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => onEdit(category)}>
                   <Edit className="h-4 w-4 mr-2" />
                   {t('common.edit')}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -147,6 +147,7 @@ const Dashboard: React.FC = () => {
   const sortedCategories = useMemo(() => {
     const cats = [...filteredCategories];
     cats.sort((a, b) => {
+      if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
       switch (sortCriteria) {
         case 'order':
           return a.order - b.order;
@@ -347,6 +348,10 @@ const Dashboard: React.FC = () => {
     }
   };
 
+  const handleToggleCategoryPinned = (id: string, pinned: boolean) => {
+    updateCategory(id, { pinned });
+  };
+
   const handleViewCategoryTasks = (category: Category) => {
     setSelectedCategory(category);
     setCurrentCategoryId(category.id);
@@ -527,6 +532,7 @@ const Dashboard: React.FC = () => {
                                 }}
                                 onDelete={handleDeleteCategory}
                                 onViewTasks={handleViewCategoryTasks}
+                                onTogglePinned={handleToggleCategoryPinned}
                               />
                             </div>
                           )}

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -289,6 +289,8 @@ interface SettingsContextValue {
   toggleShowPinnedTasks: () => void
   showPinnedNotes: boolean
   toggleShowPinnedNotes: () => void
+  showPinnedCategories: boolean
+  toggleShowPinnedCategories: () => void
   collapseSubtasksByDefault: boolean
   toggleCollapseSubtasksByDefault: () => void
   flashcardTimer: number
@@ -344,6 +346,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   ])
   const [showPinnedTasks, setShowPinnedTasks] = useState(true)
   const [showPinnedNotes, setShowPinnedNotes] = useState(true)
+  const [showPinnedCategories, setShowPinnedCategories] = useState(true)
   const [collapseSubtasksByDefault, setCollapseSubtasksByDefault] = useState(false)
   const [syncRole, setSyncRole] = useState<'server' | 'client'>('client')
   const [syncServerUrl, setSyncServerUrl] = useState('')
@@ -421,6 +424,9 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
           if (typeof data.showPinnedNotes === 'boolean') {
             setShowPinnedNotes(data.showPinnedNotes)
           }
+          if (typeof data.showPinnedCategories === 'boolean') {
+            setShowPinnedCategories(data.showPinnedCategories)
+          }
           if (typeof data.collapseSubtasksByDefault === 'boolean') {
             setCollapseSubtasksByDefault(data.collapseSubtasksByDefault)
           }
@@ -477,6 +483,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
             homeSectionOrder,
             showPinnedTasks,
             showPinnedNotes,
+            showPinnedCategories,
             collapseSubtasksByDefault,
             flashcardTimer,
             flashcardSessionSize,
@@ -507,6 +514,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     homeSectionOrder,
     showPinnedTasks,
     showPinnedNotes,
+    showPinnedCategories,
     collapseSubtasksByDefault,
     flashcardTimer,
     flashcardSessionSize,
@@ -632,6 +640,10 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     setShowPinnedNotes(prev => !prev)
   }
 
+  const toggleShowPinnedCategories = () => {
+    setShowPinnedCategories(prev => !prev)
+  }
+
   const toggleCollapseSubtasksByDefault = () => {
     setCollapseSubtasksByDefault(prev => !prev)
   }
@@ -661,6 +673,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         toggleShowPinnedTasks,
         showPinnedNotes,
         toggleShowPinnedNotes,
+        showPinnedCategories,
+        toggleShowPinnedCategories,
         collapseSubtasksByDefault,
         toggleCollapseSubtasksByDefault,
         flashcardTimer,

--- a/src/hooks/useTaskStore.tsx
+++ b/src/hooks/useTaskStore.tsx
@@ -132,7 +132,8 @@ const useTaskStoreImpl = () => {
             createdAt: new Date(category.createdAt),
             updatedAt: new Date(category.updatedAt),
             order: typeof category.order === 'number' ? category.order : idx,
-            color: mapColor(category.color)
+            color: mapColor(category.color),
+            pinned: category.pinned ?? false
           }));
       } else {
         const defaultCategory: Category = {
@@ -142,7 +143,8 @@ const useTaskStoreImpl = () => {
           color: 0,
           createdAt: new Date(),
           updatedAt: new Date(),
-          order: 0
+          order: 0,
+          pinned: false
         };
         categoriesData = [defaultCategory];
       }
@@ -503,7 +505,8 @@ const useTaskStoreImpl = () => {
       id: Date.now().toString(),
       createdAt: new Date(),
       updatedAt: new Date(),
-      order: 0
+      order: 0,
+      pinned: categoryData.pinned ?? false
     };
     setCategories(prev => [...prev, { ...newCategory, order: prev.length }]);
   };

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -17,7 +17,8 @@
   },
   "home": {
     "pinnedTasks": "Gepinnte Tasks",
-    "pinnedNotes": "Gepinnte Notizen"
+    "pinnedNotes": "Gepinnte Notizen",
+    "pinnedCategories": "Gepinnte Kategorien"
   },
   "settings": {
     "tabs": {
@@ -73,6 +74,7 @@
     "collapseSubtasks": "Unteraufgaben standardmäßig einklappen",
     "showPinnedTasks": "Gepinnte Tasks anzeigen",
     "showPinnedNotes": "Gepinnte Notizen anzeigen",
+    "showPinnedCategories": "Gepinnte Kategorien anzeigen",
     "themePreset": "Voreinstellung",
     "custom": "custom",
     "bgColor": "Hintergrund (App)",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -17,7 +17,8 @@
   },
   "home": {
     "pinnedTasks": "Pinned Tasks",
-    "pinnedNotes": "Pinned Notes"
+    "pinnedNotes": "Pinned Notes",
+    "pinnedCategories": "Pinned Categories"
   },
   "settings": {
     "tabs": {
@@ -73,6 +74,7 @@
     "collapseSubtasks": "Collapse subtasks by default",
     "showPinnedTasks": "Show pinned tasks",
     "showPinnedNotes": "Show pinned notes",
+    "showPinnedCategories": "Show pinned categories",
     "themePreset": "Preset",
     "custom": "custom",
     "bgColor": "Background (App)",

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -7,20 +7,22 @@ import { useSettings } from '@/hooks/useSettings';
 import { isColorDark, adjustColor } from '@/utils/color';
 import { allHomeSections, HomeSection } from '@/utils/homeSections';
 import TaskCard from '@/components/TaskCard';
+import CategoryCard from '@/components/CategoryCard';
 import { useTaskStore } from '@/hooks/useTaskStore';
 import NoteCard from '@/components/NoteCard';
 import { flattenTasks } from '@/utils/taskUtils';
 
 const Home: React.FC = () => {
   const { t } = useTranslation();
-  const { notes, tasks } = useTaskStore();
+  const { notes, tasks, categories, getTasksByCategory, updateCategory } = useTaskStore();
   const {
     homeSections,
     homeSectionOrder,
     homeSectionColors,
     colorPalette,
     showPinnedTasks,
-    showPinnedNotes
+    showPinnedNotes,
+    showPinnedCategories
   } = useSettings();
 
   const orderedSections: HomeSection[] = homeSectionOrder
@@ -38,6 +40,14 @@ const Home: React.FC = () => {
         .sort((a, b) => a.task.order - b.task.order)
         .slice(0, 3),
     [tasks]
+  );
+  const pinnedCategories = useMemo(
+    () =>
+      categories
+        .filter(c => c.pinned)
+        .sort((a, b) => a.order - b.order)
+        .slice(0, 3),
+    [categories]
   );
 
   return (
@@ -73,6 +83,31 @@ const Home: React.FC = () => {
             )
           })}
         </div>
+        {showPinnedCategories && pinnedCategories.length > 0 && (
+          <div className="mb-6">
+            <h2 className="text-lg sm:text-xl font-semibold text-foreground mb-3">
+              {t('home.pinnedCategories')}
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+              {pinnedCategories.map(cat => (
+                <Link
+                  key={cat.id}
+                  to={`/tasks?categoryId=${cat.id}`}
+                  className="block"
+                >
+                  <CategoryCard
+                    category={cat}
+                    tasks={getTasksByCategory(cat.id)}
+                    onEdit={() => {}}
+                    onDelete={() => {}}
+                    onViewTasks={() => {}}
+                    onTogglePinned={(id, val) => updateCategory(id, { pinned: val })}
+                  />
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
         {showPinnedTasks && pinnedTasks.length > 0 && (
           <div className="mb-6">
             <h2 className="text-lg sm:text-xl font-semibold text-foreground mb-3">

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -64,6 +64,8 @@ const SettingsPage: React.FC = () => {
     toggleShowPinnedTasks,
     showPinnedNotes,
     toggleShowPinnedNotes,
+    showPinnedCategories,
+    toggleShowPinnedCategories,
     collapseSubtasksByDefault,
     toggleCollapseSubtasksByDefault,
     flashcardTimer,
@@ -559,6 +561,14 @@ const SettingsPage: React.FC = () => {
                   onCheckedChange={toggleShowPinnedNotes}
                 />
                 <Label htmlFor="showPinnedNotes">{t('settingsPage.showPinnedNotes')}</Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="showPinnedCategories"
+                  checked={showPinnedCategories}
+                  onCheckedChange={toggleShowPinnedCategories}
+                />
+                <Label htmlFor="showPinnedCategories">{t('settingsPage.showPinnedCategories')}</Label>
               </div>
               <DragDropContext onDragEnd={handleHomeDrag}>
                 <Droppable droppableId="homeOrder">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,6 +51,8 @@ export interface Category {
   updatedAt: Date;
   /** Sort order within the category list */
   order: number;
+  /** Whether the category is pinned */
+  pinned: boolean;
 }
 
 export interface TaskFormData {


### PR DESCRIPTION
## Summary
- allow categories to be pinned in dashboard and home page
- show pinned categories setting
- adjust category card and sorting
- update translations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685896ece618832ab923f06d195d6ab7