### PR TITLE
Fix pinned habit completion button

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -20,7 +20,7 @@ const Home: React.FC = () => {
   const { t } = useTranslation();
   const { notes, tasks, categories, getTasksByCategory, updateCategory } =
     useTaskStore();
-  const { habits } = useHabitStore();
+  const { habits, toggleHabitCompletion } = useHabitStore();
   const {
     homeSections,
     homeSectionOrder,
@@ -198,6 +198,7 @@ const Home: React.FC = () => {
                           disabled={!active}
                           onClick={(e) => {
                             e.preventDefault();
+                            e.stopPropagation();
                             if (active)
                               toggleHabitCompletion(habit.id, todayStr);
                           }}


### PR DESCRIPTION
## Summary
- properly access `toggleHabitCompletion` in home page
- stop event propagation for pinned habit button

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687268f19ccc832abff10793e6321cf0