### PR TITLE
Add sound testing in Pomodoro settings

### DIFF
--- a/src/components/PomodoroTimer.tsx
+++ b/src/components/PomodoroTimer.tsx
@@ -6,57 +6,11 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { useSettings, SettingsProvider } from "@/hooks/useSettings";
 import { hslToHex, hexToHsl, complementaryColor } from "@/utils/color";
+import { playSound } from "@/utils/sounds";
 import {
   usePomodoroHistory,
   PomodoroHistoryProvider,
 } from "@/hooks/usePomodoroHistory.tsx";
-
-type AudioContextConstructor = typeof AudioContext;
-
-const getAudioContext = (): AudioContext | null => {
-  const Ctor =
-    window.AudioContext ||
-    (window as unknown as { webkitAudioContext?: AudioContextConstructor })
-      .webkitAudioContext;
-  return Ctor ? new Ctor() : null;
-};
-
-const playSound = (url?: string) => {
-  if (url) {
-    if (url.startsWith("tone:")) {
-      const [, freqStr, durStr] = url.split(":");
-      const freq = parseFloat(freqStr) || 440;
-      const dur = parseFloat(durStr) || 0.4;
-      const ctx = getAudioContext();
-      if (ctx) {
-        const osc = ctx.createOscillator();
-        osc.type = "sine";
-        osc.frequency.setValueAtTime(freq, ctx.currentTime);
-        osc.connect(ctx.destination);
-        osc.start();
-        osc.stop(ctx.currentTime + dur);
-        return;
-      }
-    } else {
-      try {
-        const audio = new Audio(url);
-        audio.play().catch(() => {});
-        return;
-      } catch {
-        // ignore errors
-      }
-    }
-  }
-  const ctx = getAudioContext();
-  if (ctx) {
-    const osc = ctx.createOscillator();
-    osc.type = "sine";
-    osc.frequency.setValueAtTime(440, ctx.currentTime);
-    osc.connect(ctx.destination);
-    osc.start();
-    osc.stop(ctx.currentTime + 0.4);
-  }
-};
 
 interface PomodoroState {
   isRunning: boolean;

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -92,6 +92,7 @@
     "customThemeName": "Name des Themes",
     "addTheme": "Theme hinzufügen",
     "addSound": "Sound hinzufügen",
+    "testSound": "Sound testen",
     "customSoundUrl": "Sound-URL",
     "yourSounds": "Eigene Sounds",
     "yourThemes": "Eigene Themes",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -92,6 +92,7 @@
     "customThemeName": "Theme name",
     "addTheme": "Add Theme",
     "addSound": "Add Sound",
+    "testSound": "Test Sound",
     "customSoundUrl": "Sound URL",
     "yourSounds": "Your Sounds",
     "yourThemes": "Your Themes",

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import Navbar from "@/components/Navbar";
 import { useSettings, themePresets } from "@/hooks/useSettings";
-import { builtInSounds } from "@/utils/sounds";
+import { builtInSounds, playSound } from "@/utils/sounds";
 import { Task, Category, Note, Flashcard, Deck } from "@/types";
 import { Input } from "@/components/ui/input";
 import KeyInput from "@/components/KeyInput";
@@ -851,57 +851,75 @@ const SettingsPage: React.FC = () => {
                   <Label htmlFor="workSound">
                     {t("settingsPage.workSound")}
                   </Label>
-                  <Select
-                    value={pomodoro.workSound || "none"}
-                    onValueChange={(v) =>
-                      updatePomodoro("workSound", v === "none" ? "" : v)
-                    }
-                  >
-                    <SelectTrigger id="workSound">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="none">{t("common.none")}</SelectItem>
-                      {builtInSounds.map((s) => (
-                        <SelectItem key={s.url} value={s.url}>
-                          {s.label}
-                        </SelectItem>
-                      ))}
-                      {pomodoro.customSounds.map((url) => (
-                        <SelectItem key={url} value={url}>
-                          {url}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <div className="flex items-center gap-2">
+                    <Select
+                      value={pomodoro.workSound || "none"}
+                      onValueChange={(v) =>
+                        updatePomodoro("workSound", v === "none" ? "" : v)
+                      }
+                    >
+                      <SelectTrigger id="workSound">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="none">{t("common.none")}</SelectItem>
+                        {builtInSounds.map((s) => (
+                          <SelectItem key={s.url} value={s.url}>
+                            {s.label}
+                          </SelectItem>
+                        ))}
+                        {pomodoro.customSounds.map((url) => (
+                          <SelectItem key={url} value={url}>
+                            {url}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => playSound(pomodoro.workSound)}
+                    >
+                      {t("settingsPage.testSound")}
+                    </Button>
+                  </div>
                 </div>
                 <div>
                   <Label htmlFor="breakSound">
                     {t("settingsPage.breakSound")}
                   </Label>
-                  <Select
-                    value={pomodoro.breakSound || "none"}
-                    onValueChange={(v) =>
-                      updatePomodoro("breakSound", v === "none" ? "" : v)
-                    }
-                  >
-                    <SelectTrigger id="breakSound">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="none">{t("common.none")}</SelectItem>
-                      {builtInSounds.map((s) => (
-                        <SelectItem key={s.url} value={s.url}>
-                          {s.label}
-                        </SelectItem>
-                      ))}
-                      {pomodoro.customSounds.map((url) => (
-                        <SelectItem key={url} value={url}>
-                          {url}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <div className="flex items-center gap-2">
+                    <Select
+                      value={pomodoro.breakSound || "none"}
+                      onValueChange={(v) =>
+                        updatePomodoro("breakSound", v === "none" ? "" : v)
+                      }
+                    >
+                      <SelectTrigger id="breakSound">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="none">{t("common.none")}</SelectItem>
+                        {builtInSounds.map((s) => (
+                          <SelectItem key={s.url} value={s.url}>
+                            {s.label}
+                          </SelectItem>
+                        ))}
+                        {pomodoro.customSounds.map((url) => (
+                          <SelectItem key={url} value={url}>
+                            {url}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => playSound(pomodoro.breakSound)}
+                    >
+                      {t("settingsPage.testSound")}
+                    </Button>
+                  </div>
                 </div>
                 <div className="flex items-center gap-2 mt-2">
                   <Input

--- a/src/utils/sounds.ts
+++ b/src/utils/sounds.ts
@@ -10,3 +10,50 @@ export const builtInSounds: SoundOption[] = [
   { label: "Beep 2", url: "tone:660:0.4" },
   { label: "Beep 3", url: "tone:880:0.4" },
 ];
+
+type AudioContextConstructor = typeof AudioContext;
+
+const getAudioContext = (): AudioContext | null => {
+  const Ctor =
+    window.AudioContext ||
+    (window as unknown as { webkitAudioContext?: AudioContextConstructor })
+      .webkitAudioContext;
+  return Ctor ? new Ctor() : null;
+};
+
+export const playSound = (url?: string) => {
+  if (url) {
+    if (url.startsWith("tone:")) {
+      const [, freqStr, durStr] = url.split(":");
+      const freq = parseFloat(freqStr) || 440;
+      const dur = parseFloat(durStr) || 0.4;
+      const ctx = getAudioContext();
+      if (ctx) {
+        const osc = ctx.createOscillator();
+        osc.type = "sine";
+        osc.frequency.setValueAtTime(freq, ctx.currentTime);
+        osc.connect(ctx.destination);
+        osc.start();
+        osc.stop(ctx.currentTime + dur);
+        return;
+      }
+    } else {
+      try {
+        const audio = new Audio(url);
+        audio.play().catch(() => {});
+        return;
+      } catch {
+        // ignore errors
+      }
+    }
+  }
+  const ctx = getAudioContext();
+  if (ctx) {
+    const osc = ctx.createOscillator();
+    osc.type = "sine";
+    osc.frequency.setValueAtTime(440, ctx.currentTime);
+    osc.connect(ctx.destination);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.4);
+  }
+};


### PR DESCRIPTION
## Summary
- expose `playSound` utility
- reuse it in `PomodoroTimer`
- add sound test buttons in the settings
- update translations for new label

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68692056621c832a9e5c7d7e173b56d8