### PR TITLE
Fix habit tracker update from completed tasks

### DIFF
--- a/src/hooks/useTaskStore.tsx
+++ b/src/hooks/useTaskStore.tsx
@@ -342,13 +342,11 @@ const useTaskStoreImpl = () => {
           }
           if (
             typeof updates.completed === 'boolean' &&
-            task.recurringId &&
-            (task.dueDate || task.createdAt)
+            task.recurringId
           ) {
-            const refDate = task.dueDate || task.createdAt;
             affected = {
               id: task.recurringId,
-              date: format(refDate, 'yyyy-MM-dd'),
+              date: format(task.createdAt, 'yyyy-MM-dd'),
               completed: updates.completed,
             };
           }


### PR DESCRIPTION
## Summary
- ensure completing auto-generated tasks updates habits for the creation date

## Testing
- `npx --yes vitest run` *(fails: Cannot find package 'vitest')*

------
https://chatgpt.com/codex/tasks/task_e_6859e7df5178832aaae009915bb0d1ea