### PR TITLE
Improve habit tracker design

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -16,6 +16,7 @@ import {
   Columns,
   LayoutGrid,
   List,
+  Flame,
   Cog,
   Timer,
   BookOpen,
@@ -122,7 +123,7 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
                   <Link to="/habits" className="flex items-center">
-                    <List className="h-4 w-4 mr-2" /> {t('navbar.habits')}
+                    <Flame className="h-4 w-4 mr-2" /> {t('navbar.habits')}
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
@@ -218,7 +219,7 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                 </Link>
                 <Link to="/habits" className="flex-1">
                   <Button variant="outline" size="sm" className="w-full">
-                    <List className="h-4 w-4 mr-2" />
+                    <Flame className="h-4 w-4 mr-2" />
                     {t('navbar.habits')}
                   </Button>
                 </Link>

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -176,6 +176,7 @@
     "pomodoro": "Pomodoro",
     "notes": "Notizen",
     "recurring": "Wiederkehrend",
+    "habits": "Gewohnheiten",
     "settings": "Einstellungen"
   },
   "categoryModal": {
@@ -249,7 +250,9 @@
   "habits": {
     "title": "Gewohnheiten",
     "none": "Keine Gewohnheiten vorhanden.",
-    "clickToToggle": "Klicke zum Umschalten"
+    "clickToToggle": "Klicke zum Umschalten",
+    "streak": "Serie: {{count}}",
+    "progress": "{{completed}} von {{total}} erledigt"
   },
   "statistics": {
     "title": "Task-Statistiken",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -176,6 +176,7 @@
     "pomodoro": "Pomodoro",
     "notes": "Notes",
     "recurring": "Recurring",
+    "habits": "Habits",
     "settings": "Settings"
   },
   "categoryModal": {
@@ -249,7 +250,9 @@
   "habits": {
     "title": "Habit Tracker",
     "none": "No habits available.",
-    "clickToToggle": "Click to toggle completion"
+    "clickToToggle": "Click to toggle completion",
+    "streak": "Streak: {{count}}",
+    "progress": "{{completed}}/{{total}} done"
   },
   "statistics": {
     "title": "Task Statistics",

--- a/src/pages/HabitTracker.tsx
+++ b/src/pages/HabitTracker.tsx
@@ -1,19 +1,79 @@
-import React from 'react';
-import Navbar from '@/components/Navbar';
-import { useTaskStore } from '@/hooks/useTaskStore';
-import { useTranslation } from 'react-i18next';
-import { eachDayOfInterval, subDays, startOfDay, format } from 'date-fns';
+import React from 'react'
+import Navbar from '@/components/Navbar'
+import { useTaskStore } from '@/hooks/useTaskStore'
+import { useSettings } from '@/hooks/useSettings'
+import { useTranslation } from 'react-i18next'
+import {
+  startOfDay,
+  subWeeks,
+  addWeeks,
+  startOfWeek,
+  addDays,
+  getISOWeek,
+  format
+} from 'date-fns'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import {
+  complementaryColor,
+  adjustColor,
+  isColorDark,
+  hslToHex
+} from '@/utils/color'
+import { Task } from '@/types'
 
 const HabitTrackerPage: React.FC = () => {
-  const { recurring, toggleHabitCompletion } = useTaskStore();
-  const { t } = useTranslation();
+  const { recurring, toggleHabitCompletion } = useTaskStore()
+  const { colorPalette, theme } = useSettings()
+  const { t } = useTranslation()
 
-  const today = startOfDay(new Date());
-  const days = eachDayOfInterval({ start: subDays(today, 83), end: today });
+  const today = startOfDay(new Date())
+  const start = startOfWeek(subWeeks(today, 51), { weekStartsOn: 1 })
+  const weeks: Date[] = []
+  for (let i = 0; i < 52; i++) {
+    weeks.push(addWeeks(start, i))
+  }
 
-  const weeks: Date[][] = [];
-  for (let i = 0; i < days.length; i += 7) {
-    weeks.push(days.slice(i, i + 7));
+  const getFrequencyDays = (habit: Task): number[] => {
+    if (
+      habit.recurrencePattern === 'weekly' &&
+      typeof habit.startWeekday === 'number'
+    ) {
+      return [habit.startWeekday]
+    }
+    return [0, 1, 2, 3, 4, 5, 6]
+  }
+
+  const calculateStreak = (habit: Task, freqDays: number[]): number => {
+    const history = new Set(habit.habitHistory || [])
+    let streak = 0
+    let day = today
+    while (day >= start) {
+      if (freqDays.includes(day.getDay())) {
+        const key = format(day, 'yyyy-MM-dd')
+        if (history.has(key)) streak++
+        else break
+      }
+      day = addDays(day, -1)
+    }
+    return streak
+  }
+
+  const countTotals = (
+    habit: Task,
+    freqDays: number[]
+  ): { total: number; completed: number } => {
+    const history = new Set(habit.habitHistory || [])
+    let total = 0
+    let completed = 0
+    weeks.forEach(w => {
+      freqDays.forEach(d => {
+        const date = addDays(w, d)
+        if (date > today || date < start) return
+        total++
+        if (history.has(format(date, 'yyyy-MM-dd'))) completed++
+      })
+    })
+    return { total, completed }
   }
 
   return (
@@ -24,36 +84,83 @@ const HabitTrackerPage: React.FC = () => {
           <p className="text-sm text-muted-foreground">{t('habits.none')}</p>
         ) : (
           <div className="space-y-6 overflow-x-auto">
-            {recurring.map(habit => (
-              <div key={habit.id} className="flex items-center space-x-2">
-                <span className="w-32 truncate text-sm text-foreground">
-                  {habit.title}
-                </span>
-                <div className="flex">
-                  {weeks.map((week, wi) => (
-                    <div key={wi} className="flex flex-col">
-                      {week.map(day => {
-                        const dateStr = format(day, 'yyyy-MM-dd');
-                        const done = habit.habitHistory?.includes(dateStr);
-                        return (
-                          <div
-                            key={dateStr}
-                            title={format(day, 'MMM d')}
-                            onClick={() => toggleHabitCompletion(habit.id, dateStr)}
-                            className={`w-3 h-3 m-0.5 rounded cursor-pointer hover:opacity-75 ${done ? 'bg-green-500' : 'bg-muted'}`}
-                          />
-                        );
-                      })}
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ))}
+            {recurring.map(habit => {
+              const freqDays = getFrequencyDays(habit)
+              const { total, completed } = countTotals(habit, freqDays)
+              const streak = calculateStreak(habit, freqDays)
+              const baseColor = colorPalette[habit.color] ?? colorPalette[0]
+              const textColor = complementaryColor(baseColor)
+              const doneColor = adjustColor(
+                baseColor,
+                isColorDark(baseColor) ? 20 : -20
+              )
+              const emptyColor = hslToHex(theme.muted)
+              const rows = [...freqDays].sort((a, b) => a - b)
+              return (
+                <Card
+                  key={habit.id}
+                  style={{ backgroundColor: baseColor, color: textColor }}
+                >
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-base">{habit.title}</CardTitle>
+                    <p className="text-xs">
+                      {t('habits.streak', { count: streak })} •{' '}
+                      {t('habits.progress', { completed, total })}
+                    </p>
+                  </CardHeader>
+                  <CardContent className="overflow-x-auto">
+                    <table className="table-fixed border-collapse">
+                      <thead>
+                        <tr>
+                          <th className="w-8 text-xs" />
+                          {weeks.map(w => (
+                            <th
+                              key={w.toISOString()}
+                              className="w-8 text-center text-[10px]"
+                            >
+                              {getISOWeek(w)}
+                            </th>
+                          ))}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {rows.map(r => (
+                          <tr key={r} className="h-6">
+                            <td className="text-xs pr-1">
+                              {format(addDays(start, r), 'EEE')}
+                            </td>
+                            {weeks.map(w => {
+                              const date = addDays(w, r)
+                              if (date > today) return <td key={date.toISOString()} />
+                              const dateStr = format(date, 'yyyy-MM-dd')
+                              const done = habit.habitHistory?.includes(dateStr)
+                              return (
+                                <td key={dateStr} className="p-0.5">
+                                  <div
+                                    className="w-6 h-6 rounded cursor-pointer hover:opacity-80"
+                                    style={{
+                                      backgroundColor: done ? doneColor : emptyColor
+                                    }}
+                                    onClick={() =>
+                                      toggleHabitCompletion(habit.id, dateStr)
+                                    }
+                                  />
+                                </td>
+                              )
+                            })}
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </CardContent>
+                </Card>
+              )
+            })}
           </div>
         )}
       </div>
     </div>
-  );
-};
+  )
+}
 
-export default HabitTrackerPage;
+export default HabitTrackerPage

--- a/src/utils/homeSections.ts
+++ b/src/utils/homeSections.ts
@@ -7,6 +7,7 @@ import {
   Pencil,
   Timer,
   List,
+  Flame,
   Cog,
   LucideIcon
 } from 'lucide-react'
@@ -29,5 +30,6 @@ export const allHomeSections: HomeSection[] = [
   { key: 'pomodoro', labelKey: 'homeSections.pomodoro', path: '/pomodoro', icon: Timer },
   { key: 'notes', labelKey: 'homeSections.notes', path: '/notes', icon: List },
   { key: 'recurring', labelKey: 'homeSections.recurring', path: '/recurring', icon: List },
+  { key: 'habits', labelKey: 'homeSections.habits', path: '/habits', icon: Flame },
   { key: 'settings', labelKey: 'homeSections.settings', path: '/settings', icon: Cog }
 ]


### PR DESCRIPTION
## Summary
- add Habits section to start page settings
- replace navbar icon with Flame
- enhance habit tracker UI with colored cards and statistics
- update translations for new habit features

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859be671390832ab84bd0f6d9845507