### PR TITLE
Fix timer hook import

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ import TimersPage from "./pages/Timers";
 import TimerDetailPage from "./pages/TimerDetail";
 import ClockPage from "./pages/Clock";
 import { PomodoroHistoryProvider } from "@/hooks/usePomodoroHistory.tsx";
-import { TimersProvider } from "@/hooks/useTimers";
+import { TimersProvider } from "@/hooks/useTimers.tsx";
 import ReleaseNotesModal from "@/components/ReleaseNotesModal";
 import SurprisePage from "./pages/Surprise";
 import SurpriseListener from "@/components/SurpriseListener";

--- a/src/components/TimerCard.tsx
+++ b/src/components/TimerCard.tsx
@@ -10,7 +10,7 @@ import {
   Settings,
 } from "lucide-react";
 import TimerCircle from "./TimerCircle";
-import { useTimers } from "@/hooks/useTimers";
+import { useTimers } from "@/hooks/useTimers.tsx";
 import { useSettings } from "@/hooks/useSettings";
 import { isColorDark, complementarySameHue, adjustColor } from "@/utils/color";
 import { Button } from "@/components/ui/button";

--- a/src/components/TimerTicker.tsx
+++ b/src/components/TimerTicker.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useTimers } from "@/hooks/useTimers";
+import { useTimers } from "@/hooks/useTimers.tsx";
 
 const TimerTicker = () => {
   const tick = useTimers((state) => state.tick);

--- a/src/pages/TimerDetail.tsx
+++ b/src/pages/TimerDetail.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import Navbar from "@/components/Navbar";
 import TimerCircle from "@/components/TimerCircle";
 import { Button } from "@/components/ui/button";
-import { useTimers } from "@/hooks/useTimers";
+import { useTimers } from "@/hooks/useTimers.tsx";
 import { Play, Pause, RotateCcw, Plus, Edit } from "lucide-react";
 import { useSettings } from "@/hooks/useSettings";
 import { isColorDark, complementaryColor } from "@/utils/color";

--- a/src/pages/Timers.tsx
+++ b/src/pages/Timers.tsx
@@ -3,7 +3,7 @@ import Navbar from "@/components/Navbar";
 import TimerCard from "@/components/TimerCard";
 import TimerModal from "@/components/TimerModal";
 import { Button } from "@/components/ui/button";
-import { useTimers } from "@/hooks/useTimers";
+import { useTimers } from "@/hooks/useTimers.tsx";
 import { useTranslation } from "react-i18next";
 import {
   DndContext,


### PR DESCRIPTION
## Summary
- fix path for timer hook imports

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_686a69786398832ab76ea293440648b3