### PR TITLE
Fix select and service worker errors

### DIFF
--- a/src/components/ServiceWorkerManager.tsx
+++ b/src/components/ServiceWorkerManager.tsx
@@ -10,7 +10,7 @@ const ServiceWorkerManager: React.FC = () => {
     if (offlineCache) {
       const swPath = import.meta.env.DEV ? "/dev-sw.js?dev-sw" : "/sw.js";
       navigator.serviceWorker
-        .register(swPath, { type: "module" })
+        .register(swPath, import.meta.env.DEV ? undefined : { type: "module" })
         .catch((err) => console.error("SW registration failed", err));
     } else {
       navigator.serviceWorker.getRegistrations().then((regs) => {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -852,16 +852,16 @@ const SettingsPage: React.FC = () => {
                     {t("settingsPage.workSound")}
                   </Label>
                   <Select
-                    value={pomodoro.workSound}
-                    onValueChange={(v) => updatePomodoro("workSound", v)}
+                    value={pomodoro.workSound || "none"}
+                    onValueChange={(v) =>
+                      updatePomodoro("workSound", v === "none" ? "" : v)
+                    }
                   >
                     <SelectTrigger id="workSound">
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="">
-                        {t("common.none")}
-                      </SelectItem>
+                      <SelectItem value="none">{t("common.none")}</SelectItem>
                       {builtInSounds.map((s) => (
                         <SelectItem key={s.url} value={s.url}>
                           {s.label}
@@ -880,16 +880,16 @@ const SettingsPage: React.FC = () => {
                     {t("settingsPage.breakSound")}
                   </Label>
                   <Select
-                    value={pomodoro.breakSound}
-                    onValueChange={(v) => updatePomodoro("breakSound", v)}
+                    value={pomodoro.breakSound || "none"}
+                    onValueChange={(v) =>
+                      updatePomodoro("breakSound", v === "none" ? "" : v)
+                    }
                   >
                     <SelectTrigger id="breakSound">
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="">
-                        {t("common.none")}
-                      </SelectItem>
+                      <SelectItem value="none">{t("common.none")}</SelectItem>
                       {builtInSounds.map((s) => (
                         <SelectItem key={s.url} value={s.url}>
                           {s.label}


### PR DESCRIPTION
## Summary
- map empty pomodoro sound values to a sentinel value so Radix select items are always non-empty
- skip module registration for the dev service worker

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68691cd33e9c832abd0176b44e6e1675