### PR TITLE
Fix dev server proxy

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,8 +21,9 @@ export default defineConfig(({ mode }) => ({
     port: 8081,
     proxy: {
       '/api': {
-        target: 'http://localhost:3002',
+        target: 'https://localhost:3002',
         changeOrigin: true,
+        secure: false,
       }
     }
   },


### PR DESCRIPTION
## Summary
- configure Vite proxy to use HTTPS for the backend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686160b34944832a825628d1d9d4b051