### PR TITLE
Improve import export

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ npm start    # startet die gebaute App auf Port 3002
 - Lern- und Pausendauer frei konfigurierbar (auch direkt im Timer anpassbar)
 - Daten können im Einstellungsbereich exportiert und importiert werden
   (inklusive Einstellungen)
+- Import zeigt eine Vorschau der einzufügenden Elemente und bestätigt den Erfolg
+- Zusätzlich kann die reine Datenstruktur als JSON exportiert werden
 - Zentrale Synchronisation über HTTP. Ein Container kann als Sync-Server
   betrieben werden, alle anderen senden ihre Daten regelmäßig dorthin.
   Der Server listet seine IP-Adressen auf und führt ein Log über eingehende

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -143,7 +143,13 @@
     "notes": "Notizen",
     "decksAndCards": "Decks & Karten",
     "all": "Alles",
-    "export": "Export"
+    "export": "Export",
+    "import": "Import",
+    "exportStructure": "Struktur exportieren",
+    "importPreview": "Import-Vorschau",
+    "importSuccess": "Import erfolgreich",
+    "importError": "Import fehlgeschlagen",
+    "categories": "Kategorien: {{count}}"
   },
   "noteModal": {
     "editTitle": "Notiz bearbeiten",
@@ -159,7 +165,8 @@
     "edit": "Bearbeiten",
     "delete": "Löschen",
     "back": "Zurück",
-    "undo": "Rückgängig"
+    "undo": "Rückgängig",
+    "continue": "Weiter"
   },
   "noteDetail": {
     "notFound": "Notiz nicht gefunden.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -143,7 +143,13 @@
     "notes": "Notes",
     "decksAndCards": "Decks & Cards",
     "all": "All",
-    "export": "Export"
+    "export": "Export",
+    "import": "Import",
+    "exportStructure": "Export structure",
+    "importPreview": "Import preview",
+    "importSuccess": "Import successful",
+    "importError": "Import failed",
+    "categories": "Categories: {{count}}"
   },
   "noteModal": {
     "editTitle": "Edit Note",
@@ -159,7 +165,8 @@
     "edit": "Edit",
     "delete": "Delete",
     "back": "Back",
-    "undo": "Undo"
+    "undo": "Undo",
+    "continue": "Continue"
   },
   "noteDetail": {
     "notFound": "Note not found.",


### PR DESCRIPTION
## Summary
- show import preview before loading file
- add success indicator dialog
- allow exporting data structure
- update translations
- document improved import/export in README

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_685acaf03a90832a96e3f1702cadc969