### PR TITLE
Fix sync for inventory and other data

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -667,6 +667,9 @@ function mergeData(curr, inc) {
     timers: mergeLists(curr.timers, inc.timers, null),
     trips: mergeLists(curr.trips, inc.trips, null),
     workDays: mergeLists(curr.workDays, inc.workDays, null),
+    items: mergeLists(curr.items, inc.items, null),
+    itemCategories: mergeLists(curr.itemCategories, inc.itemCategories, null),
+    itemTags: mergeLists(curr.itemTags, inc.itemTags, null),
     settings: { ...curr.settings, ...inc.settings },
     deletions: mergeLists(curr.deletions, inc.deletions, "deletedAt"),
   };
@@ -702,6 +705,13 @@ function applyDeletions(data) {
   data.decks = (data.decks || []).filter((d) => shouldKeep("deck", d));
   data.trips = (data.trips || []).filter((t) => shouldKeep("trip", t));
   data.workDays = (data.workDays || []).filter((d) => shouldKeep("workday", d));
+  data.items = (data.items || []).filter((i) => shouldKeep("inventoryItem", i));
+  data.itemCategories = (data.itemCategories || []).filter((c) =>
+    shouldKeep("inventoryCategory", c),
+  );
+  data.itemTags = (data.itemTags || []).filter((t) =>
+    shouldKeep("inventoryTag", t),
+  );
   data.pomodoroSessions = (data.pomodoroSessions || []).filter((s) =>
     shouldKeep("pomodoro", s),
   );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -160,7 +160,10 @@ export interface Deletion {
     | "timer"
     | "pomodoro"
     | "workday"
-    | "trip";
+    | "trip"
+    | "inventoryItem"
+    | "inventoryCategory"
+    | "inventoryTag";
   deletedAt: Date;
 }
 

--- a/src/utils/offline.ts
+++ b/src/utils/offline.ts
@@ -10,6 +10,9 @@ import {
   Timer,
   Trip,
   WorkDay,
+  InventoryItem,
+  ItemCategory,
+  ItemTag,
 } from "@/types";
 import { applyDeletions, mergeData } from "./sync";
 
@@ -25,6 +28,9 @@ export interface OfflineData {
   timers: Timer[];
   trips: Trip[];
   workDays: WorkDay[];
+  items: InventoryItem[];
+  itemCategories: ItemCategory[];
+  itemTags: ItemTag[];
   deletions: Deletion[];
 }
 
@@ -62,6 +68,9 @@ export const updateOfflineData = (partial: Partial<OfflineData>) => {
     timers: [],
     trips: [],
     workDays: [],
+    items: [],
+    itemCategories: [],
+    itemTags: [],
     deletions: [],
   };
   saveOfflineData({ ...current, ...partial });
@@ -80,6 +89,9 @@ export const syncWithServer = async (): Promise<OfflineData> => {
     timers: [],
     trips: [],
     workDays: [],
+    items: [],
+    itemCategories: [],
+    itemTags: [],
     deletions: [],
   };
   if (!navigator.onLine) return local;

--- a/src/utils/sync.ts
+++ b/src/utils/sync.ts
@@ -10,6 +10,9 @@ import {
   Timer,
   Trip,
   WorkDay,
+  InventoryItem,
+  ItemCategory,
+  ItemTag,
 } from "@/types";
 
 export interface AllData {
@@ -24,6 +27,9 @@ export interface AllData {
   timers: Timer[];
   trips: Trip[];
   workDays: WorkDay[];
+  items: InventoryItem[];
+  itemCategories: ItemCategory[];
+  itemTags: ItemTag[];
   deletions: Deletion[];
 }
 
@@ -64,6 +70,9 @@ export function mergeData(curr: AllData, inc: AllData): AllData {
     timers: mergeLists(curr.timers, inc.timers, null),
     trips: mergeLists(curr.trips, inc.trips, null),
     workDays: mergeLists(curr.workDays, inc.workDays, null),
+    items: mergeLists(curr.items, inc.items, null),
+    itemCategories: mergeLists(curr.itemCategories, inc.itemCategories, null),
+    itemTags: mergeLists(curr.itemTags, inc.itemTags, null),
     deletions: mergeLists(curr.deletions, inc.deletions, "deletedAt"),
   };
 }
@@ -98,6 +107,13 @@ export function applyDeletions(data: AllData): AllData {
   data.decks = (data.decks || []).filter((d) => shouldKeep("deck", d));
   data.trips = (data.trips || []).filter((t) => shouldKeep("trip", t));
   data.workDays = (data.workDays || []).filter((d) => shouldKeep("workday", d));
+  data.items = (data.items || []).filter((i) => shouldKeep("inventoryItem", i));
+  data.itemCategories = (data.itemCategories || []).filter((c) =>
+    shouldKeep("inventoryCategory", c),
+  );
+  data.itemTags = (data.itemTags || []).filter((t) =>
+    shouldKeep("inventoryTag", t),
+  );
   data.pomodoroSessions = (data.pomodoroSessions || []).filter((s) =>
     shouldKeep("pomodoro", s as unknown as { id: string; updatedAt?: Date }),
   );


### PR DESCRIPTION
## Summary
- include inventory data in AllData interface
- support inventory sync in client/store logic
- keep inventory records when applying deletions
- update server sync logic for inventory data
- extend deletion types for inventory

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: @eslint/js module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877ef2fab34832ab2a09a7b5ab16fe2