### PR TITLE
Fix habit start date handling

### DIFF
--- a/src/hooks/useTaskStore.tsx
+++ b/src/hooks/useTaskStore.tsx
@@ -344,9 +344,9 @@ const useTaskStoreImpl = () => {
             typeof updates.completed === 'boolean' &&
             task.recurringId
           ) {
-            // Extract the date to mark in the habit tracker
-            // Use either the creation date or due date of the task
-            const dateToMark = task.dueDate || task.createdAt;
+          // Extract the date to mark in the habit tracker
+          // Use the creation date of the task
+          const dateToMark = task.createdAt;
             affected = {
               id: task.recurringId,
               date: format(dateToMark, 'yyyy-MM-dd'),
@@ -503,10 +503,7 @@ const useTaskStoreImpl = () => {
         if (task.recurringId === id) {
           // Check if this task was created on the date we're toggling
           const taskDate = format(task.createdAt, 'yyyy-MM-dd');
-          // Also check against the due date if available
-          const dueDate = task.dueDate ? format(task.dueDate, 'yyyy-MM-dd') : null;
-          
-          if (taskDate === date || (dueDate && dueDate === date)) {
+          if (taskDate === date) {
             return {
               ...task,
               completed: markComplete,

--- a/src/pages/HabitTracker.tsx
+++ b/src/pages/HabitTracker.tsx
@@ -25,7 +25,7 @@ import {
 import { Task } from '@/types'
 
 const HabitTrackerPage: React.FC = () => {
-  const { recurring, toggleHabitCompletion } = useTaskStore()
+  const { recurring, tasks, toggleHabitCompletion } = useTaskStore()
   const { colorPalette, theme } = useSettings()
   const { t } = useTranslation()
 
@@ -115,6 +115,17 @@ const HabitTrackerPage: React.FC = () => {
               )
               const emptyColor = hslToHex(theme.muted)
               const rows = [...freqDays].sort((a, b) => a - b)
+              const habitTasks = tasks.filter(t => t.recurringId === habit.id)
+              const firstTaskDate = habitTasks.length
+                ? startOfDay(
+                    habitTasks.reduce(
+                      (min, t) => (t.createdAt < min ? t.createdAt : min),
+                      habitTasks[0].createdAt
+                    )
+                  )
+                : habit.startDate
+                ? startOfDay(new Date(habit.startDate))
+                : startOfDay(habit.createdAt)
               return (
                 <Card
                   key={habit.id}
@@ -168,17 +179,19 @@ const HabitTrackerPage: React.FC = () => {
                               const dateStr = format(date, 'yyyy-MM-dd')
                               const done = habit.habitHistory?.includes(dateStr)
                               const future = date > today
+                              const beforeStart = date < firstTaskDate
+                              const inactive = future || beforeStart
                               const currentDay = isToday(date)
                               return (
                                 <td key={dateStr} className="p-0.5">
                                   <div
-                                    className={`h-6 aspect-square w-full rounded hover:opacity-80 ${future ? 'cursor-default opacity-50' : 'cursor-pointer'}`}
+                                    className={`h-6 aspect-square w-full rounded hover:opacity-80 ${inactive ? 'cursor-default opacity-50' : 'cursor-pointer'}`}
                                     style={{
                                       backgroundColor: done ? doneColor : emptyColor,
                                       outline: currentDay ? `2px solid ${textColor}` : undefined
                                     }}
                                     onClick={() =>
-                                      !future && toggleHabitCompletion(habit.id, dateStr)
+                                      !inactive && toggleHabitCompletion(habit.id, dateStr)
                                     }
                                   />
                                 </td>


### PR DESCRIPTION
## Summary
- limit habit tracker interactions to dates after the first generated task

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859eda161e4832a83e8d98364ab68a8