### PR TITLE
Handle habit history via tasks

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -121,7 +121,7 @@ const Dashboard: React.FC = () => {
   const colorOptions = useMemo(() => {
     const tasksForColors = selectedCategory
       ? getTasksByCategory(selectedCategory.id)
-      : tasks;
+      : tasks.filter(t => t.visible !== false);
     const colors = new Set<number>();
     tasksForColors.forEach(task => colors.add(task.color));
     return Array.from(colors);
@@ -226,13 +226,13 @@ const Dashboard: React.FC = () => {
   // Statistics
   const totalTasks = selectedCategory
     ? getTasksByCategory(selectedCategory.id).length
-    : tasks.length;
+    : tasks.filter(t => t.visible !== false).length;
 
   const totalCategories = selectedCategory ? 1 : categories.length;
 
   const completedTasks = (selectedCategory
     ? getTasksByCategory(selectedCategory.id)
-    : tasks
+    : tasks.filter(t => t.visible !== false)
   ).filter(task => {
     const hasSubtasks = task.subtasks.length > 0;
     if (hasSubtasks) {

--- a/src/pages/HabitTracker.tsx
+++ b/src/pages/HabitTracker.tsx
@@ -47,14 +47,17 @@ const HabitTrackerPage: React.FC = () => {
     return [0, 1, 2, 3, 4, 5, 6]
   }
 
-  const calculateStreak = (habit: Task, freqDays: number[]): number => {
-    const history = new Set(habit.habitHistory || [])
+  const calculateStreak = (
+    habit: Task,
+    freqDays: number[],
+    map: Record<string, Task>
+  ): number => {
     let streak = 0
     let day = today
     while (day >= yearStart) {
       if (freqDays.includes(day.getDay())) {
         const key = format(day, 'yyyy-MM-dd')
-        if (history.has(key)) streak++
+        if (map[key]?.completed) streak++
         else break
       }
       day = addDays(day, -1)
@@ -64,9 +67,9 @@ const HabitTrackerPage: React.FC = () => {
 
   const countTotals = (
     habit: Task,
-    freqDays: number[]
+    freqDays: number[],
+    map: Record<string, Task>
   ): { total: number; completed: number } => {
-    const history = new Set(habit.habitHistory || [])
     let total = 0
     let completed = 0
     weeks.forEach(w => {
@@ -74,7 +77,8 @@ const HabitTrackerPage: React.FC = () => {
         const date = addDays(w, d)
         if (date > today || date < yearStart) return
         total++
-        if (history.has(format(date, 'yyyy-MM-dd'))) completed++
+        const key = format(date, 'yyyy-MM-dd')
+        if (map[key]?.completed) completed++
       })
     })
     return { total, completed }
@@ -105,8 +109,8 @@ const HabitTrackerPage: React.FC = () => {
           <div className="space-y-6">
             {recurring.map(habit => {
               const freqDays = getFrequencyDays(habit)
-              const { total, completed } = countTotals(habit, freqDays)
-              const streak = calculateStreak(habit, freqDays)
+              const { total, completed } = countTotals(habit, freqDays, map)
+              const streak = calculateStreak(habit, freqDays, map)
               const baseColor = colorPalette[habit.color] ?? colorPalette[0]
               const textColor = complementaryColor(baseColor)
               const doneColor = adjustColor(
@@ -116,6 +120,11 @@ const HabitTrackerPage: React.FC = () => {
               const emptyColor = hslToHex(theme.muted)
               const rows = [...freqDays].sort((a, b) => a - b)
               const habitTasks = tasks.filter(t => t.recurringId === habit.id)
+              const map = habitTasks.reduce<Record<string, Task>>((m, t) => {
+                const key = format(t.createdAt, 'yyyy-MM-dd')
+                m[key] = t
+                return m
+              }, {})
               const firstTaskDate = habitTasks.length
                 ? startOfDay(
                     habitTasks.reduce(
@@ -177,10 +186,10 @@ const HabitTrackerPage: React.FC = () => {
                             {weeks.map(w => {
                               const date = addDays(w, r)
                               const dateStr = format(date, 'yyyy-MM-dd')
-                              const done = habit.habitHistory?.includes(dateStr)
+                              const done = map[dateStr]?.completed
                               const future = date > today
                               const beforeStart = date < firstTaskDate
-                              const inactive = future || beforeStart
+                              const inactive = future || beforeStart || !map[dateStr]
                               const currentDay = isToday(date)
                               return (
                                 <td key={dateStr} className="p-0.5">

--- a/src/pages/Kanban.tsx
+++ b/src/pages/Kanban.tsx
@@ -126,9 +126,9 @@ const Kanban: React.FC = () => {
     navigate(`/tasks/${task.id}?categoryId=${task.categoryId}`);
   };
 
-  const flattened = flattenTasks(tasks);
+  const flattened = flattenTasks(tasks.filter(t => t.visible !== false));
   const colorOptions = useMemo(
-    () => Array.from(new Set(tasks.map(t => t.color))),
+    () => Array.from(new Set(tasks.filter(t => t.visible !== false).map(t => t.color))),
     [tasks]
   );
 

--- a/src/pages/TimeBlocking.tsx
+++ b/src/pages/TimeBlocking.tsx
@@ -58,7 +58,7 @@ const TimeBlockingPage = () => {
   const tasksByDate = useMemo(() => {
     const map: Record<string, typeof tasks> = {};
     tasks.forEach(t => {
-      if (!t.dueDate) return;
+      if (!t.dueDate || t.visible === false) return;
       const key = new Date(t.dueDate).toDateString();
       if (!map[key]) map[key] = [];
       map[key].push(t);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,8 +42,8 @@ export interface Task {
   template?: boolean;
   titleTemplate?: string;
   customIntervalDays?: number;
-  /** Dates completed when used as habit template */
-  habitHistory?: string[];
+  /** Whether the task is visible to the user */
+  visible?: boolean;
 }
 
 export interface Category {


### PR DESCRIPTION
## Summary
- track habit completion via individual tasks instead of `habitHistory`
- pre-create future recurring tasks hidden from the user until due
- toggle habit completion directly updates the associated task
- drop hidden tasks when deleting the template
- hide invisible tasks in dashboards and kanban

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*
- `npm run build:dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a7ce1603c832a8aaf84f70eceb1f0