### PR TITLE
Fix Worklog JSX syntax error

### DIFF
--- a/src/pages/Worklog.tsx
+++ b/src/pages/Worklog.tsx
@@ -211,8 +211,9 @@ const WorklogPage: React.FC = () => {
               </ul>
             </CardContent>
           </Card>
-        ))}
-        <Card
+        );
+      })}
+      <Card
           className={`p-2 ${worklogCardShadow ? "shadow" : ""}`}
           style={{ backgroundColor: colorPalette[defaultTripColor], color: isColorDark(colorPalette[defaultTripColor]) ? "#fff" : "#000" }}
         >


### PR DESCRIPTION
## Summary
- close the map callback in `Worklog` properly to satisfy JSX parser

## Testing
- `npm run build:dev`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872e7a63f44832a922dcfa3a2e0a5bb