### PR TITLE
Enable offline editing and sync

### DIFF
--- a/src/utils/offline.ts
+++ b/src/utils/offline.ts
@@ -1,0 +1,75 @@
+import { Task, Category, Note, Flashcard, Deck, Deletion } from '@/types'
+import { applyDeletions, mergeData } from './sync'
+
+export interface OfflineData {
+  tasks: Task[]
+  categories: Category[]
+  notes: Note[]
+  recurring: Task[]
+  flashcards: Flashcard[]
+  decks: Deck[]
+  deletions: Deletion[]
+}
+
+const KEY = 'offlineData'
+
+const replacer = (_: string, value: any) =>
+  value instanceof Date ? value.toISOString() : value
+
+const reviver = (_: string, value: any) => {
+  if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}T/.test(value)) {
+    return new Date(value)
+  }
+  return value
+}
+
+export const loadOfflineData = (): OfflineData | null => {
+  const raw = localStorage.getItem(KEY)
+  return raw ? (JSON.parse(raw, reviver) as OfflineData) : null
+}
+
+export const saveOfflineData = (data: OfflineData) => {
+  localStorage.setItem(KEY, JSON.stringify(data, replacer))
+}
+
+export const updateOfflineData = (partial: Partial<OfflineData>) => {
+  const current = loadOfflineData() || {
+    tasks: [],
+    categories: [],
+    notes: [],
+    recurring: [],
+    flashcards: [],
+    decks: [],
+    deletions: []
+  }
+  saveOfflineData({ ...current, ...partial })
+}
+
+export const syncWithServer = async (): Promise<OfflineData> => {
+  const local = loadOfflineData() || {
+    tasks: [],
+    categories: [],
+    notes: [],
+    recurring: [],
+    flashcards: [],
+    decks: [],
+    deletions: []
+  }
+  if (!navigator.onLine) return local
+  try {
+    const res = await fetch('/api/all')
+    if (!res.ok) throw new Error('fetch failed')
+    const serverData = (await res.json()) as OfflineData
+    const merged = applyDeletions(mergeData(serverData, local))
+    await fetch('/api/all', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(merged, replacer)
+    })
+    saveOfflineData(merged)
+    return merged
+  } catch (err) {
+    console.error('Sync failed', err)
+    return local
+  }
+}

--- a/src/utils/sync.ts
+++ b/src/utils/sync.ts
@@ -1,0 +1,70 @@
+import { Task, Category, Note, Flashcard, Deck, Deletion } from '@/types'
+
+export interface AllData {
+  tasks: Task[]
+  categories: Category[]
+  notes: Note[]
+  recurring: Task[]
+  flashcards: Flashcard[]
+  decks: Deck[]
+  deletions: Deletion[]
+}
+
+export function mergeLists<T extends { id: string; [key: string]: any }>(
+  curr: T[] = [],
+  inc: T[] = [],
+  compare: string | null = 'updatedAt'
+): T[] {
+  const map = new Map<string, T>()
+  for (const c of curr) map.set(c.id, c)
+  for (const i of inc || []) {
+    if (map.has(i.id)) {
+      const ex = map.get(i.id)!
+      if (compare && ex[compare] && i[compare]) {
+        if (new Date(i[compare]) > new Date(ex[compare])) map.set(i.id, i)
+      }
+    } else {
+      map.set(i.id, i)
+    }
+  }
+  return Array.from(map.values())
+}
+
+export function mergeData(curr: AllData, inc: AllData): AllData {
+  return {
+    tasks: mergeLists(curr.tasks, inc.tasks),
+    categories: mergeLists(curr.categories, inc.categories),
+    notes: mergeLists(curr.notes, inc.notes),
+    recurring: mergeLists(curr.recurring, inc.recurring),
+    flashcards: mergeLists(curr.flashcards, inc.flashcards, null),
+    decks: mergeLists(curr.decks, inc.decks, null),
+    deletions: mergeLists(curr.deletions, inc.deletions, 'deletedAt')
+  }
+}
+
+export function applyDeletions(data: AllData): AllData {
+  const maps: Record<string, Map<string, Date>> = {}
+  for (const d of data.deletions || []) {
+    maps[d.type] = maps[d.type] || new Map<string, Date>()
+    const curr = maps[d.type].get(d.id)
+    const time = new Date(d.deletedAt)
+    if (!curr || time > curr) maps[d.type].set(d.id, time)
+  }
+  const shouldKeep = (
+    type: string,
+    item: { id: string; updatedAt?: Date }
+  ) => {
+    const m = maps[type]
+    if (!m) return true
+    const t = m.get(item.id)
+    if (!t) return true
+    return !(item.updatedAt && new Date(item.updatedAt) <= t)
+  }
+  data.tasks = (data.tasks || []).filter(t => shouldKeep('task', t))
+  data.categories = (data.categories || []).filter(c => shouldKeep('category', c))
+  data.notes = (data.notes || []).filter(n => shouldKeep('note', n))
+  data.recurring = (data.recurring || []).filter(r => shouldKeep('recurring', r))
+  data.flashcards = (data.flashcards || []).filter(f => shouldKeep('flashcard', f))
+  data.decks = (data.decks || []).filter(d => shouldKeep('deck', d))
+  return data
+}


### PR DESCRIPTION
## Summary
- add generic sync helpers for merging data and applying deletions
- persist tasks, notes and cards locally when offline
- sync local data with the server when connection is available

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d45f0cea8832ab4c0360a7f8c947f