### PR TITLE
Add settings overview and custom theme management

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -174,8 +174,8 @@ the data off as soon as the server can be reached again.
 - Standard priority for new tasks adjustable
 - multilingual surface (German, English) selectable
 -Several theme presets (Light, Dark, Ocean, Dark-Red, Hacker,
-Motivation) and your own "custom" theme selectable
-- In the custom theme, colors of the interface and cards can be adjusted individually
+Motivation) are available. You can create and manage multiple custom
+themes with individually adjustable colors.
 - Each theme preset now includes a suitable color palette for categories, tasks and notes
 - New "Info" rider in the settings shows version number, release notes and readme
 - German or English can be selected in the "Language" tab

--- a/README.md
+++ b/README.md
@@ -170,8 +170,9 @@ npm start    # startet die gebaute App auf Port 3002
 - Standard-Priorität für neue Tasks einstellbar
 - Mehrsprachige Oberfläche (Deutsch, Englisch) auswählbar
 - Mehrere Theme-Voreinstellungen (light, dark, ocean, dark-red, hacker,
-  motivation) und ein eigenes "Custom"-Theme wählbar
-- Im Custom-Theme lassen sich Farben der Oberfläche und Karten individuell anpassen
+  motivation) stehen zur Auswahl. Eigene Themes können benannt,
+  gespeichert und verwaltet werden, wobei alle Farben individuell
+  anpassbar sind.
 - Jede Theme-Voreinstellung bringt nun eine passende Farbpalette für Kategorien,
   Tasks und Notizen mit
 - Neuer "Info"-Reiter in den Einstellungen zeigt Versionsnummer, Release Notes und README

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -953,6 +953,9 @@ interface SettingsContextValue {
   updateTheme: (key: keyof typeof defaultTheme, value: string) => void
   themeName: string
   updateThemeName: (name: string) => void
+  customThemes: { name: string; theme: typeof defaultTheme; colorPalette: string[] }[]
+  addCustomTheme: (name: string) => void
+  deleteCustomTheme: (name: string) => void
   colorPalette: string[]
   updatePaletteColor: (index: number, value: string) => void
   homeSectionColors: Record<string, number>
@@ -1022,6 +1025,11 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   )
   const [theme, setTheme] = useState(defaultTheme)
   const [themeName, setThemeName] = useState('light')
+  const [customThemes, setCustomThemes] = useState<{
+    name: string
+    theme: typeof defaultTheme
+    colorPalette: string[]
+  }[]>([])
   const [colorPalette, setColorPalette] = useState<string[]>(defaultColorPalette)
   const [homeSectionColors, setHomeSectionColors] = useState<Record<string, number>>(
     { ...defaultHomeSectionColors }
@@ -1083,12 +1091,18 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
             if (!preset && Array.isArray(data.colorPalette)) {
               setColorPalette(data.colorPalette)
             }
+            if (Array.isArray(data.customThemes)) {
+              setCustomThemes(data.customThemes)
+            }
           } else {
             if (data.theme) {
               setTheme({ ...defaultTheme, ...data.theme })
             }
             if (Array.isArray(data.colorPalette)) {
               setColorPalette(data.colorPalette)
+            }
+            if (Array.isArray(data.customThemes)) {
+              setCustomThemes(data.customThemes)
             }
           }
           if (Array.isArray(data.homeSectionOrder)) {
@@ -1199,6 +1213,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
             defaultTaskPriority: priority,
             theme,
             themeName,
+            customThemes,
             colorPalette,
             homeSectionColors,
             homeSections,
@@ -1237,6 +1252,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     priority,
     theme,
     themeName,
+    customThemes,
     colorPalette,
     homeSectionColors,
     homeSections,
@@ -1297,9 +1313,13 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const updateThemeName = (name: string) => {
     setThemeName(name)
     const preset = themePresets[name]
+    const custom = customThemes.find(t => t.name === name)
     if (preset) {
       setTheme(preset.theme)
       setColorPalette(preset.colorPalette)
+    } else if (custom) {
+      setTheme(custom.theme)
+      setColorPalette(custom.colorPalette)
     }
   }
 
@@ -1310,6 +1330,24 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
       return arr
     })
     setThemeName('custom')
