### PR TITLE
Add CSV import for worklog

### DIFF
--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -753,7 +753,8 @@
     "workTime": "Arbeitszeit",
     "duration": "Dauer",
     "totalTime": "Insgesamt: {{hours}}h {{minutes}}m",
-    "exportCsv": "CSV exportieren"
+    "exportCsv": "CSV exportieren",
+    "importCsv": "CSV importieren"
   },
   "worklogDetail": {
     "title": "Arbeitszeit-Details",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -753,7 +753,8 @@
     "workTime": "Work Time",
     "duration": "Duration",
     "totalTime": "Total: {{hours}}h {{minutes}}m",
-    "exportCsv": "Export CSV"
+    "exportCsv": "Export CSV",
+    "importCsv": "Import CSV"
   },
   "worklogDetail": {
     "title": "Worklog Details",

--- a/src/pages/WorklogDetail.tsx
+++ b/src/pages/WorklogDetail.tsx
@@ -26,14 +26,7 @@ const WorklogDetailPage: React.FC = () => {
   const { colorPalette } = useSettings();
 
   const trip = id === "default" ? null : trips.find((tr) => tr.id === id);
-  if (id !== "default" && !trip) {
-    return (
-      <div className="min-h-screen bg-background">
-        <Navbar title={t("worklogDetail.title") as string} />
-        <div className="p-4">Not found</div>
-      </div>
-    );
-  }
+  const notFound = id !== "default" && !trip;
 
   const days = workDays.filter((d) =>
     id === "default" ? !d.tripId : d.tripId === id,
@@ -90,6 +83,14 @@ const WorklogDetailPage: React.FC = () => {
     [weekData, colorPalette],
   );
 
+  if (notFound) {
+    return (
+      <div className="min-h-screen bg-background">
+        <Navbar title={t("worklogDetail.title") as string} />
+        <div className="p-4">Not found</div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-background">

--- a/src/pages/WorklogDetail.tsx
+++ b/src/pages/WorklogDetail.tsx
@@ -5,6 +5,8 @@ import { useWorklog } from "@/hooks/useWorklog";
 import { useTranslation } from "react-i18next";
 import { useSettings } from "@/hooks/useSettings";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { format } from "date-fns";
 import {
   ResponsiveContainer,
   BarChart,


### PR DESCRIPTION
## Summary
- add csv import to worklog trips
- place quick settings gear to top right of worklog cards
- add translations for csv import
- fix missing imports in worklog detail page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872ebcabf40832abe67725d73771d69