### PR TITLE
Fix settings trip color

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -184,6 +184,8 @@ const SettingsPage: React.FC = () => {
     updatePaletteColor,
     homeSectionColors,
     updateHomeSectionColor,
+    defaultTripColor,
+    updateDefaultTripColor,
   } = useSettings();
 
   const { t } = useTranslation();


### PR DESCRIPTION
## Summary
- include `defaultTripColor` and updater in settings hook usage

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68730b2ed2cc832a9e6f95ea1cdf439e