### PR TITLE
Add navbar item reordering

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -36,8 +36,8 @@ interface NavbarProps {
 
 const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
   const { t } = useTranslation();
-  const { colorPalette, navbarItems } = useSettings();
-  const tasksKeys = [
+  const { colorPalette, navbarItems, navbarItemOrder } = useSettings();
+  const tasksKeys = navbarItemOrder.tasks || [
     "overview",
     "kanban",
     "schedule",
@@ -45,7 +45,7 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
     "habits",
     "statistics",
   ];
-  const learningKeys = [
+  const learningKeys = navbarItemOrder.learning || [
     "cards",
     "decks",
     "pomodoro",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -112,6 +112,7 @@
     "yourSounds": "Eigene Sounds",
     "yourThemes": "Eigene Themes",
     "otherLinks": "Weitere Links",
+    "dragHint": "Zum Sortieren ziehen",
     "custom": "custom",
     "bgColor": "Hintergrund (App)",
     "fgColor": "Textfarbe",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -112,6 +112,7 @@
     "yourSounds": "Your Sounds",
     "yourThemes": "Your Themes",
     "otherLinks": "Other links",
+    "dragHint": "Drag items to reorder",
     "custom": "custom",
     "bgColor": "Background (App)",
     "fgColor": "Text color",


### PR DESCRIPTION
## Summary
- allow reordering navbar items in settings via drag and drop
- persist navbar item order in settings
- display hint about dragging to reorder
- keep translations in sync

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b6bf874a0832a9a64a6efb1a85d38