### PR TITLE
Fix pomodoro customSounds load

### DIFF
--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -1120,7 +1120,13 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
             setShortcuts({ ...defaultShortcuts, ...data.shortcuts });
           }
           if (data.pomodoro) {
-            setPomodoro({ ...defaultPomodoro, ...data.pomodoro });
+            setPomodoro({
+              ...defaultPomodoro,
+              ...data.pomodoro,
+              customSounds: Array.isArray(data.pomodoro.customSounds)
+                ? data.pomodoro.customSounds
+                : defaultPomodoro.customSounds,
+            });
           }
           if (data.defaultTaskPriority) {
             setPriority(data.defaultTaskPriority);


### PR DESCRIPTION
## Summary
- ensure `customSounds` defaults to an array when loading pomodoro settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68691339fdc4832ab7aec02e7b3a5f88