### PR TITLE
Implement reorderable standalone links

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -71,9 +71,10 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
     });
     return set;
   }, [navbarGroups, navbarItemOrder]);
-  const standalone = allNavbarItems.filter(
-    (i) => !groupedSet.has(i.key) && navbarItems.includes(i.key),
-  );
+  const standalone = (navbarItemOrder["standalone"] || [])
+    .filter((k) => !groupedSet.has(k) && navbarItems.includes(k))
+    .map((k) => itemMap[k])
+    .filter(Boolean) as typeof allNavbarItems;
   const [showMobileMenu, setShowMobileMenu] = React.useState(false);
   const [openMenu, setOpenMenu] = React.useState<string | null>(null);
   return (
@@ -129,11 +130,13 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
               const hasItems = keys.some((k) => navbarItems.includes(k));
               if (!hasItems) return null;
               const groupIcon =
-                grp === "tasks"
-                  ? <ClipboardList className="h-4 w-4 mr-2" />
-                  : grp === "learning"
-                  ? <GraduationCap className="h-4 w-4 mr-2" />
-                  : <List className="h-4 w-4 mr-2" />;
+                grp === "tasks" ? (
+                  <ClipboardList className="h-4 w-4 mr-2" />
+                ) : grp === "learning" ? (
+                  <GraduationCap className="h-4 w-4 mr-2" />
+                ) : (
+                  <List className="h-4 w-4 mr-2" />
+                );
               return (
                 <DropdownMenu
                   key={grp}
@@ -144,9 +147,7 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                     <Button
                       variant="outline"
                       size="sm"
-                      onClick={() =>
-                        setOpenMenu(openMenu === grp ? null : grp)
-                      }
+                      onClick={() => setOpenMenu(openMenu === grp ? null : grp)}
                       className="flex items-center"
                     >
                       {groupIcon}
@@ -201,7 +202,11 @@ const Navbar: React.FC<NavbarProps> = ({ title, category, onHomeClick }) => {
                       if (!item) return null;
                       return (
                         <Link to={item.path} className="flex-1" key={k}>
-                          <Button variant="outline" size="sm" className="w-full">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="w-full"
+                          >
                             {iconMap[k]}
                             {t(item.labelKey)}
                           </Button>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -397,18 +397,17 @@ const SettingsPage: React.FC = () => {
     }
   };
 
-  const handleNavbarDrag = (group: string) => ({
-    active,
-    over,
-  }: DragEndEvent) => {
-    if (!over || active.id === over.id) return;
-    const list = navbarItemOrder[group] || [];
-    const oldIndex = list.indexOf(active.id as string);
-    const newIndex = list.indexOf(over.id as string);
-    if (oldIndex !== -1 && newIndex !== -1) {
-      reorderNavbarItems(group, oldIndex, newIndex);
-    }
-  };
+  const handleNavbarDrag =
+    (group: string) =>
+    ({ active, over }: DragEndEvent) => {
+      if (!over || active.id === over.id) return;
+      const list = navbarItemOrder[group] || [];
+      const oldIndex = list.indexOf(active.id as string);
+      const newIndex = list.indexOf(over.id as string);
+      if (oldIndex !== -1 && newIndex !== -1) {
+        reorderNavbarItems(group, oldIndex, newIndex);
+      }
+    };
 
   const download = (data: unknown, name: string) => {
     const blob = new Blob([JSON.stringify(data, null, 2)], {
@@ -1449,7 +1448,9 @@ const SettingsPage: React.FC = () => {
                       >
                         <div className="space-y-1">
                           {navbarItemOrder[grp].map((k) => {
-                            const item = allNavbarItems.find((i) => i.key === k);
+                            const item = allNavbarItems.find(
+                              (i) => i.key === k,
+                            );
                             if (!item) return null;
                             return (
                               <SortableNavItem key={k} id={k}>
@@ -1458,9 +1459,13 @@ const SettingsPage: React.FC = () => {
                                     <Checkbox
                                       id={`nav-${k}`}
                                       checked={navbarItems.includes(k)}
-                                      onCheckedChange={() => toggleNavbarItem(k)}
+                                      onCheckedChange={() =>
+                                        toggleNavbarItem(k)
+                                      }
                                     />
-                                    <Label htmlFor={`nav-${k}`}>{t(item.labelKey)}</Label>
+                                    <Label htmlFor={`nav-${k}`}>
+                                      {t(item.labelKey)}
+                                    </Label>
                                   </div>
                                   <GripVertical className="h-4 w-4 text-muted-foreground" />
                                 </div>
@@ -1510,16 +1515,40 @@ const SettingsPage: React.FC = () => {
                   <p className="text-xs font-semibold text-muted-foreground">
                     {t("settingsPage.otherLinks")}
                   </p>
-                  {allNavbarItems.map((item) => (
-                    <div key={item.key} className="flex items-center space-x-2">
-                      <Checkbox
-                        id={`nav-${item.key}`}
-                        checked={navbarItems.includes(item.key)}
-                        onCheckedChange={() => toggleNavbarItem(item.key)}
-                      />
-                      <Label htmlFor={`nav-${item.key}`}>{t(item.labelKey)}</Label>
-                    </div>
-                  ))}
+                  <DndContext
+                    sensors={sensors}
+                    collisionDetection={closestCenter}
+                    onDragEnd={handleNavbarDrag("standalone")}
+                  >
+                    <SortableContext
+                      items={navbarItemOrder.standalone}
+                      strategy={verticalListSortingStrategy}
+                    >
+                      <div className="space-y-1">
+                        {navbarItemOrder.standalone.map((k) => {
+                          const item = allNavbarItems.find((i) => i.key === k);
+                          if (!item) return null;
+                          return (
+                            <SortableNavItem key={k} id={k}>
+                              <div className="flex items-center justify-between border rounded p-2 bg-card">
+                                <div className="flex items-center space-x-2">
+                                  <Checkbox
+                                    id={`nav-${k}`}
+                                    checked={navbarItems.includes(k)}
+                                    onCheckedChange={() => toggleNavbarItem(k)}
+                                  />
+                                  <Label htmlFor={`nav-${k}`}>
+                                    {t(item.labelKey)}
+                                  </Label>
+                                </div>
+                                <GripVertical className="h-4 w-4 text-muted-foreground" />
+                              </div>
+                            </SortableNavItem>
+                          );
+                        })}
+                      </div>
+                    </SortableContext>
+                  </DndContext>
                 </div>
                 <Button variant="outline" onClick={resetNavbarSettings}>
                   {t("settingsPage.resetNavbar")}


### PR DESCRIPTION
## Summary
- allow storing custom order for standalone navbar items
- support reordering other links in settings via drag and drop
- use new order when rendering standalone links

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687b7dbe0160832aba557d44a7279a75