### PR TITLE
Improve timer interactions

### DIFF
--- a/src/components/TimerCard.tsx
+++ b/src/components/TimerCard.tsx
@@ -4,6 +4,7 @@ import { Play, Pause, RotateCcw, Plus } from "lucide-react";
 import TimerCircle from "./TimerCircle";
 import { useTimers } from "@/hooks/useTimers";
 import { useSettings } from "@/hooks/useSettings";
+import { isColorDark, complementaryColor } from "@/utils/color";
 import { Button } from "@/components/ui/button";
 
 interface Props {
@@ -14,17 +15,24 @@ const TimerCard: React.FC<Props> = ({ id }) => {
   const navigate = useNavigate();
   const timer = useTimers((state) => state.timers.find((t) => t.id === id));
   const { startTimer, pauseTimer, resumeTimer, extendTimer } = useTimers();
-  const { timerExtendSeconds } = useSettings();
+  const { timerExtendSeconds, colorPalette } = useSettings();
   if (!timer) return null;
   const { title, color, duration, remaining, isRunning, isPaused } = timer;
+  const baseColor = colorPalette[color] ?? colorPalette[0];
+  const textColor = isColorDark(baseColor) ? "#fff" : "#000";
+  const ringColor = complementaryColor(baseColor);
   const handleClick = () => navigate(`/timers/${id}`);
   return (
-    <div className="p-4 border rounded shadow flex flex-col items-center">
+    <div
+      className="p-4 border rounded shadow flex flex-col items-center"
+      style={{ backgroundColor: baseColor, color: textColor }}
+    >
       <div className="cursor-pointer" onClick={handleClick}>
         <TimerCircle
           remaining={remaining}
           duration={duration}
           color={color}
+          ringColor={ringColor}
           size={60}
           paused={isPaused}
         />
@@ -50,11 +58,10 @@ const TimerCard: React.FC<Props> = ({ id }) => {
         )}
         {isRunning && (
           <Button
-            size="icon"
             variant="outline"
             onClick={() => extendTimer(id, timerExtendSeconds)}
           >
-            <Plus className="h-4 w-4" />
+            <Plus className="h-4 w-4 mr-1" />+{timerExtendSeconds}s
           </Button>
         )}
         {!isRunning && remaining === 0 && (

--- a/src/components/TimerCircle.tsx
+++ b/src/components/TimerCircle.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { useSettings } from "@/hooks/useSettings";
+import { complementaryColor } from "@/utils/color";
 
 interface Props {
   remaining: number;
   duration: number;
   size?: number;
   color: number;
+  ringColor?: string;
   paused?: boolean;
 }
 
@@ -27,6 +29,7 @@ const TimerCircle: React.FC<Props> = ({
   duration,
   size = 80,
   color,
+  ringColor: ringColorProp,
   paused,
 }) => {
   const { colorPalette } = useSettings();
@@ -36,7 +39,8 @@ const TimerCircle: React.FC<Props> = ({
   const circumference = normalizedRadius * 2 * Math.PI;
   const progress = remaining / duration;
   const strokeDashoffset = circumference - progress * circumference;
-  const ringColor = colorPalette[color] ?? colorPalette[0];
+  const baseColor = colorPalette[color] ?? colorPalette[0];
+  const ringColor = ringColorProp ?? complementaryColor(baseColor);
   return (
     <div className="relative" style={{ width: radius * 2, height: radius * 2 }}>
       <svg

--- a/src/components/TimerModal.tsx
+++ b/src/components/TimerModal.tsx
@@ -23,29 +23,39 @@ interface TimerModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSave: (data: TimerFormData) => void;
+  initialData?: TimerFormData;
 }
 
-const TimerModal: React.FC<TimerModalProps> = ({ isOpen, onClose, onSave }) => {
+const TimerModal: React.FC<TimerModalProps> = ({
+  isOpen,
+  onClose,
+  onSave,
+  initialData,
+}) => {
   const { t } = useTranslation();
   const { colorPalette, defaultTimerColor } = useSettings();
-  const [data, setData] = useState<TimerFormData>({
-    title: "",
-    hours: 0,
-    minutes: 0,
-    seconds: 0,
-    color: defaultTimerColor,
-  });
-
-  useEffect(() => {
-    if (!isOpen) return;
-    setData({
+  const [data, setData] = useState<TimerFormData>(
+    initialData ?? {
       title: "",
       hours: 0,
       minutes: 0,
       seconds: 0,
       color: defaultTimerColor,
-    });
-  }, [isOpen, defaultTimerColor]);
+    },
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setData(
+      initialData ?? {
+        title: "",
+        hours: 0,
+        minutes: 0,
+        seconds: 0,
+        color: defaultTimerColor,
+      },
+    );
+  }, [isOpen, defaultTimerColor, initialData]);
 
   const handleChange = (field: keyof TimerFormData, value: string | number) => {
     setData((prev) => ({ ...prev, [field]: value }));
@@ -61,7 +71,9 @@ const TimerModal: React.FC<TimerModalProps> = ({ isOpen, onClose, onSave }) => {
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>{t("timers.new")}</DialogTitle>
+          <DialogTitle>
+            {t(initialData ? "timerModal.editTitle" : "timerModal.newTitle")}
+          </DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>

--- a/src/hooks/useTimers.ts
+++ b/src/hooks/useTimers.ts
@@ -149,7 +149,7 @@ export const useTimers = create<TimersState>()(
             if (!t.isRunning || t.isPaused) return t;
             const last = t.lastTick ?? now;
             const elapsed = (now - last) / 1000;
-            let remaining = t.remaining - elapsed;
+            const remaining = t.remaining - elapsed;
             if (remaining <= 0) {
               return {
                 ...t,

--- a/src/hooks/useTimers.ts
+++ b/src/hooks/useTimers.ts
@@ -34,6 +34,10 @@ interface TimersState {
   resumeTimer: (id: string) => void;
   stopTimer: (id: string) => void;
   extendTimer: (id: string, seconds: number) => void;
+  updateTimer: (
+    id: string,
+    data: Pick<Timer, "title" | "color" | "duration">,
+  ) => void;
   tick: () => void;
 }
 
@@ -103,7 +107,6 @@ export const useTimers = create<TimersState>()(
                   ...t,
                   isRunning: false,
                   isPaused: false,
-                  remaining: 0,
                   startTime: undefined,
                   lastTick: undefined,
                   pauseStart: undefined,
@@ -123,19 +126,46 @@ export const useTimers = create<TimersState>()(
               : t,
           ),
         })),
+      updateTimer: (id, data) =>
+        set((state) => ({
+          timers: state.timers.map((t) =>
+            t.id === id
+              ? {
+                  ...t,
+                  title: data.title,
+                  color: data.color,
+                  duration: data.duration,
+                  remaining: t.isRunning
+                    ? Math.min(t.remaining, data.duration)
+                    : data.duration,
+                }
+              : t,
+          ),
+        })),
       tick: () => {
         const now = Date.now();
         set((state) => ({
           timers: state.timers.map((t) => {
             if (!t.isRunning || t.isPaused) return t;
             const last = t.lastTick ?? now;
-            const elapsed = Math.floor((now - last) / 1000);
-            const remaining = Math.max(0, t.remaining - elapsed);
+            const elapsed = (now - last) / 1000;
+            let remaining = t.remaining - elapsed;
+            if (remaining <= 0) {
+              return {
+                ...t,
+                isRunning: false,
+                isPaused: false,
+                remaining: t.duration,
+                startTime: undefined,
+                lastTick: undefined,
+                pauseStart: undefined,
+              };
+            }
             return {
               ...t,
               remaining,
               lastTick: now,
-              isRunning: remaining > 0,
+              isRunning: true,
             };
           }),
         }));

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -263,6 +263,10 @@
     "back": "Rückseite *",
     "chooseDeck": "Deck wählen"
   },
+  "timerModal": {
+    "editTitle": "Timer bearbeiten",
+    "newTitle": "Neuer Timer"
+  },
   "notFound": {
     "title": "404",
     "message": "Oops! Seite nicht gefunden",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -263,6 +263,10 @@
     "back": "Back *",
     "chooseDeck": "Choose deck"
   },
+  "timerModal": {
+    "editTitle": "Edit Timer",
+    "newTitle": "New Timer"
+  },
   "notFound": {
     "title": "404",
     "message": "Oops! Page not found",

--- a/src/pages/TimerDetail.tsx
+++ b/src/pages/TimerDetail.tsx
@@ -20,22 +20,24 @@ const TimerDetail: React.FC = () => {
   const updateTimer = useTimers((state) => state.updateTimer);
   const { timerExtendSeconds, colorPalette } = useSettings();
   const [editOpen, setEditOpen] = React.useState(false);
+
+  const initialData = React.useMemo(() => {
+    if (!timer) return null;
+    return {
+      title: timer.title,
+      hours: Math.floor(timer.duration / 3600),
+      minutes: Math.floor((timer.duration % 3600) / 60),
+      seconds: Math.floor(timer.duration % 60),
+      color: timer.color,
+    };
+  }, [timer]);
+
   if (!timer) return null;
+
   const { title, color, duration, remaining, isRunning, isPaused } = timer;
   const baseColor = colorPalette[color] ?? colorPalette[0];
   const textColor = isColorDark(baseColor) ? "#fff" : "#000";
   const ringColor = complementaryColor(baseColor);
-
-  const initialData = React.useMemo(
-    () => ({
-      title,
-      hours: Math.floor(duration / 3600),
-      minutes: Math.floor((duration % 3600) / 60),
-      seconds: Math.floor(duration % 60),
-      color,
-    }),
-    [title, duration, color],
-  );
 
   const handleEditSave = (data: {
     title: string;

--- a/src/pages/TimerDetail.tsx
+++ b/src/pages/TimerDetail.tsx
@@ -5,8 +5,10 @@ import Navbar from "@/components/Navbar";
 import TimerCircle from "@/components/TimerCircle";
 import { Button } from "@/components/ui/button";
 import { useTimers } from "@/hooks/useTimers";
-import { Play, Pause, RotateCcw, Plus } from "lucide-react";
+import { Play, Pause, RotateCcw, Plus, Edit } from "lucide-react";
 import { useSettings } from "@/hooks/useSettings";
+import { isColorDark, complementaryColor } from "@/utils/color";
+import TimerModal from "@/components/TimerModal";
 
 const TimerDetail: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -15,9 +17,36 @@ const TimerDetail: React.FC = () => {
   const timer = useTimers((state) => state.timers.find((t) => t.id === id));
   const { startTimer, pauseTimer, resumeTimer, stopTimer, extendTimer } =
     useTimers();
-  const { timerExtendSeconds } = useSettings();
+  const updateTimer = useTimers((state) => state.updateTimer);
+  const { timerExtendSeconds, colorPalette } = useSettings();
+  const [editOpen, setEditOpen] = React.useState(false);
   if (!timer) return null;
   const { title, color, duration, remaining, isRunning, isPaused } = timer;
+  const baseColor = colorPalette[color] ?? colorPalette[0];
+  const textColor = isColorDark(baseColor) ? "#fff" : "#000";
+  const ringColor = complementaryColor(baseColor);
+
+  const initialData = React.useMemo(
+    () => ({
+      title,
+      hours: Math.floor(duration / 3600),
+      minutes: Math.floor((duration % 3600) / 60),
+      seconds: Math.floor(duration % 60),
+      color,
+    }),
+    [title, duration, color],
+  );
+
+  const handleEditSave = (data: {
+    title: string;
+    hours: number;
+    minutes: number;
+    seconds: number;
+    color: number;
+  }) => {
+    const dur = data.hours * 3600 + data.minutes * 60 + data.seconds;
+    updateTimer(id!, { title: data.title, color: data.color, duration: dur });
+  };
   return (
     <div className="min-h-screen bg-background flex flex-col">
       <Navbar
@@ -29,10 +58,13 @@ const TimerDetail: React.FC = () => {
           remaining={remaining}
           duration={duration}
           color={color}
+          ringColor={ringColor}
           size={150}
           paused={isPaused}
         />
-        <div className="text-xl font-semibold">{title}</div>
+        <div className="text-xl font-semibold" style={{ color: textColor }}>
+          {title}
+        </div>
         <div className="flex space-x-2">
           {!isRunning && (
             <Button onClick={() => startTimer(id!)}>
@@ -54,7 +86,8 @@ const TimerDetail: React.FC = () => {
               variant="outline"
               onClick={() => extendTimer(id!, timerExtendSeconds)}
             >
-              <Plus className="h-4 w-4 mr-2" /> {t("timers.extend")}
+              <Plus className="h-4 w-4 mr-2" />
+              {t("timers.extend")} +{timerExtendSeconds}s
             </Button>
           )}
           {isRunning && (
@@ -62,8 +95,17 @@ const TimerDetail: React.FC = () => {
               <RotateCcw className="h-4 w-4 mr-2" /> {t("timers.stop")}
             </Button>
           )}
+          <Button variant="outline" onClick={() => setEditOpen(true)}>
+            <Edit className="h-4 w-4 mr-2" /> {t("common.edit")}
+          </Button>
         </div>
       </div>
+      <TimerModal
+        isOpen={editOpen}
+        onClose={() => setEditOpen(false)}
+        onSave={handleEditSave}
+        initialData={initialData}
+      />
     </div>
   );
 };

--- a/src/pages/Timers.tsx
+++ b/src/pages/Timers.tsx
@@ -32,7 +32,7 @@ const TimersPage: React.FC = () => {
     <div className="min-h-screen bg-background flex flex-col">
       <Navbar title={t("navbar.timers")} />
       <div className="p-4 flex-1">
-        <div className="mb-4">
+        <div className="mb-4 flex justify-center">
           <Button onClick={() => setOpen(true)}>{t("timers.new")}</Button>
         </div>
         {sorted.length === 0 && (


### PR DESCRIPTION
## Summary
- center new timer button
- allow editing timers via modal
- keep remaining time on stop and reset when finished
- use card color for timers and complementary ring colors
- show extend amount on buttons
- fix slow seconds in ticker
- add timerModal translations

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6866d49978d4832aafdb583d06d42c03