### PR TITLE
Display pomodoro stats with larger time units

### DIFF
--- a/src/components/PomodoroStats.tsx
+++ b/src/components/PomodoroStats.tsx
@@ -10,6 +10,7 @@ import {
   Tooltip,
 } from "recharts";
 import { useTranslation } from "react-i18next";
+import { formatDuration } from "@/utils/time";
 
 const PomodoroStats: React.FC = () => {
   const stats = usePomodoroStats();
@@ -24,10 +25,10 @@ const PomodoroStats: React.FC = () => {
         </CardHeader>
         <CardContent>
           <p className="text-sm">
-            {t("pomodoroStats.work")}: {stats.totalWorkMinutes} min
+            {t("pomodoroStats.work")}: {formatDuration(stats.totalWorkMinutes, t)}
           </p>
           <p className="text-sm">
-            {t("pomodoroStats.break")}: {stats.totalBreakMinutes} min
+            {t("pomodoroStats.break")}: {formatDuration(stats.totalBreakMinutes, t)}
           </p>
           <p className="text-sm mb-2">
             {t("pomodoroStats.cycles")}: {stats.totalCycles}
@@ -69,10 +70,10 @@ const PomodoroStats: React.FC = () => {
         </CardHeader>
         <CardContent>
           <p className="text-sm">
-            {t("pomodoroStats.work")}: {stats.todayTotals.workMinutes} min
+            {t("pomodoroStats.work")}: {formatDuration(stats.todayTotals.workMinutes, t)}
           </p>
           <p className="text-sm">
-            {t("pomodoroStats.break")}: {stats.todayTotals.breakMinutes} min
+            {t("pomodoroStats.break")}: {formatDuration(stats.todayTotals.breakMinutes, t)}
           </p>
           <p className="text-sm mb-2">
             {t("pomodoroStats.cycles")}: {stats.todayTotals.cycles}

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -656,6 +656,20 @@
     "friday": "Freitag",
     "saturday": "Samstag"
   },
+  "timeUnits": {
+    "minute": "Minute",
+    "minutes": "Minuten",
+    "hour": "Stunde",
+    "hours": "Stunden",
+    "day": "Tag",
+    "days": "Tage",
+    "week": "Woche",
+    "weeks": "Wochen",
+    "month": "Monat",
+    "months": "Monate",
+    "year": "Jahr",
+    "years": "Jahre"
+  },
   "ui": {
     "previous": "Zurück",
     "next": "Weiter",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -656,6 +656,20 @@
     "friday": "Friday",
     "saturday": "Saturday"
   },
+  "timeUnits": {
+    "minute": "minute",
+    "minutes": "minutes",
+    "hour": "hour",
+    "hours": "hours",
+    "day": "day",
+    "days": "days",
+    "week": "week",
+    "weeks": "weeks",
+    "month": "month",
+    "months": "months",
+    "year": "year",
+    "years": "years"
+  },
   "ui": {
     "previous": "Previous",
     "next": "Next",

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,24 @@
+export const formatDuration = (
+  minutes: number,
+  t: (key: string) => string,
+): string => {
+  const units = [
+    { value: 525600, single: "year", plural: "years" },
+    { value: 43200, single: "month", plural: "months" },
+    { value: 10080, single: "week", plural: "weeks" },
+    { value: 1440, single: "day", plural: "days" },
+    { value: 60, single: "hour", plural: "hours" },
+    { value: 1, single: "minute", plural: "minutes" },
+  ];
+  let remaining = Math.floor(minutes);
+  const parts: string[] = [];
+  for (const u of units) {
+    if (remaining >= u.value) {
+      const qty = Math.floor(remaining / u.value);
+      const key = qty === 1 ? u.single : u.plural;
+      parts.push(`${qty} ${t(`timeUnits.${key}`)}`);
+      remaining %= u.value;
+    }
+  }
+  return parts.length ? parts.join(", ") : `0 ${t("timeUnits.minutes")}`;
+};


### PR DESCRIPTION
## Summary
- add `formatDuration` helper for minute conversion
- display pomodoro statistics using human readable durations
- provide translations for time units in English and German

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866f2b0b964832aab2e19292c01805f