### PR TITLE
Improve complementary color calculation

### DIFF
--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -92,12 +92,14 @@ export const adjustColor = (hex: string, percent: number): string => {
 };
 
 export const complementaryColor = (hex: string): string => {
-  const [hStr, sStr, lStr] = hexToHsl(hex).split(/\s+/);
-  const h = (parseFloat(hStr) + 180) % 360;
-  const s = parseFloat(sStr);
-  let l = parseFloat(lStr);
-  l = isColorDark(hex) ? Math.min(100, l + 40) : Math.max(0, l - 40);
-  return hslToHex(`${h} ${s}% ${l}%`);
+  const dark = isColorDark(hex);
+  const adjusted = adjustColor(hex, dark ? 60 : -60);
+  if (colorContrast(hex, adjusted) < 128) {
+    const blackContrast = colorContrast(hex, "#000000");
+    const whiteContrast = colorContrast(hex, "#ffffff");
+    return blackContrast > whiteContrast ? "#000000" : "#ffffff";
+  }
+  return adjusted;
 };
 
 export const colorContrast = (hex1: string, hex2: string): number => {


### PR DESCRIPTION
## Summary
- refine complementary color algorithm to prefer contrast adjustments and fallback to black/white when needed

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea5c67378832a8a07836c783f256e