### PR TITLE
Fix habit sync from recurring tasks

### DIFF
--- a/src/hooks/useTaskStore.tsx
+++ b/src/hooks/useTaskStore.tsx
@@ -343,11 +343,12 @@ const useTaskStoreImpl = () => {
           if (
             typeof updates.completed === 'boolean' &&
             task.recurringId &&
-            task.dueDate
+            (task.dueDate || task.createdAt)
           ) {
+            const refDate = task.dueDate || task.createdAt;
             affected = {
               id: task.recurringId,
-              date: format(task.dueDate, 'yyyy-MM-dd'),
+              date: format(refDate, 'yyyy-MM-dd'),
               completed: updates.completed,
             };
           }
@@ -499,8 +500,10 @@ const useTaskStoreImpl = () => {
       prev.map(task => {
         if (
           task.recurringId === id &&
-          task.dueDate &&
-          format(task.dueDate, 'yyyy-MM-dd') === date
+          (
+            (task.dueDate && format(task.dueDate, 'yyyy-MM-dd') === date) ||
+            format(task.createdAt, 'yyyy-MM-dd') === date
+          )
         ) {
           return {
             ...task,


### PR DESCRIPTION
## Summary
- ensure updating auto-created tasks updates habit tracker
- update habit completion toggle to find tasks by creation date when no due date

## Testing
- `npx vitest` *(fails: missing prebuilt `better-sqlite3` binaries)*

------
https://chatgpt.com/codex/tasks/task_e_6859c7f78150832abd3302c8fc2cc9f0