### PR TITLE
Add customizable Pomodoro alerts and dynamic break color

### DIFF
--- a/src/components/PomodoroTimer.tsx
+++ b/src/components/PomodoroTimer.tsx
@@ -5,10 +5,34 @@ import { Button } from "@/components/ui/button";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { useSettings, SettingsProvider } from "@/hooks/useSettings";
+import { hslToHex, hexToHsl, complementaryColor } from "@/utils/color";
 import {
   usePomodoroHistory,
   PomodoroHistoryProvider,
 } from "@/hooks/usePomodoroHistory.tsx";
+
+const playSound = (url?: string) => {
+  if (url) {
+    try {
+      const audio = new Audio(url);
+      audio.play().catch(() => {});
+      return;
+    } catch {
+      // ignore errors
+    }
+  }
+  try {
+    const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+    const osc = ctx.createOscillator();
+    osc.type = "sine";
+    osc.frequency.setValueAtTime(440, ctx.currentTime);
+    osc.connect(ctx.destination);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.4);
+  } catch {
+    // ignore
+  }
+};
 
 interface PomodoroState {
   isRunning: boolean;
@@ -163,7 +187,7 @@ const PomodoroTimer: React.FC<PomodoroTimerProps> = ({
     setStartTime,
     startTime,
   } = usePomodoroStore();
-  const { pomodoro, updatePomodoro } = useSettings();
+  const { pomodoro, updatePomodoro, theme } = useSettings();
   const { addSession, endBreak } = usePomodoroHistory();
   const { t } = useTranslation();
   const pipWindowRef = useRef<Window | null>(null);
@@ -349,6 +373,39 @@ const PomodoroTimer: React.FC<PomodoroTimerProps> = ({
   useEffect(() => {
     setDurations(pomodoro.workMinutes * 60, pomodoro.breakMinutes * 60);
   }, [pomodoro, setDurations]);
+
+  const prevMode = useRef(mode);
+  useEffect(() => {
+    if (prevMode.current !== mode) {
+      if (mode === "break") {
+        playSound(pomodoro.workSound);
+      } else {
+        playSound(pomodoro.breakSound);
+      }
+      prevMode.current = mode;
+    }
+    const breakColor = theme["pomodoro-break-ring"];
+    if (mode === "break") {
+      const comp = hexToHsl(
+        complementaryColor(hslToHex(breakColor)),
+      );
+      document.documentElement.style.setProperty("--background", breakColor);
+      document.documentElement.style.setProperty("--pomodoro-break-ring", comp);
+    } else {
+      document.documentElement.style.setProperty("--background", theme.background);
+      document.documentElement.style.setProperty(
+        "--pomodoro-break-ring",
+        breakColor,
+      );
+    }
+    return () => {
+      document.documentElement.style.setProperty("--background", theme.background);
+      document.documentElement.style.setProperty(
+        "--pomodoro-break-ring",
+        breakColor,
+      );
+    };
+  }, [mode, pomodoro.workSound, pomodoro.breakSound, theme]);
 
   if (compact && !isRunning) return null;
 

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -16,7 +16,12 @@ const defaultShortcuts: ShortcutKeys = {
   newFlashcard: "ctrl+alt+f",
 };
 
-const defaultPomodoro = { workMinutes: 25, breakMinutes: 5 };
+const defaultPomodoro = {
+  workMinutes: 25,
+  breakMinutes: 5,
+  workSound: "",
+  breakSound: "",
+};
 const defaultFlashcardSettings = {
   timerSeconds: 10,
   sessionSize: 5,
@@ -950,8 +955,16 @@ export const defaultHomeSectionColors: Record<string, number> =
 interface SettingsContextValue {
   shortcuts: ShortcutKeys;
   updateShortcut: (key: keyof ShortcutKeys, value: string) => void;
-  pomodoro: { workMinutes: number; breakMinutes: number };
-  updatePomodoro: (key: "workMinutes" | "breakMinutes", value: number) => void;
+  pomodoro: {
+    workMinutes: number;
+    breakMinutes: number;
+    workSound: string;
+    breakSound: string;
+  };
+  updatePomodoro: (
+    key: "workMinutes" | "breakMinutes" | "workSound" | "breakSound",
+    value: number | string,
+  ) => void;
   defaultTaskPriority: "low" | "medium" | "high";
   updateDefaultTaskPriority: (value: "low" | "medium" | "high") => void;
   theme: typeof defaultTheme;
@@ -1340,8 +1353,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
   };
 
   const updatePomodoro = (
-    key: "workMinutes" | "breakMinutes",
-    value: number,
+    key: "workMinutes" | "breakMinutes" | "workSound" | "breakSound",
+    value: number | string,
   ) => {
     setPomodoro((prev) => ({ ...prev, [key]: value }));
   };

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -64,6 +64,8 @@
     "newFlashcard": "Neue Karte",
     "workMinutes": "Lernzeit (Minuten)",
     "breakMinutes": "Pause (Minuten)",
+    "workSound": "Sound bei Pausenstart (URL)",
+    "breakSound": "Sound bei Arbeitsstart (URL)",
     "flashcardTimer": "Timer pro Karte (Sekunden)",
     "flashcardSessionSize": "Training-Session Größe",
     "startMode": "Startmodus",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -64,6 +64,8 @@
     "newFlashcard": "New Card",
     "workMinutes": "Work time (minutes)",
     "breakMinutes": "Break (minutes)",
+    "workSound": "Work end sound URL",
+    "breakSound": "Break end sound URL",
     "flashcardTimer": "Timer per card (seconds)",
     "flashcardSessionSize": "Training session size",
     "startMode": "Start mode",

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -843,6 +843,32 @@ const SettingsPage: React.FC = () => {
                     }
                   />
                 </div>
+                <div>
+                  <Label htmlFor="workSound">
+                    {t("settingsPage.workSound")}
+                  </Label>
+                  <Input
+                    id="workSound"
+                    type="text"
+                    value={pomodoro.workSound}
+                    onChange={(e) =>
+                      updatePomodoro("workSound", e.target.value)
+                    }
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="breakSound">
+                    {t("settingsPage.breakSound")}
+                  </Label>
+                  <Input
+                    id="breakSound"
+                    type="text"
+                    value={pomodoro.breakSound}
+                    onChange={(e) =>
+                      updatePomodoro("breakSound", e.target.value)
+                    }
+                  />
+                </div>
               </TabsContent>
               <TabsContent value="flashcards" className="space-y-4">
                 <div>


### PR DESCRIPTION
## Summary
- allow configuring break and work end sounds in settings
- store new sound settings in `pomodoro` config
- change page background and ring color when a break begins
- play custom sounds when switching modes
- provide translations for the new settings

## Testing
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866d63dce0c832a82648de02b6987f4