### PR TITLE
Add color gradient preview for theme selection

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -8,7 +8,7 @@ import KeyInput from '@/components/KeyInput'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
 import { Link } from 'react-router-dom'
-import { hslToHex, hexToHsl } from '@/utils/color'
+import { hslToHex, hexToHsl, paletteToGradient } from '@/utils/color'
 import { Checkbox } from '@/components/ui/checkbox'
 import { allHomeSections } from '@/utils/homeSections'
 import {
@@ -943,12 +943,24 @@ const SettingsPage: React.FC = () => {
                   <SelectContent className="max-h-60 overflow-y-auto">
                     {customThemes.map(ct => (
                       <SelectItem key={ct.name} value={ct.name}>
-                        {ct.name}
+                        <span className="flex items-center gap-2 w-full">
+                          <span>{ct.name}</span>
+                          <span
+                            className="flex-1 h-3 rounded"
+                            style={{ background: paletteToGradient(ct.colorPalette) }}
+                          />
+                        </span>
                       </SelectItem>
                     ))}
                     {Object.keys(themePresets).map(name => (
                       <SelectItem key={name} value={name}>
-                        {name}
+                        <span className="flex items-center gap-2 w-full">
+                          <span>{name}</span>
+                          <span
+                            className="flex-1 h-3 rounded"
+                            style={{ background: paletteToGradient(themePresets[name].colorPalette) }}
+                          />
+                        </span>
                       </SelectItem>
                     ))}
                     <SelectItem value="custom">{t('settingsPage.custom')}</SelectItem>

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -115,3 +115,6 @@ export const colorContrast = (hex1: string, hex2: string): number => {
   const yiq2 = (r2 * 299 + g2 * 587 + b2 * 114) / 1000;
   return Math.abs(yiq1 - yiq2);
 };
+
+export const paletteToGradient = (colors: string[]): string =>
+  `linear-gradient(to right, ${colors.join(', ')})`;


### PR DESCRIPTION
## Summary
- show a color gradient preview for each theme in the settings dropdown
- support creating gradients from palette colors

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686020037fac832aae2eba127c98f64e