### PR TITLE
Improve theme preset preview

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -8,7 +8,7 @@ import KeyInput from '@/components/KeyInput'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
 import { Link } from 'react-router-dom'
-import { hslToHex, hexToHsl, paletteToGradient } from '@/utils/color'
+import { hslToHex, hexToHsl, themeToGradient } from '@/utils/color'
 import { Checkbox } from '@/components/ui/checkbox'
 import { allHomeSections } from '@/utils/homeSections'
 import {
@@ -946,8 +946,8 @@ const SettingsPage: React.FC = () => {
                         <span className="flex items-center gap-2 w-full">
                           <span>{ct.name}</span>
                           <span
-                            className="flex-1 h-3 rounded min-w-[50px]"
-                            style={{ background: paletteToGradient(ct.colorPalette) }}
+                            className="flex-1 h-3 rounded w-full"
+                            style={{ background: themeToGradient(ct.theme, ct.colorPalette) }}
                           />
                         </span>
                       </SelectItem>
@@ -957,8 +957,8 @@ const SettingsPage: React.FC = () => {
                         <span className="flex items-center gap-2 w-full">
                           <span>{name}</span>
                           <span
-                            className="flex-1 h-3 rounded min-w-[50px]"
-                            style={{ background: paletteToGradient(themePresets[name].colorPalette) }}
+                            className="flex-1 h-3 rounded w-full"
+                            style={{ background: themeToGradient(themePresets[name].theme, themePresets[name].colorPalette) }}
                           />
                         </span>
                       </SelectItem>

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -118,3 +118,33 @@ export const colorContrast = (hex1: string, hex2: string): number => {
 
 export const paletteToGradient = (colors: string[]): string =>
   `linear-gradient(to right, ${colors.join(', ')})`;
+
+export const weightedGradient = (
+  colors: string[],
+  weights: number[],
+): string => {
+  if (colors.length !== weights.length) return paletteToGradient(colors);
+  const total = weights.reduce((s, w) => s + w, 0);
+  let acc = 0;
+  const stops = colors.map((c, i) => {
+    const start = (acc / total) * 100;
+    acc += weights[i];
+    const end = (acc / total) * 100;
+    return `${c} ${start}% ${end}%`;
+  });
+  return `linear-gradient(to right, ${stops.join(', ')})`;
+};
+
+export const themeToGradient = (
+  theme: Record<string, string>,
+  palette: string[],
+): string => {
+  const colors = [
+    `hsl(${theme.background})`,
+    `hsl(${theme.foreground})`,
+    `hsl(${theme.accent})`,
+    ...palette,
+  ];
+  const weights = [3, 2, 2, ...new Array(palette.length).fill(1)];
+  return weightedGradient(colors, weights);
+};


### PR DESCRIPTION
## Summary
- visualize theme palettes with weighted gradient
- fill gradient bar across the dropdown item

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860e01bbd84832aa6644cec0f10cf47