### PR TITLE
Improve timer card actions and sorting

### DIFF
--- a/src/components/TimerCard.tsx
+++ b/src/components/TimerCard.tsx
@@ -1,11 +1,15 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
-import { Play, Pause, RotateCcw, Plus } from "lucide-react";
+import { Play, Pause, RotateCcw, Plus, Edit, Trash2 } from "lucide-react";
 import TimerCircle from "./TimerCircle";
 import { useTimers } from "@/hooks/useTimers";
 import { useSettings } from "@/hooks/useSettings";
 import { isColorDark, complementaryColor } from "@/utils/color";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import ConfirmDialog from "@/components/ConfirmDialog";
+import TimerModal from "./TimerModal";
+import { useTranslation } from "react-i18next";
 
 interface Props {
   id: string;
@@ -13,20 +17,68 @@ interface Props {
 
 const TimerCard: React.FC<Props> = ({ id }) => {
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const timer = useTimers((state) => state.timers.find((t) => t.id === id));
-  const { startTimer, pauseTimer, resumeTimer, extendTimer } = useTimers();
+  const {
+    startTimer,
+    pauseTimer,
+    resumeTimer,
+    stopTimer,
+    extendTimer,
+    removeTimer,
+    updateTimer,
+  } = useTimers();
   const { timerExtendSeconds, colorPalette } = useSettings();
+  const [editOpen, setEditOpen] = React.useState(false);
+  const [deleteOpen, setDeleteOpen] = React.useState(false);
   if (!timer) return null;
   const { title, color, duration, remaining, isRunning, isPaused } = timer;
   const baseColor = colorPalette[color] ?? colorPalette[0];
   const textColor = isColorDark(baseColor) ? "#fff" : "#000";
   const ringColor = complementaryColor(baseColor);
+  const actionStyle = { color: ringColor, borderColor: ringColor };
   const handleClick = () => navigate(`/timers/${id}`);
+  const handleEditSave = (data: {
+    title: string;
+    hours: number;
+    minutes: number;
+    seconds: number;
+    color: number;
+  }) => {
+    const dur = data.hours * 3600 + data.minutes * 60 + data.seconds;
+    updateTimer(id, { title: data.title, color: data.color, duration: dur });
+  };
   return (
-    <div
-      className="p-4 border rounded shadow flex flex-col items-center"
+    <Card
+      className="relative flex flex-col items-center p-4"
       style={{ backgroundColor: baseColor, color: textColor }}
     >
+      <div className="absolute right-2 top-2 flex space-x-1">
+        <Button
+          size="icon"
+          variant="ghost"
+          style={actionStyle}
+          onClick={() => stopTimer(id)}
+        >
+          <RotateCcw className="h-4 w-4" />
+        </Button>
+        <Button
+          size="icon"
+          variant="ghost"
+          style={actionStyle}
+          onClick={() => setEditOpen(true)}
+        >
+          <Edit className="h-4 w-4" />
+        </Button>
+        <Button
+          size="icon"
+          variant="ghost"
+          style={actionStyle}
+          onClick={() => setDeleteOpen(true)}
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </div>
       <div className="cursor-pointer" onClick={handleClick}>
         <TimerCircle
           remaining={remaining}
@@ -37,40 +89,85 @@ const TimerCard: React.FC<Props> = ({ id }) => {
           paused={isPaused}
         />
       </div>
-      <div className="mt-2 text-sm font-semibold text-center break-all w-full">
-        {title}
-      </div>
-      <div className="flex space-x-1 mt-2">
-        {!isRunning && (
-          <Button size="icon" variant="outline" onClick={() => startTimer(id)}>
-            <Play className="h-4 w-4" />
-          </Button>
-        )}
-        {isRunning && !isPaused && (
-          <Button size="icon" variant="outline" onClick={() => pauseTimer(id)}>
-            <Pause className="h-4 w-4" />
-          </Button>
-        )}
-        {isRunning && isPaused && (
-          <Button size="icon" variant="outline" onClick={() => resumeTimer(id)}>
-            <Play className="h-4 w-4" />
-          </Button>
-        )}
-        {isRunning && (
-          <Button
-            variant="outline"
-            onClick={() => extendTimer(id, timerExtendSeconds)}
-          >
-            <Plus className="h-4 w-4 mr-1" />+{timerExtendSeconds}s
-          </Button>
-        )}
-        {!isRunning && remaining === 0 && (
-          <Button size="icon" variant="outline" onClick={() => startTimer(id)}>
-            <RotateCcw className="h-4 w-4" />
-          </Button>
-        )}
-      </div>
-    </div>
+      <CardHeader className="py-2">
+        <CardTitle className="text-base text-center break-all">
+          {title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col items-center p-0 space-y-2 mt-1">
+        <div className="flex space-x-1">
+          {!isRunning && (
+            <Button
+              size="icon"
+              variant="outline"
+              style={actionStyle}
+              onClick={() => startTimer(id)}
+            >
+              <Play className="h-4 w-4" />
+            </Button>
+          )}
+          {isRunning && !isPaused && (
+            <Button
+              size="icon"
+              variant="outline"
+              style={actionStyle}
+              onClick={() => pauseTimer(id)}
+            >
+              <Pause className="h-4 w-4" />
+            </Button>
+          )}
+          {isRunning && isPaused && (
+            <Button
+              size="icon"
+              variant="outline"
+              style={actionStyle}
+              onClick={() => resumeTimer(id)}
+            >
+              <Play className="h-4 w-4" />
+            </Button>
+          )}
+          {isRunning && (
+            <Button
+              variant="outline"
+              style={actionStyle}
+              onClick={() => extendTimer(id, timerExtendSeconds)}
+            >
+              <Plus className="h-4 w-4 mr-1" />+{timerExtendSeconds}s
+            </Button>
+          )}
+          {!isRunning && remaining === 0 && (
+            <Button
+              size="icon"
+              variant="outline"
+              style={actionStyle}
+              onClick={() => startTimer(id)}
+            >
+              <RotateCcw className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      </CardContent>
+      <TimerModal
+        isOpen={editOpen}
+        onClose={() => setEditOpen(false)}
+        onSave={handleEditSave}
+        initialData={{
+          title,
+          hours: Math.floor(duration / 3600),
+          minutes: Math.floor((duration % 3600) / 60),
+          seconds: Math.floor(duration % 60),
+          color,
+        }}
+      />
+      <ConfirmDialog
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        title={t("timers.deleteConfirm", { title })}
+        onConfirm={() => removeTimer(id)}
+        confirmText={t("common.delete")}
+        cancelText={t("common.cancel")}
+      />
+    </Card>
   );
 };
 

--- a/src/components/TimerCircle.tsx
+++ b/src/components/TimerCircle.tsx
@@ -75,7 +75,7 @@ const TimerCircle: React.FC<Props> = ({
         <div
           className={size > 100 ? "text-4xl font-bold" : "text-2xl font-bold"}
         >
-          {paused ? `||` : formatTime(remaining)}
+          {formatTime(remaining)}
         </div>
       </div>
     </div>

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -503,6 +503,7 @@
     "stop": "Stopp",
     "extend": "Verlängern",
     "detailTitle": "Timer",
+    "deleteConfirm": "Soll \"{{title}}\" wirklich gelöscht werden?",
     "none": "Keine Timer vorhanden"
   },
   "commandPalette": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -503,6 +503,7 @@
     "stop": "Stop",
     "extend": "Extend",
     "detailTitle": "Timer",
+    "deleteConfirm": "Are you sure you want to delete \"{{title}}\"?",
     "none": "No timers available"
   },
   "commandPalette": {

--- a/src/pages/Timers.tsx
+++ b/src/pages/Timers.tsx
@@ -5,12 +5,58 @@ import TimerModal from "@/components/TimerModal";
 import { Button } from "@/components/ui/button";
 import { useTimers } from "@/hooks/useTimers";
 import { useTranslation } from "react-i18next";
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  rectSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+
+interface SortableTimerProps {
+  id: string;
+}
+
+const SortableTimer: React.FC<SortableTimerProps> = ({ id }) => {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id });
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      <TimerCard id={id} />
+    </div>
+  );
+};
 
 const TimersPage: React.FC = () => {
   const { t } = useTranslation();
   const timers = useTimers((state) => state.timers);
   const addTimer = useTimers((state) => state.addTimer);
+  const reorderTimers = useTimers((state) => state.reorderTimers);
   const [open, setOpen] = useState(false);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+  );
+
+  const handleDragEnd = ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id) return;
+    const oldIndex = timers.findIndex((t) => t.id === active.id);
+    const newIndex = timers.findIndex((t) => t.id === over.id);
+    if (oldIndex !== -1 && newIndex !== -1) {
+      reorderTimers(oldIndex, newIndex);
+    }
+  };
 
   const handleSave = (data: {
     title: string;
@@ -23,11 +69,6 @@ const TimersPage: React.FC = () => {
     addTimer({ title: data.title, color: data.color, duration });
   };
 
-  const sorted = [...timers].sort((a, b) => {
-    if (a.isRunning === b.isRunning) return 0;
-    return a.isRunning ? -1 : 1;
-  });
-
   return (
     <div className="min-h-screen bg-background flex flex-col">
       <Navbar title={t("navbar.timers")} />
@@ -35,16 +76,27 @@ const TimersPage: React.FC = () => {
         <div className="mb-4 flex justify-center">
           <Button onClick={() => setOpen(true)}>{t("timers.new")}</Button>
         </div>
-        {sorted.length === 0 && (
+        {timers.length === 0 && (
           <p className="text-center text-muted-foreground">
             {t("timers.none")}
           </p>
         )}
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {sorted.map((t) => (
-            <TimerCard key={t.id} id={t.id} />
-          ))}
-        </div>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={timers.map((t) => t.id)}
+            strategy={rectSortingStrategy}
+          >
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 auto-rows-fr">
+              {timers.map((t) => (
+                <SortableTimer key={t.id} id={t.id} />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
       </div>
       <TimerModal
         isOpen={open}


### PR DESCRIPTION
## Summary
- keep original timer duration with new `baseDuration`
- place edit/delete/stop buttons in top-right of each timer card
- tint timer controls with complementary colors for readability
- allow free drag & drop sorting of timers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6866db01b53c832aa4e7f8a6dd9bf591