### PR TITLE
Improve timer button colors

### DIFF
--- a/src/components/TimerCard.tsx
+++ b/src/components/TimerCard.tsx
@@ -12,7 +12,7 @@ import {
 import TimerCircle from "./TimerCircle";
 import { useTimers } from "@/hooks/useTimers";
 import { useSettings } from "@/hooks/useSettings";
-import { isColorDark, complementaryColor, adjustColor } from "@/utils/color";
+import { isColorDark, complementarySameHue, adjustColor } from "@/utils/color";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -49,14 +49,15 @@ const TimerCard: React.FC<Props> = ({ id }) => {
   const { title, color, duration, remaining, isRunning, isPaused } = timer;
   const baseColor = colorPalette[color] ?? colorPalette[0];
   const textColor = isColorDark(baseColor) ? "#fff" : "#000";
-  const ringColor = complementaryColor(baseColor);
   const trackColor = isColorDark(baseColor)
     ? adjustColor(baseColor, -30)
     : adjustColor(baseColor, 30);
+  const ringColor = complementarySameHue(trackColor);
+  const hoverColor = complementarySameHue(ringColor);
   const actionStyle = {
     color: ringColor,
     borderColor: ringColor,
-    "--hover-color": trackColor,
+    "--hover-color": hoverColor,
   } as React.CSSProperties;
   const iconColor = isColorDark(ringColor) ? "#fff" : "#000";
   const handleClick = () => navigate(`/timers/${id}`);

--- a/src/components/TimerCircle.tsx
+++ b/src/components/TimerCircle.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useSettings } from "@/hooks/useSettings";
-import { complementaryColor, isColorDark, adjustColor } from "@/utils/color";
+import { complementarySameHue, isColorDark, adjustColor } from "@/utils/color";
 
 interface Props {
   remaining: number;
@@ -41,10 +41,10 @@ const TimerCircle: React.FC<Props> = ({
     duration > 0 ? Math.max(0, Math.min(1, remaining / duration)) : 0;
   const strokeDashoffset = circumference - progress * circumference;
   const baseColor = colorPalette[color] ?? colorPalette[0];
-  const ringColor = ringColorProp ?? complementaryColor(baseColor);
   const trackColor = isColorDark(baseColor)
     ? adjustColor(baseColor, -30)
     : adjustColor(baseColor, 30);
+  const ringColor = ringColorProp ?? complementarySameHue(trackColor);
   return (
     <div className="relative" style={{ width: radius * 2, height: radius * 2 }}>
       <svg

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -91,6 +91,23 @@ export const adjustColor = (hex: string, percent: number): string => {
   return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
 };
 
+export const complementarySameHue = (
+  hex: string,
+  start = 60,
+  threshold = 128,
+): string => {
+  const dark = isColorDark(hex);
+  let perc = dark ? start : -start;
+  let adjusted = adjustColor(hex, perc);
+  let contrast = colorContrast(hex, adjusted);
+  while (contrast < threshold && Math.abs(perc) < 100) {
+    perc += perc > 0 ? 10 : -10;
+    adjusted = adjustColor(hex, perc);
+    contrast = colorContrast(hex, adjusted);
+  }
+  return adjusted;
+};
+
 export const complementaryColor = (hex: string): string => {
   const dark = isColorDark(hex);
   const adjusted = adjustColor(hex, dark ? 60 : -60);


### PR DESCRIPTION
## Summary
- add `complementarySameHue` helper to pick contrasting shades
- use new color helper in `TimerCard` and `TimerCircle`

## Testing
- `npm run typecheck`
- `npm run lint`
- `CI=true npm test`
- `npm run format:check` *(fails: code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_6869238707ec832abd5ac151e2e364ea