### PR TITLE
Add TypeScript typecheck workflow

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,25 @@
+name: TypeScript Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "npm"
+      - name: Install dependencies
+        run: npm ci
+      - name: Run type check
+        run: npm run typecheck

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "format:check": "prettier --check .",
     "preview": "vite preview",
     "start": "node server/index.js",
-    "test": "vitest"
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary
- add npm script `typecheck` to run `tsc --noEmit`
- create GitHub Actions workflow to run the type checker on pushes and PRs

## Testing
- `npm run lint`
- `npm test` *(exited after tests passed)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6865764de8d8832a8ea9be9d92fbf4c3