### PR TITLE
Fix dashboard respecting settings

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -145,7 +145,7 @@ const Dashboard: React.FC = () => {
   const [showCompleted, setShowCompleted] = useState<boolean>(showCompletedByDefault);
   const [showHidden, setShowHidden] = useState<boolean>(false);
 
-
+  
   useEffect(() => {
     const params = new URLSearchParams(searchParams);
     if (params.get('sort') !== sortCriteria) {
@@ -153,6 +153,14 @@ const Dashboard: React.FC = () => {
       setSearchParams(params, { replace: true });
     }
   }, [sortCriteria]);
+
+  useEffect(() => {
+    setTaskLayout(defaultTaskLayout);
+  }, [defaultTaskLayout]);
+
+  useEffect(() => {
+    setShowCompleted(showCompletedByDefault);
+  }, [showCompletedByDefault]);
 
   useEffect(() => {
     const catId = searchParams.get('categoryId');


### PR DESCRIPTION
## Summary
- ensure Dashboard task view respects default settings on reload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ff3c12674832aaa2e27aa4fc4a812