### PR TITLE
Decouple habits from tasks

### DIFF
--- a/src/components/HabitModal.tsx
+++ b/src/components/HabitModal.tsx
@@ -107,7 +107,9 @@ const HabitModal: React.FC<HabitModalProps> = ({
             <Label htmlFor="recurrence">{t("habitModal.recurrence")}</Label>
             <Select
               value={formData.recurrencePattern}
-              onValueChange={(v) => handleChange("recurrencePattern", v as any)}
+              onValueChange={(v: HabitFormData["recurrencePattern"]) =>
+                handleChange("recurrencePattern", v)
+              }
             >
               <SelectTrigger>
                 <SelectValue />

--- a/src/components/HabitModal.tsx
+++ b/src/components/HabitModal.tsx
@@ -1,0 +1,171 @@
+import React, { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { Habit, HabitFormData } from "@/types";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useSettings } from "@/hooks/useSettings";
+
+interface HabitModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (data: HabitFormData) => void;
+  habit?: Habit;
+}
+
+const HabitModal: React.FC<HabitModalProps> = ({
+  isOpen,
+  onClose,
+  onSave,
+  habit,
+}) => {
+  const { t } = useTranslation();
+  const { colorPalette } = useSettings();
+  const [formData, setFormData] = useState<HabitFormData>({
+    title: "",
+    color: 0,
+  });
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (habit) {
+      setFormData({
+        title: habit.title,
+        color: habit.color,
+        recurrencePattern: habit.recurrencePattern,
+        customIntervalDays: habit.customIntervalDays,
+        startWeekday: habit.startWeekday,
+        startDate: habit.startDate ? new Date(habit.startDate) : undefined,
+      });
+    } else {
+      setFormData({ title: "", color: 0 });
+    }
+  }, [isOpen, habit]);
+
+  const handleChange = <K extends keyof HabitFormData>(
+    field: K,
+    val: HabitFormData[K],
+  ) => {
+    setFormData((prev) => ({ ...prev, [field]: val }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (formData.title.trim()) {
+      onSave(formData);
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {habit ? t("habitModal.editTitle") : t("habitModal.newTitle")}
+          </DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <Label htmlFor="title">{t("habitModal.title")}</Label>
+            <Input
+              id="title"
+              value={formData.title}
+              onChange={(e) => handleChange("title", e.target.value)}
+              required
+              autoFocus
+            />
+          </div>
+          <div>
+            <Label>{t("habitModal.color")}</Label>
+            <div className="flex space-x-2 mt-2">
+              {colorPalette.map((c, idx) => (
+                <button
+                  key={idx}
+                  type="button"
+                  className={`w-8 h-8 rounded-full border-2 transition-all ${formData.color === idx ? "border-gray-800 scale-110" : "border-gray-300 hover:scale-105"}`}
+                  style={{ backgroundColor: c }}
+                  onClick={() => handleChange("color", idx)}
+                />
+              ))}
+            </div>
+          </div>
+          <div>
+            <Label htmlFor="recurrence">{t("habitModal.recurrence")}</Label>
+            <Select
+              value={formData.recurrencePattern}
+              onValueChange={(v) => handleChange("recurrencePattern", v as any)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="daily">{t("habitModal.daily")}</SelectItem>
+                <SelectItem value="weekly">{t("habitModal.weekly")}</SelectItem>
+                <SelectItem value="monthly">
+                  {t("habitModal.monthly")}
+                </SelectItem>
+                <SelectItem value="yearly">{t("habitModal.yearly")}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          {formData.recurrencePattern === "weekly" && (
+            <div>
+              <Label htmlFor="weekday">{t("taskModal.weekday")}</Label>
+              <Input
+                id="weekday"
+                type="number"
+                value={formData.startWeekday ?? ""}
+                onChange={(e) =>
+                  handleChange(
+                    "startWeekday",
+                    e.target.value ? Number(e.target.value) : undefined,
+                  )
+                }
+              />
+            </div>
+          )}
+          {formData.recurrencePattern === "daily" && (
+            <div>
+              <Label htmlFor="custom">{t("habitModal.customInterval")}</Label>
+              <Input
+                id="custom"
+                type="number"
+                value={formData.customIntervalDays ?? ""}
+                onChange={(e) =>
+                  handleChange(
+                    "customIntervalDays",
+                    e.target.value ? Number(e.target.value) : undefined,
+                  )
+                }
+              />
+            </div>
+          )}
+          <div className="flex justify-end space-x-2 pt-4">
+            <Button type="button" variant="outline" onClick={onClose}>
+              {t("common.cancel")}
+            </Button>
+            <Button type="submit">
+              {habit ? t("common.save") : t("common.create")}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default HabitModal;

--- a/src/hooks/useHabitStore.tsx
+++ b/src/hooks/useHabitStore.tsx
@@ -1,0 +1,140 @@
+import React, { useState, useEffect, createContext, useContext } from "react";
+import { Habit, HabitFormData } from "@/types";
+import {
+  loadOfflineData,
+  updateOfflineData,
+  syncWithServer,
+} from "@/utils/offline";
+
+const API_URL = "/api/habits";
+
+const generateId = () =>
+  (crypto as { randomUUID?: () => string }).randomUUID?.() ||
+  `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+const useHabitStoreImpl = () => {
+  const [habits, setHabits] = useState<Habit[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      const offline = loadOfflineData();
+      if (offline) {
+        setHabits(
+          (offline.habits || []).map((h) => ({
+            ...h,
+            createdAt: new Date(h.createdAt),
+            updatedAt: new Date(h.updatedAt),
+          })),
+        );
+      }
+      const synced = await syncWithServer();
+      setHabits(
+        (synced.habits || []).map((h) => ({
+          ...h,
+          createdAt: new Date(h.createdAt),
+          updatedAt: new Date(h.updatedAt),
+        })),
+      );
+      setLoaded(true);
+    };
+    load();
+  }, []);
+
+  useEffect(() => {
+    if (!loaded) return;
+    const save = async () => {
+      try {
+        updateOfflineData({ habits });
+        if (navigator.onLine) {
+          await fetch(API_URL, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(habits),
+          });
+        }
+      } catch (err) {
+        console.error("Error saving habits", err);
+      }
+      if (navigator.onLine) await syncWithServer();
+    };
+    save();
+  }, [habits, loaded]);
+
+  const addHabit = (data: HabitFormData) => {
+    const newHabit: Habit = {
+      ...data,
+      id: generateId(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      completions: [],
+      order: habits.length,
+      pinned: false,
+    };
+    setHabits((prev) => [...prev, newHabit]);
+  };
+
+  const updateHabit = (id: string, updates: Partial<Habit>) => {
+    setHabits((prev) =>
+      prev.map((h) =>
+        h.id === id ? { ...h, ...updates, updatedAt: new Date() } : h,
+      ),
+    );
+  };
+
+  const deleteHabit = (id: string) => {
+    setHabits((prev) => prev.filter((h) => h.id !== id));
+  };
+
+  const toggleHabitCompletion = (id: string, date: string) => {
+    setHabits((prev) =>
+      prev.map((h) => {
+        if (h.id !== id) return h;
+        const set = new Set(h.completions);
+        if (set.has(date)) set.delete(date);
+        else set.add(date);
+        return { ...h, completions: Array.from(set), updatedAt: new Date() };
+      }),
+    );
+  };
+
+  const reorderHabits = (from: number, to: number) => {
+    setHabits((prev) => {
+      const sorted = [...prev].sort((a, b) => a.order - b.order);
+      const [item] = sorted.splice(from, 1);
+      sorted.splice(to, 0, item);
+      return sorted.map((h, idx) => ({ ...h, order: idx }));
+    });
+  };
+
+  return {
+    habits,
+    addHabit,
+    updateHabit,
+    deleteHabit,
+    toggleHabitCompletion,
+    reorderHabits,
+  };
+};
+
+type HabitStore = ReturnType<typeof useHabitStoreImpl>;
+
+const HabitStoreContext = createContext<HabitStore | null>(null);
+
+export const HabitStoreProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const store = useHabitStoreImpl();
+  return (
+    <HabitStoreContext.Provider value={store}>
+      {children}
+    </HabitStoreContext.Provider>
+  );
+};
+
+export const useHabitStore = () => {
+  const ctx = useContext(HabitStoreContext);
+  if (!ctx)
+    throw new Error("useHabitStore must be used within HabitStoreProvider");
+  return ctx;
+};

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -996,6 +996,8 @@ interface SettingsContextValue {
   toggleShowPinnedNotes: () => void;
   showPinnedCategories: boolean;
   toggleShowPinnedCategories: () => void;
+  showPinnedHabits: boolean;
+  toggleShowPinnedHabits: () => void;
   collapseSubtasksByDefault: boolean;
   toggleCollapseSubtasksByDefault: () => void;
   defaultTaskLayout: "list" | "grid";
@@ -1082,6 +1084,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
   const [showPinnedTasks, setShowPinnedTasks] = useState(true);
   const [showPinnedNotes, setShowPinnedNotes] = useState(true);
   const [showPinnedCategories, setShowPinnedCategories] = useState(true);
+  const [showPinnedHabits, setShowPinnedHabits] = useState(true);
   const [collapseSubtasksByDefault, setCollapseSubtasksByDefault] =
     useState(false);
   const [defaultTaskLayout, setDefaultTaskLayout] = useState<"list" | "grid">(
@@ -1197,6 +1200,9 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
           if (typeof data.showPinnedCategories === "boolean") {
             setShowPinnedCategories(data.showPinnedCategories);
           }
+          if (typeof data.showPinnedHabits === "boolean") {
+            setShowPinnedHabits(data.showPinnedHabits);
+          }
           if (typeof data.collapseSubtasksByDefault === "boolean") {
             setCollapseSubtasksByDefault(data.collapseSubtasksByDefault);
           }
@@ -1282,6 +1288,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
             showPinnedTasks,
             showPinnedNotes,
             showPinnedCategories,
+            showPinnedHabits,
             collapseSubtasksByDefault,
             defaultTaskLayout,
             showCompletedByDefault,
@@ -1323,6 +1330,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
     showPinnedTasks,
     showPinnedNotes,
     showPinnedCategories,
+    showPinnedHabits,
     collapseSubtasksByDefault,
     defaultTaskLayout,
     showCompletedByDefault,
@@ -1536,6 +1544,10 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
     setShowPinnedCategories((prev) => !prev);
   };
 
+  const toggleShowPinnedHabits = () => {
+    setShowPinnedHabits((prev) => !prev);
+  };
+
   const toggleCollapseSubtasksByDefault = () => {
     setCollapseSubtasksByDefault((prev) => !prev);
   };
@@ -1572,6 +1584,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
         toggleShowPinnedNotes,
         showPinnedCategories,
         toggleShowPinnedCategories,
+        showPinnedHabits,
+        toggleShowPinnedHabits,
         collapseSubtasksByDefault,
         toggleCollapseSubtasksByDefault,
         defaultTaskLayout,

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -21,7 +21,8 @@
   "home": {
     "pinnedTasks": "Gepinnte Tasks",
     "pinnedNotes": "Gepinnte Notizen",
-    "pinnedCategories": "Gepinnte Kategorien"
+    "pinnedCategories": "Gepinnte Kategorien",
+    "pinnedHabits": "Gepinnte Gewohnheiten"
   },
   "settings": {
     "tabs": {
@@ -88,6 +89,7 @@
     "showPinnedTasks": "Gepinnte Tasks anzeigen",
     "showPinnedNotes": "Gepinnte Notizen anzeigen",
     "showPinnedCategories": "Gepinnte Kategorien anzeigen",
+    "showPinnedHabits": "Gepinnte Gewohnheiten anzeigen",
     "offlineCache": "Offline-Cache aktivieren",
     "themePreset": "Voreinstellung",
     "customThemeName": "Name des Themes",
@@ -183,6 +185,18 @@
     "title": "Titel *",
     "text": "Text (Markdown)",
     "color": "Farbe"
+  },
+  "habitModal": {
+    "editTitle": "Gewohnheit bearbeiten",
+    "newTitle": "Neue Gewohnheit",
+    "title": "Titel *",
+    "color": "Farbe",
+    "recurrence": "Wiederholung",
+    "daily": "Täglich",
+    "weekly": "Wöchentlich",
+    "monthly": "Monatlich",
+    "yearly": "Jährlich",
+    "customInterval": "Individuelle Tage"
   },
   "common": {
     "cancel": "Abbrechen",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -21,7 +21,8 @@
   "home": {
     "pinnedTasks": "Pinned Tasks",
     "pinnedNotes": "Pinned Notes",
-    "pinnedCategories": "Pinned Categories"
+    "pinnedCategories": "Pinned Categories",
+    "pinnedHabits": "Pinned Habits"
   },
   "settings": {
     "tabs": {
@@ -88,6 +89,7 @@
     "showPinnedTasks": "Show pinned tasks",
     "showPinnedNotes": "Show pinned notes",
     "showPinnedCategories": "Show pinned categories",
+    "showPinnedHabits": "Show pinned habits",
     "offlineCache": "Enable offline cache",
     "themePreset": "Preset",
     "customThemeName": "Theme name",
@@ -183,6 +185,18 @@
     "title": "Title *",
     "text": "Text (Markdown)",
     "color": "Color"
+  },
+  "habitModal": {
+    "editTitle": "Edit Habit",
+    "newTitle": "New Habit",
+    "title": "Title *",
+    "color": "Color",
+    "recurrence": "Recurrence",
+    "daily": "Daily",
+    "weekly": "Weekly",
+    "monthly": "Monthly",
+    "yearly": "Yearly",
+    "customInterval": "Custom days"
   },
   "common": {
     "cancel": "Cancel",

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,6 +9,7 @@ import { allHomeSections, HomeSection } from "@/utils/homeSections";
 import TaskCard from "@/components/TaskCard";
 import CategoryCard from "@/components/CategoryCard";
 import { useTaskStore } from "@/hooks/useTaskStore";
+import { useHabitStore } from "@/hooks/useHabitStore";
 import NoteCard from "@/components/NoteCard";
 import { flattenTasks } from "@/utils/taskUtils";
 
@@ -16,6 +17,7 @@ const Home: React.FC = () => {
   const { t } = useTranslation();
   const { notes, tasks, categories, getTasksByCategory, updateCategory } =
     useTaskStore();
+  const { habits } = useHabitStore();
   const {
     homeSections,
     homeSectionOrder,
@@ -24,6 +26,7 @@ const Home: React.FC = () => {
     showPinnedTasks,
     showPinnedNotes,
     showPinnedCategories,
+    showPinnedHabits,
   } = useSettings();
 
   const orderedSections: HomeSection[] = homeSectionOrder
@@ -55,6 +58,14 @@ const Home: React.FC = () => {
         .sort((a, b) => a.order - b.order)
         .slice(0, 3),
     [categories],
+  );
+  const pinnedHabits = useMemo(
+    () =>
+      habits
+        .filter((h) => h.pinned)
+        .sort((a, b) => a.order - b.order)
+        .slice(0, 3),
+    [habits],
   );
 
   return (
@@ -141,6 +152,23 @@ const Home: React.FC = () => {
                     onViewDetails={() => {}}
                     showSubtasks={false}
                   />
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {showPinnedHabits && pinnedHabits.length > 0 && (
+          <div className="mb-6">
+            <h2 className="text-lg sm:text-xl font-semibold text-foreground mb-3">
+              {t("home.pinnedHabits")}
+            </h2>
+            <div className="space-y-3">
+              {pinnedHabits.map((habit) => (
+                <Link key={habit.id} to="/habits" className="block">
+                  <Card>
+                    <CardContent className="p-3">{habit.title}</CardContent>
+                  </Card>
                 </Link>
               ))}
             </div>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -129,6 +129,8 @@ const SettingsPage: React.FC = () => {
     toggleShowPinnedNotes,
     showPinnedCategories,
     toggleShowPinnedCategories,
+    showPinnedHabits,
+    toggleShowPinnedHabits,
     collapseSubtasksByDefault,
     toggleCollapseSubtasksByDefault,
     defaultTaskLayout,
@@ -1165,6 +1167,16 @@ const SettingsPage: React.FC = () => {
                   />
                   <Label htmlFor="showPinnedCategories">
                     {t("settingsPage.showPinnedCategories")}
+                  </Label>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id="showPinnedHabits"
+                    checked={showPinnedHabits}
+                    onCheckedChange={toggleShowPinnedHabits}
+                  />
+                  <Label htmlFor="showPinnedHabits">
+                    {t("settingsPage.showPinnedHabits")}
                   </Label>
                 </div>
                 <DndContext

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -119,6 +119,30 @@ export interface Flashcard {
   typedTotal?: number;
 }
 
+export interface Habit {
+  id: string;
+  title: string;
+  color: number;
+  recurrencePattern?: "daily" | "weekly" | "monthly" | "yearly";
+  customIntervalDays?: number;
+  startWeekday?: number;
+  startDate?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+  order: number;
+  pinned: boolean;
+  completions: string[];
+}
+
+export interface HabitFormData {
+  title: string;
+  color: number;
+  recurrencePattern?: "daily" | "weekly" | "monthly" | "yearly";
+  customIntervalDays?: number;
+  startWeekday?: number;
+  startDate?: Date;
+}
+
 export interface Deck {
   id: string;
   name: string;

--- a/src/utils/offline.ts
+++ b/src/utils/offline.ts
@@ -4,6 +4,7 @@ import {
   Note,
   Flashcard,
   Deck,
+  Habit,
   Deletion,
   PomodoroSession,
   Timer,
@@ -15,6 +16,7 @@ export interface OfflineData {
   categories: Category[];
   notes: Note[];
   recurring: Task[];
+  habits: Habit[];
   flashcards: Flashcard[];
   decks: Deck[];
   pomodoroSessions: PomodoroSession[];
@@ -49,6 +51,7 @@ export const updateOfflineData = (partial: Partial<OfflineData>) => {
     categories: [],
     notes: [],
     recurring: [],
+    habits: [],
     flashcards: [],
     decks: [],
     pomodoroSessions: [],
@@ -64,6 +67,7 @@ export const syncWithServer = async (): Promise<OfflineData> => {
     categories: [],
     notes: [],
     recurring: [],
+    habits: [],
     flashcards: [],
     decks: [],
     pomodoroSessions: [],

--- a/src/utils/sync.ts
+++ b/src/utils/sync.ts
@@ -4,6 +4,7 @@ import {
   Note,
   Flashcard,
   Deck,
+  Habit,
   Deletion,
   PomodoroSession,
   Timer,
@@ -14,6 +15,7 @@ export interface AllData {
   categories: Category[];
   notes: Note[];
   recurring: Task[];
+  habits: Habit[];
   flashcards: Flashcard[];
   decks: Deck[];
   pomodoroSessions: PomodoroSession[];
@@ -47,6 +49,7 @@ export function mergeData(curr: AllData, inc: AllData): AllData {
     categories: mergeLists(curr.categories, inc.categories),
     notes: mergeLists(curr.notes, inc.notes),
     recurring: mergeLists(curr.recurring, inc.recurring),
+    habits: mergeLists(curr.habits, inc.habits),
     flashcards: mergeLists(curr.flashcards, inc.flashcards, null),
     decks: mergeLists(curr.decks, inc.decks, null),
     pomodoroSessions: mergeLists(
@@ -82,15 +85,13 @@ export function applyDeletions(data: AllData): AllData {
   data.recurring = (data.recurring || []).filter((r) =>
     shouldKeep("recurring", r),
   );
+  data.habits = (data.habits || []).filter((h) => shouldKeep("habit", h));
   data.flashcards = (data.flashcards || []).filter((f) =>
     shouldKeep("flashcard", f),
   );
   data.decks = (data.decks || []).filter((d) => shouldKeep("deck", d));
   data.pomodoroSessions = (data.pomodoroSessions || []).filter((s) =>
-    shouldKeep(
-      "pomodoro",
-      s as unknown as { id: string; updatedAt?: Date },
-    ),
+    shouldKeep("pomodoro", s as unknown as { id: string; updatedAt?: Date }),
   );
   data.timers = (data.timers || []).filter((t) =>
     shouldKeep("timer", t as unknown as { id: string; updatedAt?: Date }),


### PR DESCRIPTION
## Summary
- add Habit type and store
- track habits separately with new API endpoints
- create HabitModal for editing habits
- display pinned habits on home screen and manage via settings
- update translations for new habit features

## Testing
- `npx vitest run`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_686c0131e7c0832a8c7448cab7b05ebe