### PR TITLE
Restructure worklog settings

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -36,7 +36,7 @@ interface NavbarProps {
 
 const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
   const { t } = useTranslation();
-  const { colorPalette, enableWorklog } = useSettings();
+  const { colorPalette } = useSettings();
   const [showMobileMenu, setShowMobileMenu] = React.useState(false);
   const [openMenu, setOpenMenu] = React.useState<string | null>(null);
   return (
@@ -190,13 +190,11 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                     <Clock className="h-4 w-4 mr-2" /> {t("navbar.clock")}
                   </Link>
                 </DropdownMenuItem>
-                {enableWorklog && (
-                  <DropdownMenuItem asChild>
-                    <Link to="/worklog" className="flex items-center">
-                      <Clock className="h-4 w-4 mr-2" /> {t("navbar.worklog")}
-                    </Link>
-                  </DropdownMenuItem>
-                )}
+                <DropdownMenuItem asChild>
+                  <Link to="/worklog" className="flex items-center">
+                    <Clock className="h-4 w-4 mr-2" /> {t("navbar.worklog")}
+                  </Link>
+                </DropdownMenuItem>
                 <DropdownMenuItem asChild>
                   <Link to="/flashcards/stats" className="flex items-center">
                     <BarChart3 className="h-4 w-4 mr-2" />{" "}
@@ -303,14 +301,12 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                     {t("navbar.clock")}
                   </Button>
                 </Link>
-                {enableWorklog && (
-                  <Link to="/worklog" className="flex-1">
-                    <Button variant="outline" size="sm" className="w-full">
-                      <Clock className="h-4 w-4 mr-2" />
-                      {t("navbar.worklog")}
-                    </Button>
-                  </Link>
-                )}
+                <Link to="/worklog" className="flex-1">
+                  <Button variant="outline" size="sm" className="w-full">
+                    <Clock className="h-4 w-4 mr-2" />
+                    {t("navbar.worklog")}
+                  </Button>
+                </Link>
                 <Link to="/flashcards/stats" className="flex-1">
                   <Button variant="outline" size="sm" className="w-full">
                     <BarChart3 className="h-4 w-4 mr-2" />

--- a/src/components/TripModal.tsx
+++ b/src/components/TripModal.tsx
@@ -13,6 +13,7 @@ import { Label } from "@/components/ui/label";
 
 interface TripFormData {
   name: string;
+  location: string;
 }
 
 interface TripModalProps {
@@ -29,14 +30,14 @@ const TripModal: React.FC<TripModalProps> = ({
   trip,
 }) => {
   const { t } = useTranslation();
-  const [form, setForm] = useState<TripFormData>({ name: "" });
+  const [form, setForm] = useState<TripFormData>({ name: "", location: "" });
 
   useEffect(() => {
     if (!isOpen) return;
     if (trip) {
-      setForm({ name: trip.name });
+      setForm({ name: trip.name, location: trip.location || "" });
     } else {
-      setForm({ name: "" });
+      setForm({ name: "", location: "" });
     }
   }, [isOpen, trip]);
 
@@ -47,7 +48,7 @@ const TripModal: React.FC<TripModalProps> = ({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (form.name.trim()) {
-      onSave({ name: form.name });
+      onSave({ name: form.name, location: form.location.trim() });
       onClose();
     }
   };
@@ -63,15 +64,23 @@ const TripModal: React.FC<TripModalProps> = ({
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <Label htmlFor="trip-name">{t("tripModal.name")}</Label>
-            <Input
-              id="trip-name"
-              value={form.name}
-              onChange={(e) => handleChange("name", e.target.value)}
-              required
-              autoFocus
-            />
-          </div>
-          <div className="flex justify-end space-x-2 pt-4">
+          <Input
+            id="trip-name"
+            value={form.name}
+            onChange={(e) => handleChange("name", e.target.value)}
+            required
+            autoFocus
+          />
+        </div>
+        <div>
+          <Label htmlFor="trip-location">{t("tripModal.location")}</Label>
+          <Input
+            id="trip-location"
+            value={form.location}
+            onChange={(e) => handleChange("location", e.target.value)}
+          />
+        </div>
+        <div className="flex justify-end space-x-2 pt-4">
             <Button type="button" variant="outline" onClick={onClose}>
               {t("common.cancel")}
             </Button>

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -1050,10 +1050,8 @@ interface SettingsContextValue {
   toggleEnableWorklog: () => void;
   worklogCardShadow: boolean;
   toggleWorklogCardShadow: () => void;
-  defaultWorkLat: number | null;
-  updateDefaultWorkLat: (val: number | null) => void;
-  defaultWorkLng: number | null;
-  updateDefaultWorkLng: (val: number | null) => void;
+  defaultWorkLocation: string;
+  updateDefaultWorkLocation: (val: string) => void;
 }
 
 const SettingsContext = createContext<SettingsContextValue | undefined>(
@@ -1137,8 +1135,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
   const [offlineCache, setOfflineCache] = useState(defaultOfflineCache);
   const [enableWorklog, setEnableWorklog] = useState(defaultWorklogEnabled);
   const [worklogCardShadow, setWorklogCardShadow] = useState(true);
-  const [defaultWorkLat, setDefaultWorkLat] = useState<number | null>(null);
-  const [defaultWorkLng, setDefaultWorkLng] = useState<number | null>(null);
+  const [defaultWorkLocation, setDefaultWorkLocation] = useState("");
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
@@ -1298,11 +1295,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
           if (typeof data.worklogCardShadow === "boolean") {
             setWorklogCardShadow(data.worklogCardShadow);
           }
-          if (typeof data.defaultWorkLat === "number") {
-            setDefaultWorkLat(data.defaultWorkLat);
-          }
-          if (typeof data.defaultWorkLng === "number") {
-            setDefaultWorkLng(data.defaultWorkLng);
+          if (typeof data.defaultWorkLocation === "string") {
+            setDefaultWorkLocation(data.defaultWorkLocation);
           }
         }
       } catch (err) {
@@ -1357,8 +1351,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
             offlineCache,
             enableWorklog,
             worklogCardShadow,
-            defaultWorkLat,
-            defaultWorkLng,
+            defaultWorkLocation,
           }),
         });
       } catch (err) {
@@ -1404,8 +1397,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
     llmModel,
     offlineCache,
     worklogCardShadow,
-    defaultWorkLat,
-    defaultWorkLng,
+    defaultWorkLocation,
   ]);
 
   useEffect(() => {
@@ -1543,12 +1535,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
     setWorklogCardShadow((prev) => !prev);
   };
 
-  const updateDefaultWorkLat = (value: number | null) => {
-    setDefaultWorkLat(value);
-  };
-
-  const updateDefaultWorkLng = (value: number | null) => {
-    setDefaultWorkLng(value);
+  const updateDefaultWorkLocation = (value: string) => {
+    setDefaultWorkLocation(value);
   };
 
   const updateLanguage = (lang: string) => {
@@ -1713,10 +1701,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
         toggleEnableWorklog,
         worklogCardShadow,
         toggleWorklogCardShadow,
-        defaultWorkLat,
-        updateDefaultWorkLat,
-        defaultWorkLng,
-        updateDefaultWorkLng,
+        defaultWorkLocation,
+        updateDefaultWorkLocation,
       }}
     >
       {children}

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -34,6 +34,7 @@
       "pomodoro": "Pomodoro",
       "flashcards": "Karten",
       "timers": "Timer",
+      "worklog": "Arbeitszeiten",
       "tasks": "Tasks",
       "habits": "Gewohnheiten",
       "home": "Startseite",
@@ -46,7 +47,7 @@
     "groups": {
       "general": "Allgemein",
       "customization": "Anpassung",
-      "productivity": "Produktit\u00e4t",
+      "features": "Funktionen",
       "data": "Daten & Server",
       "info": "Info"
     },
@@ -98,8 +99,7 @@
     "showPinnedHabits": "Gepinnte Gewohnheiten anzeigen",
     "enableWorklog": "Arbeitszeiterfassung aktivieren",
     "worklogCardShadow": "Schatten bei Arbeitszeit-Karten",
-    "defaultWorkLat": "Breitengrad des Arbeitsorts",
-    "defaultWorkLng": "Längengrad des Arbeitsorts",
+    "defaultWorkLocation": "Arbeitsort",
     "offlineCache": "Offline-Cache aktivieren",
     "themePreset": "Voreinstellung",
     "customThemeName": "Name des Themes",
@@ -223,8 +223,7 @@
     "editTitle": "Reise bearbeiten",
     "newTitle": "Neue Reise",
     "name": "Name",
-    "latitude": "Breitengrad",
-    "longitude": "Längengrad"
+    "location": "Ort"
   },
   "workDayModal": {
     "editTitle": "Arbeitstag bearbeiten",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -34,6 +34,7 @@
       "pomodoro": "Pomodoro",
       "flashcards": "Cards",
       "timers": "Timers",
+      "worklog": "Worklog",
       "tasks": "Tasks",
       "habits": "Habits",
       "home": "Home",
@@ -46,7 +47,7 @@
     "groups": {
       "general": "General",
       "customization": "Customization",
-      "productivity": "Productivity",
+      "features": "Features",
       "data": "Data & Server",
       "info": "Info"
     },
@@ -98,8 +99,7 @@
     "showPinnedHabits": "Show pinned habits",
     "enableWorklog": "Enable worklog feature",
     "worklogCardShadow": "Shadow on worklog cards",
-    "defaultWorkLat": "Default work latitude",
-    "defaultWorkLng": "Default work longitude",
+    "defaultWorkLocation": "Default work location",
     "offlineCache": "Enable offline cache",
     "themePreset": "Preset",
     "customThemeName": "Theme name",
@@ -223,8 +223,7 @@
     "editTitle": "Edit Trip",
     "newTitle": "New Trip",
     "name": "Name",
-    "latitude": "Latitude",
-    "longitude": "Longitude"
+    "location": "Location"
   },
   "workDayModal": {
     "editTitle": "Edit Work Day",

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -135,10 +135,8 @@ const SettingsPage: React.FC = () => {
     toggleEnableWorklog,
     worklogCardShadow,
     toggleWorklogCardShadow,
-    defaultWorkLat,
-    updateDefaultWorkLat,
-    defaultWorkLng,
-    updateDefaultWorkLng,
+    defaultWorkLocation,
+    updateDefaultWorkLocation,
     collapseSubtasksByDefault,
     toggleCollapseSubtasksByDefault,
     defaultTaskLayout,
@@ -722,9 +720,9 @@ const SettingsPage: React.FC = () => {
                     </TabsList>
                   </AccordionContent>
                 </AccordionItem>
-                <AccordionItem value="productivity">
+                <AccordionItem value="features">
                   <AccordionTrigger className="text-sm">
-                    {t("settings.groups.productivity")}
+                    {t("settings.groups.features")}
                   </AccordionTrigger>
                   <AccordionContent className="pl-2">
                     <TabsList className="flex flex-col gap-1 bg-transparent p-0 h-auto">
@@ -742,6 +740,9 @@ const SettingsPage: React.FC = () => {
                       </TabsTrigger>
                       <TabsTrigger className="justify-start" value="timers">
                         {t("settings.tabs.timers")}
+                      </TabsTrigger>
+                      <TabsTrigger className="justify-start" value="worklog">
+                        {t("settings.tabs.worklog")}
                       </TabsTrigger>
                     </TabsList>
                   </AccordionContent>
@@ -1200,6 +1201,38 @@ const SettingsPage: React.FC = () => {
                   </div>
                 </div>
               </TabsContent>
+              <TabsContent value="worklog" className="space-y-4">
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id="enableWorklog"
+                    checked={enableWorklog}
+                    onCheckedChange={toggleEnableWorklog}
+                  />
+                  <Label htmlFor="enableWorklog">
+                    {t("settingsPage.enableWorklog")}
+                  </Label>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id="worklogCardShadow"
+                    checked={worklogCardShadow}
+                    onCheckedChange={toggleWorklogCardShadow}
+                  />
+                  <Label htmlFor="worklogCardShadow">
+                    {t("settingsPage.worklogCardShadow")}
+                  </Label>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="defaultWorkLocation">
+                    {t("settingsPage.defaultWorkLocation")}
+                  </Label>
+                  <Input
+                    id="defaultWorkLocation"
+                    value={defaultWorkLocation}
+                    onChange={(e) => updateDefaultWorkLocation(e.target.value)}
+                  />
+                </div>
+              </TabsContent>
               <TabsContent value="home" className="space-y-2">
                 <div className="flex items-center space-x-2">
                   <Checkbox
@@ -1240,58 +1273,6 @@ const SettingsPage: React.FC = () => {
                   <Label htmlFor="showPinnedHabits">
                     {t("settingsPage.showPinnedHabits")}
                   </Label>
-                </div>
-                <div className="flex items-center space-x-2">
-                  <Checkbox
-                    id="enableWorklog"
-                    checked={enableWorklog}
-                    onCheckedChange={toggleEnableWorklog}
-                  />
-                  <Label htmlFor="enableWorklog">
-                    {t("settingsPage.enableWorklog")}
-                  </Label>
-                </div>
-                <div className="flex items-center space-x-2">
-                  <Checkbox
-                    id="worklogCardShadow"
-                    checked={worklogCardShadow}
-                    onCheckedChange={toggleWorklogCardShadow}
-                  />
-                  <Label htmlFor="worklogCardShadow">
-                    {t("settingsPage.worklogCardShadow")}
-                  </Label>
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="defaultWorkLat">
-                    {t("settingsPage.defaultWorkLat")}
-                  </Label>
-                  <Input
-                    id="defaultWorkLat"
-                    type="number"
-                    step="any"
-                    value={defaultWorkLat ?? ""}
-                    onChange={(e) =>
-                      updateDefaultWorkLat(
-                        e.target.value === "" ? null : Number(e.target.value),
-                      )
-                    }
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="defaultWorkLng">
-                    {t("settingsPage.defaultWorkLng")}
-                  </Label>
-                  <Input
-                    id="defaultWorkLng"
-                    type="number"
-                    step="any"
-                    value={defaultWorkLng ?? ""}
-                    onChange={(e) =>
-                      updateDefaultWorkLng(
-                        e.target.value === "" ? null : Number(e.target.value),
-                      )
-                    }
-                  />
                 </div>
                 <DndContext
                   sensors={sensors}

--- a/src/pages/Worklog.tsx
+++ b/src/pages/Worklog.tsx
@@ -5,12 +5,10 @@ import { Link } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import TripModal from "@/components/TripModal";
 import WorkDayModal from "@/components/WorkDayModal";
-import { MapContainer, TileLayer, Marker } from "react-leaflet";
 import { useWorklog } from "@/hooks/useWorklog";
 import { useSettings } from "@/hooks/useSettings";
 import { useTranslation } from "react-i18next";
 import { format } from "date-fns";
-import "leaflet/dist/leaflet.css";
 
 const WorklogPage: React.FC = () => {
   const { t } = useTranslation();
@@ -24,7 +22,7 @@ const WorklogPage: React.FC = () => {
     updateWorkDay,
     deleteWorkDay,
   } = useWorklog();
-  const { worklogCardShadow, defaultWorkLat, defaultWorkLng } = useSettings();
+  const { worklogCardShadow } = useSettings();
   const [showTripModal, setShowTripModal] = useState(false);
   const [editingTrip, setEditingTrip] = useState<string | null>(null);
   const [showDayModal, setShowDayModal] = useState(false);
@@ -36,7 +34,7 @@ const WorklogPage: React.FC = () => {
   const currentTrip = trips.find((t) => t.id === editingTrip);
   const currentDay = workDays.find((d) => d.id === editingDay);
 
-  const handleSaveTrip = (data: { name: string }) => {
+  const handleSaveTrip = (data: { name: string; location: string }) => {
     if (editingTrip) {
       updateTrip(editingTrip, data);
     } else {
@@ -85,6 +83,11 @@ const WorklogPage: React.FC = () => {
                   <Link to={`/worklog/${trip.id}`} className="hover:underline">
                     {trip.name}
                   </Link>
+                  {trip.location && (
+                    <span className="ml-2 text-sm text-muted-foreground">
+                      ({trip.location})
+                    </span>
+                  )}
                 </span>
                 <span className="space-x-2">
                   <Button
@@ -177,16 +180,6 @@ const WorklogPage: React.FC = () => {
             >
               {t("worklog.addDay")}
             </Button>
-            {defaultWorkLat !== null && defaultWorkLng !== null && (
-              <MapContainer
-                center={[defaultWorkLat, defaultWorkLng]}
-                zoom={6}
-                className="h-40 w-full rounded mb-2"
-              >
-                <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
-                <Marker position={[defaultWorkLat, defaultWorkLng]} />
-              </MapContainer>
-            )}
             <ul className="ml-4 list-disc">
               {workDays
                 .filter((d) => !d.tripId)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -241,6 +241,7 @@ export interface WorkDay {
 export interface Trip {
   id: string;
   name: string;
+  location?: string;
 }
 
 export interface InventoryItem {


### PR DESCRIPTION
## Summary
- rename settings group to *Features*
- move worklog settings to a dedicated tab
- store a textual location for trips
- remove map fields and always show worklog link in navbar
- adjust translations accordingly

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6872c8673044832a884860539fffc172