### PR TITLE
Fix timer card visuals

### DIFF
--- a/src/components/TimerCard.tsx
+++ b/src/components/TimerCard.tsx
@@ -1,12 +1,26 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
-import { Play, Pause, RotateCcw, Plus, Edit, Trash2 } from "lucide-react";
+import {
+  Play,
+  Pause,
+  RotateCcw,
+  Plus,
+  Edit,
+  Trash2,
+  Settings,
+} from "lucide-react";
 import TimerCircle from "./TimerCircle";
 import { useTimers } from "@/hooks/useTimers";
 import { useSettings } from "@/hooks/useSettings";
 import { isColorDark, complementaryColor } from "@/utils/color";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
 import ConfirmDialog from "@/components/ConfirmDialog";
 import TimerModal from "./TimerModal";
 import { useTranslation } from "react-i18next";
@@ -54,23 +68,32 @@ const TimerCard: React.FC<Props> = ({ id }) => {
       className="relative flex flex-col items-center p-4 min-h-[220px] min-w-[160px]"
       style={{ backgroundColor: baseColor, color: textColor }}
     >
-      <div className="absolute right-2 top-2 flex space-x-1">
-        <Button
-          size="icon"
-          variant="ghost"
-          style={actionStyle}
-          onClick={() => setEditOpen(true)}
-        >
-          <Edit className="h-4 w-4" style={{ color: iconColor }} />
-        </Button>
-        <Button
-          size="icon"
-          variant="ghost"
-          style={actionStyle}
-          onClick={() => setDeleteOpen(true)}
-        >
-          <Trash2 className="h-4 w-4" style={{ color: iconColor }} />
-        </Button>
+      <div className="absolute right-2 top-2">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              size="icon"
+              variant="ghost"
+              style={actionStyle}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Settings className="h-4 w-4" style={{ color: iconColor }} />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="bg-background z-50">
+            <DropdownMenuItem onClick={() => setEditOpen(true)}>
+              <Edit className="h-4 w-4 mr-2" />
+              {t("common.edit")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => setDeleteOpen(true)}
+              className="text-destructive"
+            >
+              <Trash2 className="h-4 w-4 mr-2" />
+              {t("common.delete")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
       <div className="cursor-pointer" onClick={handleClick}>
         <TimerCircle
@@ -125,8 +148,8 @@ const TimerCard: React.FC<Props> = ({ id }) => {
               style={actionStyle}
               onClick={() => extendTimer(id, timerExtendSeconds)}
             >
-              <Plus className="h-4 w-4 mr-1" style={{ color: iconColor }} />+
-              {timerExtendSeconds}s
+              <Plus className="h-4 w-4 mr-1" style={{ color: iconColor }} />
+              <span style={{ color: iconColor }}>+{timerExtendSeconds}s</span>
             </Button>
           )}
           {isRunning && (

--- a/src/components/TimerCircle.tsx
+++ b/src/components/TimerCircle.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useSettings } from "@/hooks/useSettings";
-import { complementaryColor } from "@/utils/color";
+import { complementaryColor, isColorDark, adjustColor } from "@/utils/color";
 
 interface Props {
   remaining: number;
@@ -42,15 +42,18 @@ const TimerCircle: React.FC<Props> = ({
   const strokeDashoffset = circumference - progress * circumference;
   const baseColor = colorPalette[color] ?? colorPalette[0];
   const ringColor = ringColorProp ?? complementaryColor(baseColor);
+  const trackColor = isColorDark(baseColor)
+    ? adjustColor(baseColor, -30)
+    : adjustColor(baseColor, 30);
   return (
     <div className="relative" style={{ width: radius * 2, height: radius * 2 }}>
       <svg
         width={radius * 2}
         height={radius * 2}
-        className="transform -rotate-90"
+        className="transform -rotate-90 scale-x-[-1]"
       >
         <circle
-          stroke="hsl(var(--muted))"
+          stroke={trackColor}
           fill="transparent"
           strokeWidth={stroke}
           r={normalizedRadius}

--- a/src/pages/TimerDetail.tsx
+++ b/src/pages/TimerDetail.tsx
@@ -103,7 +103,9 @@ const TimerDetail: React.FC = () => {
               onClick={() => extendTimer(id!, timerExtendSeconds)}
             >
               <Plus className="h-4 w-4 mr-2" style={{ color: iconColor }} />
-              {t("timers.extend")} +{timerExtendSeconds}s
+              <span style={{ color: iconColor }}>
+                {t("timers.extend")} +{timerExtendSeconds}s
+              </span>
             </Button>
           )}
           {isRunning && (


### PR DESCRIPTION
## Summary
- improve timer ring colors and direction
- add dropdown actions on timer card
- ensure extend button text is visible

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68691c79659c832a80b672cee0c27364