### PR TITLE
Fix service worker registration in dev

### DIFF
--- a/src/components/ServiceWorkerManager.tsx
+++ b/src/components/ServiceWorkerManager.tsx
@@ -8,8 +8,9 @@ const ServiceWorkerManager: React.FC = () => {
     if (!('serviceWorker' in navigator)) return
 
     if (offlineCache) {
+      const swPath = import.meta.env.DEV ? '/dev-sw.js?dev-sw' : '/sw.js'
       navigator.serviceWorker
-        .register('/sw.js')
+        .register(swPath, { type: 'module' })
         .catch(err => console.error('SW registration failed', err))
     } else {
       navigator.serviceWorker.getRegistrations().then(regs => {


### PR DESCRIPTION
## Summary
- register dev service worker correctly when offline cache is enabled

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fbdd4eb68832ab845536c5f5569a7