### PR TITLE
Fix inventory page filters and add home section

### DIFF
--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -243,6 +243,7 @@
     "timers": "Timer",
     "clock": "Uhr",
     "notes": "Notizen",
+    "inventory": "Inventar",
     "recurring": "Wiederkehrend",
     "habits": "Gewohnheiten",
     "settings": "Einstellungen"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -243,6 +243,7 @@
     "timers": "Timers",
     "clock": "Clock",
     "notes": "Notes",
+    "inventory": "Inventory",
     "recurring": "Recurring",
     "habits": "Habits",
     "settings": "Settings"

--- a/src/pages/Inventory.tsx
+++ b/src/pages/Inventory.tsx
@@ -12,8 +12,8 @@ const InventoryPage: React.FC = () => {
   const { items, categories, tags, addItem } = useInventoryStore();
   const { t } = useTranslation();
   const [search, setSearch] = useState("");
-  const [catFilter, setCatFilter] = useState<string>("");
-  const [tagFilter, setTagFilter] = useState<string>("");
+  const [catFilter, setCatFilter] = useState<string>("all");
+  const [tagFilter, setTagFilter] = useState<string>("all");
   const [open, setOpen] = useState(false);
 
   const filtered = items.filter((i) => {
@@ -23,8 +23,8 @@ const InventoryPage: React.FC = () => {
       .map((id) => tags.find((t) => t.id === id)?.name)
       .filter(Boolean)
       .join(" ");
-    if (catFilter && i.categoryId !== catFilter) return false;
-    if (tagFilter && !i.tagIds.includes(tagFilter)) return false;
+    if (catFilter !== "all" && i.categoryId !== catFilter) return false;
+    if (tagFilter !== "all" && !i.tagIds.includes(tagFilter)) return false;
     return (
       text.includes(search.toLowerCase()) ||
       catName.toLowerCase().includes(search.toLowerCase()) ||
@@ -48,7 +48,7 @@ const InventoryPage: React.FC = () => {
               <SelectValue placeholder={t("inventory.categoryFilter")}/>
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="">{t("common.none")}</SelectItem>
+              <SelectItem value="all">{t("common.none")}</SelectItem>
               {categories.map((c) => (
                 <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
               ))}
@@ -59,7 +59,7 @@ const InventoryPage: React.FC = () => {
               <SelectValue placeholder={t("inventory.tagFilter")}/>
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="">{t("common.none")}</SelectItem>
+              <SelectItem value="all">{t("common.none")}</SelectItem>
               {tags.map((t) => (
                 <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
               ))}

--- a/src/utils/homeSections.ts
+++ b/src/utils/homeSections.ts
@@ -5,6 +5,7 @@ import {
   BarChart3,
   BookOpen,
   Pencil,
+  Package,
   Timer,
   Clock,
   List,
@@ -82,6 +83,12 @@ export const allHomeSections: HomeSection[] = [
     icon: Clock,
   },
   { key: "notes", labelKey: "homeSections.notes", path: "/notes", icon: List },
+  {
+    key: "inventory",
+    labelKey: "homeSections.inventory",
+    path: "/inventory",
+    icon: Package,
+  },
   {
     key: "recurring",
     labelKey: "homeSections.recurring",


### PR DESCRIPTION
## Summary
- enable Inventory in the home sections
- adjust translations for new section
- fix Radix select error by using `all` as placeholder value

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68727edc12ec832aa157a9a8b280ec22