### PR TITLE
Add habit tracker page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import ReleaseNotesModal from "@/components/ReleaseNotesModal";
 import SurprisePage from "./pages/Surprise";
 import SurpriseListener from "@/components/SurpriseListener";
 import RecurringTasksPage from "./pages/RecurringTasks";
+import HabitTrackerPage from "./pages/HabitTracker";
 import TimeBlockingPage from "./pages/TimeBlocking";
 import TaskDetailPage from "./pages/TaskDetail";
 
@@ -56,6 +57,7 @@ const App = () => (
               <Route path="/statistics" element={<Statistics />} />
               <Route path="/kanban" element={<Kanban />} />
               <Route path="/recurring" element={<RecurringTasksPage />} />
+              <Route path="/habits" element={<HabitTrackerPage />} />
               <Route path="/timeblocks" element={<TimeBlockingPage />} />
               <Route path="/flashcards/manage" element={<FlashcardManagerPage />} />
               <Route path="/flashcards/deck/:deckId" element={<DeckDetailPage />} />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -121,6 +121,11 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
+                  <Link to="/habits" className="flex items-center">
+                    <List className="h-4 w-4 mr-2" /> {t('navbar.habits')}
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
                   <Link to="/statistics" className="flex items-center">
                     <BarChart3 className="h-4 w-4 mr-2" /> {t('navbar.statistics')}
                   </Link>
@@ -209,6 +214,12 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                   <Button variant="outline" size="sm" className="w-full">
                     <List className="h-4 w-4 mr-2" />
                     {t('navbar.recurring')}
+                  </Button>
+                </Link>
+                <Link to="/habits" className="flex-1">
+                  <Button variant="outline" size="sm" className="w-full">
+                    <List className="h-4 w-4 mr-2" />
+                    {t('navbar.habits')}
                   </Button>
                 </Link>
                 <Link to="/statistics" className="flex-1">

--- a/src/hooks/useTaskStore.tsx
+++ b/src/hooks/useTaskStore.tsx
@@ -413,6 +413,7 @@ const useTaskStoreImpl = () => {
       template: true,
       startTime: data.startTime,
       endTime: data.endTime,
+      habitHistory: [],
       nextDue: shouldCreateNow
         ? calculateNextDue(
             data.recurrencePattern,
@@ -447,6 +448,20 @@ const useTaskStoreImpl = () => {
   const updateRecurringTask = (id: string, updates: Partial<Task>) => {
     setRecurring(prev =>
       prev.map(t => (t.id === id ? { ...t, ...updates, updatedAt: new Date() } : t))
+    );
+  };
+
+  const toggleHabitCompletion = (id: string, date: string) => {
+    setRecurring(prev =>
+      prev.map(habit => {
+        if (habit.id !== id) return habit;
+        const history = habit.habitHistory || [];
+        const exists = history.includes(date);
+        const newHistory = exists
+          ? history.filter(d => d !== date)
+          : [...history, date];
+        return { ...habit, habitHistory: newHistory, updatedAt: new Date() };
+      })
     );
   };
 
@@ -753,7 +768,8 @@ const useTaskStoreImpl = () => {
     recurring,
     addRecurringTask,
     updateRecurringTask,
-    deleteRecurringTask
+    deleteRecurringTask,
+    toggleHabitCompletion
   };
 };
 

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -5,6 +5,7 @@
     "kanban": "Kanban",
     "schedule": "Zeitplan",
     "recurring": "Wiederkehrend",
+    "habits": "Gewohnheiten",
     "statistics": "Task-Statistiken",
     "learning": "Lernen",
     "cards": "Karten",
@@ -244,6 +245,11 @@
   "recurring": {
     "template": "Vorlage",
     "none": "Keine Vorlagen vorhanden."
+  },
+  "habits": {
+    "title": "Gewohnheiten",
+    "none": "Keine Gewohnheiten vorhanden.",
+    "clickToToggle": "Klicke zum Umschalten"
   },
   "statistics": {
     "title": "Task-Statistiken",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -5,6 +5,7 @@
     "kanban": "Kanban",
     "schedule": "Schedule",
     "recurring": "Recurring",
+    "habits": "Habits",
     "statistics": "Task Statistics",
     "learning": "Learning",
     "cards": "Cards",
@@ -244,6 +245,11 @@
   "recurring": {
     "template": "Template",
     "none": "No templates available."
+  },
+  "habits": {
+    "title": "Habit Tracker",
+    "none": "No habits available.",
+    "clickToToggle": "Click to toggle completion"
   },
   "statistics": {
     "title": "Task Statistics",

--- a/src/pages/HabitTracker.tsx
+++ b/src/pages/HabitTracker.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import Navbar from '@/components/Navbar';
+import { useTaskStore } from '@/hooks/useTaskStore';
+import { useTranslation } from 'react-i18next';
+import { eachDayOfInterval, subDays, startOfDay, format } from 'date-fns';
+
+const HabitTrackerPage: React.FC = () => {
+  const { recurring, toggleHabitCompletion } = useTaskStore();
+  const { t } = useTranslation();
+
+  const today = startOfDay(new Date());
+  const days = eachDayOfInterval({ start: subDays(today, 83), end: today });
+
+  const weeks: Date[][] = [];
+  for (let i = 0; i < days.length; i += 7) {
+    weeks.push(days.slice(i, i + 7));
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Navbar title={t('habits.title')} />
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-8">
+        {recurring.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t('habits.none')}</p>
+        ) : (
+          <div className="space-y-6 overflow-x-auto">
+            {recurring.map(habit => (
+              <div key={habit.id} className="flex items-center space-x-2">
+                <span className="w-32 truncate text-sm text-foreground">
+                  {habit.title}
+                </span>
+                <div className="flex">
+                  {weeks.map((week, wi) => (
+                    <div key={wi} className="flex flex-col">
+                      {week.map(day => {
+                        const dateStr = format(day, 'yyyy-MM-dd');
+                        const done = habit.habitHistory?.includes(dateStr);
+                        return (
+                          <div
+                            key={dateStr}
+                            title={format(day, 'MMM d')}
+                            onClick={() => toggleHabitCompletion(habit.id, dateStr)}
+                            className={`w-3 h-3 m-0.5 rounded cursor-pointer hover:opacity-75 ${done ? 'bg-green-500' : 'bg-muted'}`}
+                          />
+                        );
+                      })}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default HabitTrackerPage;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,6 +40,8 @@ export interface Task {
   template?: boolean;
   titleTemplate?: string;
   customIntervalDays?: number;
+  /** Dates completed when used as habit template */
+  habitHistory?: string[];
 }
 
 export interface Category {


### PR DESCRIPTION
## Summary
- implement HabitTracker page with grid to mark completed days
- extend `Task` type for `habitHistory`
- manage habit completion state in task store
- link habit tracker from navbar and router
- add German and English translations

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6859a0179390832a8fae0647a5ce4498