### PR TITLE
Fix timer UI and improve ring progress

### DIFF
--- a/src/components/TimerCard.tsx
+++ b/src/components/TimerCard.tsx
@@ -37,6 +37,7 @@ const TimerCard: React.FC<Props> = ({ id }) => {
   const textColor = isColorDark(baseColor) ? "#fff" : "#000";
   const ringColor = complementaryColor(baseColor);
   const actionStyle = { color: ringColor, borderColor: ringColor };
+  const iconColor = isColorDark(ringColor) ? "#fff" : "#000";
   const handleClick = () => navigate(`/timers/${id}`);
   const handleEditSave = (data: {
     title: string;
@@ -50,7 +51,7 @@ const TimerCard: React.FC<Props> = ({ id }) => {
   };
   return (
     <Card
-      className="relative flex flex-col items-center p-4"
+      className="relative flex flex-col items-center p-4 min-h-[220px] min-w-[160px]"
       style={{ backgroundColor: baseColor, color: textColor }}
     >
       <div className="absolute right-2 top-2 flex space-x-1">
@@ -60,7 +61,7 @@ const TimerCard: React.FC<Props> = ({ id }) => {
           style={actionStyle}
           onClick={() => setEditOpen(true)}
         >
-          <Edit className="h-4 w-4" style={{ color: ringColor }} />
+          <Edit className="h-4 w-4" style={{ color: iconColor }} />
         </Button>
         <Button
           size="icon"
@@ -68,7 +69,7 @@ const TimerCard: React.FC<Props> = ({ id }) => {
           style={actionStyle}
           onClick={() => setDeleteOpen(true)}
         >
-          <Trash2 className="h-4 w-4" style={{ color: ringColor }} />
+          <Trash2 className="h-4 w-4" style={{ color: iconColor }} />
         </Button>
       </div>
       <div className="cursor-pointer" onClick={handleClick}>
@@ -95,7 +96,7 @@ const TimerCard: React.FC<Props> = ({ id }) => {
               style={actionStyle}
               onClick={() => startTimer(id)}
             >
-              <Play className="h-4 w-4" style={{ color: ringColor }} />
+              <Play className="h-4 w-4" style={{ color: iconColor }} />
             </Button>
           )}
           {isRunning && !isPaused && (
@@ -105,7 +106,7 @@ const TimerCard: React.FC<Props> = ({ id }) => {
               style={actionStyle}
               onClick={() => pauseTimer(id)}
             >
-              <Pause className="h-4 w-4" style={{ color: ringColor }} />
+              <Pause className="h-4 w-4" style={{ color: iconColor }} />
             </Button>
           )}
           {isRunning && isPaused && (
@@ -115,7 +116,7 @@ const TimerCard: React.FC<Props> = ({ id }) => {
               style={actionStyle}
               onClick={() => resumeTimer(id)}
             >
-              <Play className="h-4 w-4" style={{ color: ringColor }} />
+              <Play className="h-4 w-4" style={{ color: iconColor }} />
             </Button>
           )}
           {isRunning && (
@@ -124,8 +125,8 @@ const TimerCard: React.FC<Props> = ({ id }) => {
               style={actionStyle}
               onClick={() => extendTimer(id, timerExtendSeconds)}
             >
-              <Plus className="h-4 w-4 mr-1" style={{ color: ringColor }} />
-              +{timerExtendSeconds}s
+              <Plus className="h-4 w-4 mr-1" style={{ color: iconColor }} />+
+              {timerExtendSeconds}s
             </Button>
           )}
           {isRunning && (
@@ -135,7 +136,7 @@ const TimerCard: React.FC<Props> = ({ id }) => {
               style={actionStyle}
               onClick={() => stopTimer(id)}
             >
-              <RotateCcw className="h-4 w-4" style={{ color: ringColor }} />
+              <RotateCcw className="h-4 w-4" style={{ color: iconColor }} />
             </Button>
           )}
           {!isRunning && remaining === 0 && (
@@ -145,7 +146,7 @@ const TimerCard: React.FC<Props> = ({ id }) => {
               style={actionStyle}
               onClick={() => startTimer(id)}
             >
-              <RotateCcw className="h-4 w-4" style={{ color: ringColor }} />
+              <RotateCcw className="h-4 w-4" style={{ color: iconColor }} />
             </Button>
           )}
         </div>

--- a/src/components/TimerCircle.tsx
+++ b/src/components/TimerCircle.tsx
@@ -37,7 +37,8 @@ const TimerCircle: React.FC<Props> = ({
   const stroke = 8;
   const normalizedRadius = radius - stroke / 2;
   const circumference = normalizedRadius * 2 * Math.PI;
-  const progress = remaining / duration;
+  const progress =
+    duration > 0 ? Math.max(0, Math.min(1, remaining / duration)) : 0;
   const strokeDashoffset = circumference - progress * circumference;
   const baseColor = colorPalette[color] ?? colorPalette[0];
   const ringColor = ringColorProp ?? complementaryColor(baseColor);

--- a/src/pages/TimerDetail.tsx
+++ b/src/pages/TimerDetail.tsx
@@ -38,6 +38,8 @@ const TimerDetail: React.FC = () => {
   const baseColor = colorPalette[color] ?? colorPalette[0];
   const textColor = isColorDark(baseColor) ? "#fff" : "#000";
   const ringColor = complementaryColor(baseColor);
+  const actionStyle = { color: ringColor, borderColor: ringColor };
+  const iconColor = isColorDark(ringColor) ? "#fff" : "#000";
 
   const handleEditSave = (data: {
     title: string;
@@ -69,36 +71,61 @@ const TimerDetail: React.FC = () => {
         </div>
         <div className="flex space-x-2">
           {!isRunning && (
-            <Button onClick={() => startTimer(id!)}>
-              <Play className="h-4 w-4 mr-2" /> {t("timers.start")}
+            <Button style={actionStyle} onClick={() => startTimer(id!)}>
+              <Play className="h-4 w-4 mr-2" style={{ color: iconColor }} />
+              {t("timers.start")}
             </Button>
           )}
           {isRunning && !isPaused && (
-            <Button variant="outline" onClick={() => pauseTimer(id!)}>
-              <Pause className="h-4 w-4 mr-2" /> {t("timers.pause")}
+            <Button
+              variant="outline"
+              style={actionStyle}
+              onClick={() => pauseTimer(id!)}
+            >
+              <Pause className="h-4 w-4 mr-2" style={{ color: iconColor }} />
+              {t("timers.pause")}
             </Button>
           )}
           {isRunning && isPaused && (
-            <Button variant="outline" onClick={() => resumeTimer(id!)}>
-              <Play className="h-4 w-4 mr-2" /> {t("timers.resume")}
+            <Button
+              variant="outline"
+              style={actionStyle}
+              onClick={() => resumeTimer(id!)}
+            >
+              <Play className="h-4 w-4 mr-2" style={{ color: iconColor }} />
+              {t("timers.resume")}
             </Button>
           )}
           {isRunning && (
             <Button
               variant="outline"
+              style={actionStyle}
               onClick={() => extendTimer(id!, timerExtendSeconds)}
             >
-              <Plus className="h-4 w-4 mr-2" />
+              <Plus className="h-4 w-4 mr-2" style={{ color: iconColor }} />
               {t("timers.extend")} +{timerExtendSeconds}s
             </Button>
           )}
           {isRunning && (
-            <Button variant="outline" onClick={() => stopTimer(id!)}>
-              <RotateCcw className="h-4 w-4 mr-2" /> {t("timers.stop")}
+            <Button
+              variant="outline"
+              style={actionStyle}
+              onClick={() => stopTimer(id!)}
+            >
+              <RotateCcw
+                className="h-4 w-4 mr-2"
+                style={{ color: iconColor }}
+              />
+              {t("timers.stop")}
             </Button>
           )}
-          <Button variant="outline" onClick={() => setEditOpen(true)}>
-            <Edit className="h-4 w-4 mr-2" /> {t("common.edit")}
+          <Button
+            variant="outline"
+            style={actionStyle}
+            onClick={() => setEditOpen(true)}
+          >
+            <Edit className="h-4 w-4 mr-2" style={{ color: iconColor }} />
+            {t("common.edit")}
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add minimum size for timer cards so buttons don't overlap
- adapt icon color to high-contrast black/white
- clamp timer ring progress calculations
- apply same button styling on timer detail page

## Testing
- `npx vitest run` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6869197e9350832aa2d0a2bf39f66766