### PR TITLE
Fix clickable drag items

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -439,7 +439,11 @@ const Dashboard: React.FC = () => {
     setSearchParams(params, { replace: true });
   };
 
-  const sensors = useSensors(useSensor(PointerSensor));
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 }
+    })
+  );
 
   const handleCategoryDragEnd = ({ active, over }: DragEndEvent) => {
     if (!over || active.id === over.id) return;

--- a/src/pages/Kanban.tsx
+++ b/src/pages/Kanban.tsx
@@ -100,7 +100,11 @@ const Kanban: React.FC = () => {
     done: ''
   });
 
-  const sensors = useSensors(useSensor(PointerSensor));
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 }
+    })
+  );
 
   const onDragEnd = ({ active, over }: DragEndEvent) => {
     if (!over) return;

--- a/src/pages/Notes.tsx
+++ b/src/pages/Notes.tsx
@@ -60,7 +60,11 @@ const NotesPage = () => {
     addNote(data);
   };
 
-  const sensors = useSensors(useSensor(PointerSensor));
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 }
+    })
+  );
 
   const handleDragEnd = ({ active, over }: DragEndEvent) => {
     if (!over || active.id === over.id) return;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -270,7 +270,11 @@ const SettingsPage: React.FC = () => {
     return () => clearInterval(id)
   }, [syncRole])
 
-  const sensors = useSensors(useSensor(PointerSensor))
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 }
+    })
+  )
 
   const handleHomeDrag = ({ active, over }: DragEndEvent) => {
     if (!over || active.id === over.id) return


### PR DESCRIPTION
## Summary
- prevent accidental drag activation
- allow single-click action for categories, tasks and notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fd8856c1c832ab37dbb66e351c588