### PR TITLE
Fix PWA cache for API routes

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,15 @@ export default defineConfig(({ mode }) => ({
     VitePWA({
       registerType: 'autoUpdate',
       devOptions: { enabled: true },
+      workbox: {
+        runtimeCaching: [
+          {
+            urlPattern: /^\/api\//,
+            handler: 'NetworkOnly'
+          }
+        ],
+        navigateFallbackDenylist: [/^\/api\//]
+      },
       manifest: {
         name: 'Total Task Tracker',
         short_name: 'TaskTracker',


### PR DESCRIPTION
## Summary
- prevent Workbox from trying to cache `/api` calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fc74b72b4832aac6355e7e2407ecd