+  }
+
+  const addCustomTheme = (name: string) => {
+    setCustomThemes(prev => [
+      { name, theme: { ...theme }, colorPalette: [...colorPalette] },
+      ...prev.filter(t => t.name !== name)
+    ])
+    setThemeName(name)
+  }
+
+  const deleteCustomTheme = (name: string) => {
+    setCustomThemes(prev => prev.filter(t => t.name !== name))
+    if (themeName === name) {
+      setThemeName('light')
+      const preset = themePresets['light']
+      setTheme(preset.theme)
+      setColorPalette(preset.colorPalette)
+    }
   }
 
   const updateHomeSectionColor = (section: string, color: number) => {
@@ -1425,6 +1463,9 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         updateTheme,
         themeName,
         updateThemeName,
+        customThemes,
+        addCustomTheme,
+        deleteCustomTheme,
         colorPalette,
         updatePaletteColor,
         homeSectionColors,

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -23,6 +23,7 @@
   },
   "settings": {
     "tabs": {
+      "overview": "Übersicht",
       "shortcuts": "Shortcuts",
       "pomodoro": "Pomodoro",
       "flashcards": "Karten",
@@ -82,6 +83,9 @@
     "showPinnedCategories": "Gepinnte Kategorien anzeigen",
     "offlineCache": "Offline-Cache aktivieren",
     "themePreset": "Voreinstellung",
+    "customThemeName": "Name des Themes",
+    "addTheme": "Theme hinzufügen",
+    "yourThemes": "Eigene Themes",
     "custom": "custom",
     "bgColor": "Hintergrund (App)",
     "fgColor": "Textfarbe",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -23,6 +23,7 @@
   },
   "settings": {
     "tabs": {
+      "overview": "Overview",
       "shortcuts": "Shortcuts",
       "pomodoro": "Pomodoro",
       "flashcards": "Cards",
@@ -82,6 +83,9 @@
     "showPinnedCategories": "Show pinned categories",
     "offlineCache": "Enable offline cache",
     "themePreset": "Preset",
+    "customThemeName": "Theme name",
+    "addTheme": "Add Theme",
+    "yourThemes": "Your Themes",
     "custom": "custom",
     "bgColor": "Background (App)",
     "fgColor": "Text color",

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -158,6 +158,9 @@ const SettingsPage: React.FC = () => {
     llmModel,
     updateLlmModel,
     colorPalette,
+    customThemes,
+    addCustomTheme,
+    deleteCustomTheme,
     updatePaletteColor,
     homeSectionColors,
     updateHomeSectionColor
@@ -170,6 +173,14 @@ const SettingsPage: React.FC = () => {
   const notesInputRef = React.useRef<HTMLInputElement>(null)
   const decksInputRef = React.useRef<HTMLInputElement>(null)
   const allInputRef = React.useRef<HTMLInputElement>(null)
+
+  const [currentTab, setCurrentTab] = useState(() =>
+    localStorage.getItem('settingsTab') || 'overview'
+  )
+  const handleTabChange = (val: string) => {
+    setCurrentTab(val)
+    localStorage.setItem('settingsTab', val)
+  }
 
   type ImportType = 'tasks' | 'notes' | 'decks' | 'all'
   type ImportData = Partial<{
@@ -186,6 +197,8 @@ const SettingsPage: React.FC = () => {
   const [importResult, setImportResult] = useState<'success' | 'error' | null>(
     null
   )
+
+  const [newThemeName, setNewThemeName] = useState('')
 
   const baseColors = [
     { key: 'background', label: 'bgColor', desc: 'bgColorDesc' },
@@ -593,8 +606,13 @@ const SettingsPage: React.FC = () => {
       <div className="min-h-screen bg-background">
         <Navbar title={t('navbar.settings')} />
       <div className="max-w-5xl mx-auto px-4 py-6">
-        <Tabs defaultValue="shortcuts" className="flex gap-6">
+        <Tabs value={currentTab} onValueChange={handleTabChange} className="flex gap-6">
           <div className="w-48 overflow-y-auto max-h-[calc(100vh-8rem)]">
+            <TabsList className="flex flex-col gap-1 mb-2 bg-transparent p-0 h-auto">
+              <TabsTrigger className="justify-start" value="overview">
+                {t('settings.tabs.overview')}
+              </TabsTrigger>
+            </TabsList>
             <Accordion type="multiple" className="space-y-2">
               <AccordionItem value="general">
                 <AccordionTrigger className="text-sm">
@@ -674,6 +692,30 @@ const SettingsPage: React.FC = () => {
             </Accordion>
           </div>
           <div className="flex-1 space-y-4">
+            <TabsContent value="overview" className="space-y-4">
+              <div className="grid grid-cols-2 gap-2">
+                {[
+                  'shortcuts',
+                  'language',
+                  'home',
+                  'theme',
+                  'pomodoro',
+                  'tasks',
+                  'flashcards',
+                  'data',
+                  'ai',
+                  'info'
+                ].map(key => (
+                  <Button
+                    key={key}
+                    variant="outline"
+                    onClick={() => handleTabChange(key)}
+                  >
+                    {t(`settings.tabs.${key}`)}
+                  </Button>
+                ))}
+              </div>
+            </TabsContent>
             <TabsContent value="shortcuts" className="space-y-4">
               <div>
                 <Label htmlFor="open">{t('settingsPage.commandPalette')}</Label>
@@ -898,7 +940,12 @@ const SettingsPage: React.FC = () => {
                   <SelectTrigger id="themePreset">
                     <SelectValue />
                   </SelectTrigger>
-                  <SelectContent>
+                  <SelectContent className="max-h-60 overflow-y-auto">
+                    {customThemes.map(ct => (
+                      <SelectItem key={ct.name} value={ct.name}>
+                        {ct.name}
+                      </SelectItem>
+                    ))}
                     {Object.keys(themePresets).map(name => (
                       <SelectItem key={name} value={name}>
                         {name}
@@ -907,6 +954,44 @@ const SettingsPage: React.FC = () => {
                     <SelectItem value="custom">{t('settingsPage.custom')}</SelectItem>
                   </SelectContent>
                 </Select>
+                <div className="flex items-center gap-2 mt-2">
+                  <Input
+                    value={newThemeName}
+                    onChange={e => setNewThemeName(e.target.value)}
+                    placeholder={t('settingsPage.customThemeName') || ''}
+                  />
+                  <Button
+                    onClick={() => {
+                      if (newThemeName.trim()) {
+                        addCustomTheme(newThemeName.trim())
+                        setNewThemeName('')
+                      }
+                    }}
+                  >
+                    {t('settingsPage.addTheme')}
+                  </Button>
+                </div>
+                {customThemes.length > 0 && (
+                  <div>
+                    <p className="text-sm font-medium mt-2">
+                      {t('settingsPage.yourThemes')}
+                    </p>
+                    <ul className="space-y-1 mt-1">
+                      {customThemes.map(ct => (
+                        <li key={ct.name} className="flex items-center gap-2">
+                          <span className="flex-1">{ct.name}</span>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => deleteCustomTheme(ct.name)}
+                          >
+                            {t('common.delete')}
+                          </Button>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
               </div>
               <Accordion type="multiple" className="space-y-2">
                 <AccordionItem value="base">


### PR DESCRIPTION
## Summary
- enhance Settings page with overview tab
- remember last selected settings tab across reloads
- add scrollbar to theme selector and support custom themes
- allow creating and deleting custom themes
- update translations and README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68600e488ecc832a96204598fdc5cd58