### PR TITLE
Adjust timer layout and sizing

### DIFF
--- a/src/components/TimerCard.tsx
+++ b/src/components/TimerCard.tsx
@@ -58,17 +58,9 @@ const TimerCard: React.FC<Props> = ({ id }) => {
           size="icon"
           variant="ghost"
           style={actionStyle}
-          onClick={() => stopTimer(id)}
-        >
-          <RotateCcw className="h-4 w-4" />
-        </Button>
-        <Button
-          size="icon"
-          variant="ghost"
-          style={actionStyle}
           onClick={() => setEditOpen(true)}
         >
-          <Edit className="h-4 w-4" />
+          <Edit className="h-4 w-4" style={{ color: ringColor }} />
         </Button>
         <Button
           size="icon"
@@ -76,7 +68,7 @@ const TimerCard: React.FC<Props> = ({ id }) => {
           style={actionStyle}
           onClick={() => setDeleteOpen(true)}
         >
-          <Trash2 className="h-4 w-4" />
+          <Trash2 className="h-4 w-4" style={{ color: ringColor }} />
         </Button>
       </div>
       <div className="cursor-pointer" onClick={handleClick}>
@@ -103,7 +95,7 @@ const TimerCard: React.FC<Props> = ({ id }) => {
               style={actionStyle}
               onClick={() => startTimer(id)}
             >
-              <Play className="h-4 w-4" />
+              <Play className="h-4 w-4" style={{ color: ringColor }} />
             </Button>
           )}
           {isRunning && !isPaused && (
@@ -113,7 +105,7 @@ const TimerCard: React.FC<Props> = ({ id }) => {
               style={actionStyle}
               onClick={() => pauseTimer(id)}
             >
-              <Pause className="h-4 w-4" />
+              <Pause className="h-4 w-4" style={{ color: ringColor }} />
             </Button>
           )}
           {isRunning && isPaused && (
@@ -123,7 +115,7 @@ const TimerCard: React.FC<Props> = ({ id }) => {
               style={actionStyle}
               onClick={() => resumeTimer(id)}
             >
-              <Play className="h-4 w-4" />
+              <Play className="h-4 w-4" style={{ color: ringColor }} />
             </Button>
           )}
           {isRunning && (
@@ -132,7 +124,18 @@ const TimerCard: React.FC<Props> = ({ id }) => {
               style={actionStyle}
               onClick={() => extendTimer(id, timerExtendSeconds)}
             >
-              <Plus className="h-4 w-4 mr-1" />+{timerExtendSeconds}s
+              <Plus className="h-4 w-4 mr-1" style={{ color: ringColor }} />
+              +{timerExtendSeconds}s
+            </Button>
+          )}
+          {isRunning && (
+            <Button
+              size="icon"
+              variant="outline"
+              style={actionStyle}
+              onClick={() => stopTimer(id)}
+            >
+              <RotateCcw className="h-4 w-4" style={{ color: ringColor }} />
             </Button>
           )}
           {!isRunning && remaining === 0 && (
@@ -142,7 +145,7 @@ const TimerCard: React.FC<Props> = ({ id }) => {
               style={actionStyle}
               onClick={() => startTimer(id)}
             >
-              <RotateCcw className="h-4 w-4" />
+              <RotateCcw className="h-4 w-4" style={{ color: ringColor }} />
             </Button>
           )}
         </div>

--- a/src/components/TimerCircle.tsx
+++ b/src/components/TimerCircle.tsx
@@ -73,7 +73,13 @@ const TimerCircle: React.FC<Props> = ({
       </svg>
       <div className="absolute inset-0 flex items-center justify-center">
         <div
-          className={size > 100 ? "text-4xl font-bold" : "text-2xl font-bold"}
+          className={
+            size >= 200
+              ? "text-7xl font-bold"
+              : size > 100
+                ? "text-4xl font-bold"
+                : "text-2xl font-bold"
+          }
         >
           {formatTime(remaining)}
         </div>

--- a/src/pages/TimerDetail.tsx
+++ b/src/pages/TimerDetail.tsx
@@ -61,7 +61,7 @@ const TimerDetail: React.FC = () => {
           duration={duration}
           color={color}
           ringColor={ringColor}
-          size={150}
+          size={200}
           paused={isPaused}
         />
         <div className="text-xl font-semibold" style={{ color: textColor }}>

--- a/src/pages/Timers.tsx
+++ b/src/pages/Timers.tsx
@@ -72,7 +72,7 @@ const TimersPage: React.FC = () => {
   return (
     <div className="min-h-screen bg-background flex flex-col">
       <Navbar title={t("navbar.timers")} />
-      <div className="p-4 flex-1">
+      <div className="flex-1 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
         <div className="mb-4 flex justify-center">
           <Button onClick={() => setOpen(true)}>{t("timers.new")}</Button>
         </div>


### PR DESCRIPTION
## Summary
- fix action icon colors in `TimerCard`
- move reset button next to play and extend controls
- center timers page content
- enlarge timer display in detail view
- scale text in `TimerCircle` for large sizes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686912aa9814832ab0cd763aacd8125a