### PR TITLE
Fix worklog persistence and improve detail UI

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -582,6 +582,8 @@ export function loadAllData() {
     decks: loadDecks(),
     pomodoroSessions: loadPomodoroSessions(),
     timers: loadTimers(),
+    trips: loadTrips(),
+    workDays: loadWorkDays(),
     items: loadItems(),
     itemCategories: loadItemCategories(),
     itemTags: loadItemTags(),
@@ -846,13 +848,22 @@ app.use(
   "/api/flashcards",
   createFlashcardsRouter({ loadFlashcards, saveFlashcards, notifyClients }),
 );
-app.use("/api/decks", createDecksRouter({ loadDecks, saveDecks, notifyClients }));
+app.use(
+  "/api/decks",
+  createDecksRouter({ loadDecks, saveDecks, notifyClients }),
+);
 app.use(
   "/api/recurring",
   createRecurringRouter({ loadRecurring, saveRecurring, notifyClients }),
 );
-app.use("/api/habits", createHabitsRouter({ loadHabits, saveHabits, notifyClients }));
-app.use("/api/notes", createNotesRouter({ loadNotes, saveNotes, notifyClients }));
+app.use(
+  "/api/habits",
+  createHabitsRouter({ loadHabits, saveHabits, notifyClients }),
+);
+app.use(
+  "/api/notes",
+  createNotesRouter({ loadNotes, saveNotes, notifyClients }),
+);
 app.use(
   "/api/inventory",
   createInventoryRouter({
@@ -883,10 +894,20 @@ app.use(
 );
 app.use(
   "/api/pomodoro-sessions",
-  createPomodoroRouter({ loadPomodoroSessions, savePomodoroSessions, notifyClients }),
+  createPomodoroRouter({
+    loadPomodoroSessions,
+    savePomodoroSessions,
+    notifyClients,
+  }),
 );
-app.use("/api/timers", createTimersRouter({ loadTimers, saveTimers, notifyClients }));
-app.use("/api/trips", createTripsRouter({ loadTrips, saveTrips, notifyClients }));
+app.use(
+  "/api/timers",
+  createTimersRouter({ loadTimers, saveTimers, notifyClients }),
+);
+app.use(
+  "/api/trips",
+  createTripsRouter({ loadTrips, saveTrips, notifyClients }),
+);
 app.use(
   "/api/workdays",
   createWorkdaysRouter({ loadWorkDays, saveWorkDays, notifyClients }),
@@ -902,7 +923,10 @@ app.use(
     syncRole: () => syncRole,
   }),
 );
-app.use("/api/sync-log", createSyncLogRouter({ syncLogs, syncRole: () => syncRole }));
+app.use(
+  "/api/sync-log",
+  createSyncLogRouter({ syncLogs, syncRole: () => syncRole }),
+);
 let activePort = 3002;
 const publicIp = process.env.SERVER_PUBLIC_IP || null;
 export function setActivePort(p) {
@@ -914,7 +938,13 @@ app.use(
 );
 app.use(
   "/api/sync-status",
-  createSyncStatusRouter({ getStatus: () => ({ last: lastSyncTime, error: lastSyncError, enabled: syncEnabled }) }),
+  createSyncStatusRouter({
+    getStatus: () => ({
+      last: lastSyncTime,
+      error: lastSyncError,
+      enabled: syncEnabled,
+    }),
+  }),
 );
 app.use(
   "/api/llm",

--- a/src/components/WorkDayModal.tsx
+++ b/src/components/WorkDayModal.tsx
@@ -23,6 +23,7 @@ interface WorkDayModalProps {
   onSave: (data: WorkDayFormData) => void;
   workDay?: WorkDay;
   trips: Trip[];
+  defaultTripId?: string;
 }
 
 const WorkDayModal: React.FC<WorkDayModalProps> = ({
@@ -31,6 +32,7 @@ const WorkDayModal: React.FC<WorkDayModalProps> = ({
   onSave,
   workDay,
   trips,
+  defaultTripId,
 }) => {
   const { t } = useTranslation();
   const [form, setForm] = useState<WorkDayFormData>({
@@ -48,9 +50,9 @@ const WorkDayModal: React.FC<WorkDayModalProps> = ({
         tripId: workDay.tripId,
       });
     } else {
-      setForm({ start: "", end: "", tripId: "" });
+      setForm({ start: "", end: "", tripId: defaultTripId || "" });
     }
-  }, [isOpen, workDay]);
+  }, [isOpen, workDay, defaultTripId]);
 
   const handleChange = (field: keyof WorkDayFormData, value: string) => {
     setForm((prev) => ({ ...prev, [field]: value }));

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -753,7 +753,10 @@
     "duration": "Dauer"
   },
   "worklogDetail": {
-    "title": "Arbeitszeit-Details"
+    "title": "Arbeitszeit-Details",
+    "totalHours": "Gesamtstunden",
+    "averageHours": "Durchschnitt pro Tag",
+    "daysList": "Arbeitstage"
   },
   "ui": {
     "previous": "Zurück",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -753,7 +753,10 @@
     "duration": "Duration"
   },
   "worklogDetail": {
-    "title": "Worklog Details"
+    "title": "Worklog Details",
+    "totalHours": "Total hours",
+    "averageHours": "Average per day",
+    "daysList": "Work Days"
   },
   "ui": {
     "previous": "Previous",

--- a/src/pages/Worklog.tsx
+++ b/src/pages/Worklog.tsx
@@ -63,7 +63,7 @@ const WorklogPage: React.FC = () => {
     <div className="min-h-screen bg-background flex flex-col">
       <Navbar title={t("navbar.worklog") as string} />
       <div className="flex-1 max-w-3xl mx-auto px-4 py-4 space-y-6">
-        <div className="flex justify-between">
+        <div className="flex justify-between items-center flex-wrap gap-2">
           <h2 className="font-semibold mb-2">{t("worklog.title")}</h2>
           <Button
             onClick={() => {
@@ -120,61 +120,74 @@ const WorklogPage: React.FC = () => {
                 {t("worklog.addDay")}
               </Button>
               <ul className="ml-4 list-disc">
-              {workDays
-                .filter((d) => d.tripId === trip.id)
-                .map((d) => (
-                  <li key={d.id} className="flex justify-between items-center">
-                    <span>
-                      {format(new Date(d.start), "yyyy-MM-dd HH:mm")} -{" "}
-                      {format(new Date(d.end), "yyyy-MM-dd HH:mm")} ({" "}
-                      {duration(d.start, d.end).toFixed(2)} h)
-                    </span>
-                    <span className="space-x-2">
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => {
-                          setEditingDay(d.id);
-                          setShowDayModal(true);
-                        }}
-                      >
-                        {t("common.edit")}
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => deleteWorkDay(d.id)}
-                      >
-                        {t("common.delete")}
-                      </Button>
-                    </span>
-                  </li>
-                ))}
+                {workDays
+                  .filter((d) => d.tripId === trip.id)
+                  .map((d) => (
+                    <li
+                      key={d.id}
+                      className="flex justify-between items-center"
+                    >
+                      <span>
+                        {format(new Date(d.start), "yyyy-MM-dd HH:mm")} -{" "}
+                        {format(new Date(d.end), "yyyy-MM-dd HH:mm")} ({" "}
+                        {duration(d.start, d.end).toFixed(2)} h)
+                      </span>
+                      <span className="space-x-2">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => {
+                            setEditingDay(d.id);
+                            setShowDayModal(true);
+                          }}
+                        >
+                          {t("common.edit")}
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => deleteWorkDay(d.id)}
+                        >
+                          {t("common.delete")}
+                        </Button>
+                      </span>
+                    </li>
+                  ))}
               </ul>
             </CardContent>
           </Card>
         ))}
-        {workDays.filter((d) => !d.tripId).length > 0 && (
-          <Card className={`p-2 ${worklogCardShadow ? "shadow" : ""}`}>
-            <CardHeader className="p-2 pb-0">
-              <CardTitle className="text-base">
-                <Link to="/worklog/default" className="hover:underline">
-                  {t("worklog.noTrip")}
-                </Link>
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="pt-2">
-              {defaultWorkLat !== null && defaultWorkLng !== null && (
-                <MapContainer
-                  center={[defaultWorkLat, defaultWorkLng]}
-                  zoom={6}
-                  className="h-40 w-full rounded mb-2"
-                >
-                  <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
-                  <Marker position={[defaultWorkLat, defaultWorkLng]} />
-                </MapContainer>
-              )}
-              <ul className="ml-4 list-disc">
+        <Card className={`p-2 ${worklogCardShadow ? "shadow" : ""}`}>
+          <CardHeader className="p-2 pb-0">
+            <CardTitle className="text-base">
+              <Link to="/worklog/default" className="hover:underline">
+                {t("worklog.noTrip")}
+              </Link>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="pt-2">
+            <Button
+              size="sm"
+              className="mb-2"
+              onClick={() => {
+                setTripIdForNewDay(undefined);
+                setEditingDay(null);
+                setShowDayModal(true);
+              }}
+            >
+              {t("worklog.addDay")}
+            </Button>
+            {defaultWorkLat !== null && defaultWorkLng !== null && (
+              <MapContainer
+                center={[defaultWorkLat, defaultWorkLng]}
+                zoom={6}
+                className="h-40 w-full rounded mb-2"
+              >
+                <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+                <Marker position={[defaultWorkLat, defaultWorkLng]} />
+              </MapContainer>
+            )}
+            <ul className="ml-4 list-disc">
               {workDays
                 .filter((d) => !d.tripId)
                 .map((d) => (
@@ -205,10 +218,9 @@ const WorklogPage: React.FC = () => {
                     </span>
                   </li>
                 ))}
-              </ul>
-            </CardContent>
-          </Card>
-        )}
+            </ul>
+          </CardContent>
+        </Card>
       </div>
       <TripModal
         isOpen={showTripModal}
@@ -227,6 +239,7 @@ const WorklogPage: React.FC = () => {
         }
         workDay={currentDay}
         trips={trips}
+        defaultTripId={tripIdForNewDay}
       />
     </div>
   );

--- a/src/pages/WorklogDetail.tsx
+++ b/src/pages/WorklogDetail.tsx
@@ -4,7 +4,14 @@ import { useParams } from "react-router-dom";
 import { useWorklog } from "@/hooks/useWorklog";
 import { useTranslation } from "react-i18next";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from "recharts";
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+} from "recharts";
 
 const WorklogDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -26,10 +33,10 @@ const WorklogDetailPage: React.FC = () => {
   );
   const totalMinutes = days.reduce(
     (sum, d) =>
-      sum +
-      (new Date(d.end).getTime() - new Date(d.start).getTime()) / 60000,
+      sum + (new Date(d.end).getTime() - new Date(d.start).getTime()) / 60000,
     0,
   );
+  const avgHours = days.length ? totalMinutes / 60 / days.length : 0;
 
   const lastWeek: { date: string; minutes: number }[] = [];
   for (let i = 6; i >= 0; i--) {
@@ -54,7 +61,12 @@ const WorklogDetailPage: React.FC = () => {
         <h2 className="font-semibold">
           {id === "default" ? t("worklog.noTrip") : trip?.name}
         </h2>
-        <p>{(totalMinutes / 60).toFixed(2)} h</p>
+        <p>
+          {t("worklogDetail.totalHours")}: {(totalMinutes / 60).toFixed(2)} h
+        </p>
+        <p>
+          {t("worklogDetail.averageHours")}: {avgHours.toFixed(2)} h
+        </p>
         <Card>
           <CardHeader>
             <CardTitle className="text-base">
@@ -77,6 +89,21 @@ const WorklogDetailPage: React.FC = () => {
             </div>
           </CardContent>
         </Card>
+        <div>
+          <h3 className="font-semibold">{t("worklogDetail.daysList")}</h3>
+          <ul className="ml-4 list-disc">
+            {days.map((d) => (
+              <li key={d.id}>
+                {d.start.slice(0, 16)} - {d.end.slice(0, 16)} ({" "}
+                {(
+                  (new Date(d.end).getTime() - new Date(d.start).getTime()) /
+                  3600000
+                ).toFixed(2)}
+                h)
+              </li>
+            ))}
+          </ul>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- persist trips and workdays in `loadAllData`
- allow default trip selection when adding a work day
- tweak worklog overview layout and always show default card
- preselect trip in work day modal
- expand worklog detail page with more stats and list of days
- update translations

## Testing
- `npx vitest run`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6872bc6a5094832ab653205308601cc4