### PR TITLE
Fix toolbar visibility without preview

### DIFF
--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -32,6 +32,7 @@ interface MarkdownEditorProps {
   onChange: (value: string) => void;
   rows?: number;
   className?: string;
+  showPreview?: boolean;
 }
 
 // Global styles for the markdown editor
@@ -69,6 +70,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   onChange,
   rows = 5,
   className,
+  showPreview = true,
 }) => {
   const { t } = useTranslation();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -460,15 +462,17 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         </Tooltip>
       </div>
       <div className="relative">
-        <div
-          ref={previewRef}
-          className={cn(
-            'prose max-w-none p-8 min-h-[80px] border rounded-sm bg-background shadow-sm overflow-auto',
-            className
-          )}
-        >
-          <MarkdownWithActiveLine>{getHybridContent()}</MarkdownWithActiveLine>
-        </div>
+        {showPreview && (
+          <div
+            ref={previewRef}
+            className={cn(
+              'prose max-w-none p-8 min-h-[80px] border rounded-sm bg-background shadow-sm overflow-auto',
+              className
+            )}
+          >
+            <MarkdownWithActiveLine>{getHybridContent()}</MarkdownWithActiveLine>
+          </div>
+        )}
         <Textarea
           ref={textareaRef}
           value={value}
@@ -496,10 +500,12 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
             }
           }}
           className={cn(
-            'absolute inset-0 p-8 min-h-[80px] opacity-0 border rounded-sm shadow-sm focus-visible:ring-0 focus-visible:outline-none resize-none',
+            showPreview
+              ? 'absolute inset-0 p-8 min-h-[80px] opacity-0 border rounded-sm shadow-sm focus-visible:ring-0 focus-visible:outline-none resize-none'
+              : 'p-8 w-full min-h-[80px] border rounded-sm shadow-sm focus-visible:ring-0 focus-visible:outline-none resize-none',
             className
           )}
-          style={{ caretColor: 'transparent' }}
+          style={showPreview ? { caretColor: 'transparent' } : undefined}
         />
       </div>
       <style dangerouslySetInnerHTML={{ __html: editorStyles }} />

--- a/src/pages/NoteDetail.tsx
+++ b/src/pages/NoteDetail.tsx
@@ -7,7 +7,6 @@ import { useSettings } from '@/hooks/useSettings';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft } from 'lucide-react';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import MarkdownEditor from '@/components/MarkdownEditor';
@@ -91,22 +90,13 @@ const NoteDetailPage: React.FC = () => {
                 onCheckedChange={setShowPreview}
               />
             </div>
-            {showPreview ? (
-              <MarkdownEditor
-                value={formData.text}
-                onChange={val => handleChange('text', val)}
-                rows={20}
-                className="min-h-[60vh]"
-              />
-            ) : (
-              <Textarea
-                id="text"
-                value={formData.text}
-                onChange={e => handleChange('text', e.target.value)}
-                rows={20}
-                className="min-h-[60vh]"
-              />
-            )}
+            <MarkdownEditor
+              value={formData.text}
+              onChange={val => handleChange('text', val)}
+              rows={20}
+              className="min-h-[60vh]"
+              showPreview={showPreview}
+            />
             <div className="flex flex-wrap gap-2">
               {colorOptions.map((color, idx) => (
                 <button


### PR DESCRIPTION
## Summary
- allow MarkdownEditor to toggle preview
- keep toolbar when live preview is off

## Testing
- `npm run lint`
- `npm test` (then quit watch mode)

------
https://chatgpt.com/codex/tasks/task_e_685e2b037b34832aa5a737754c91830e