### PR TITLE
Add recursive task reset option

### DIFF
--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -11,6 +11,7 @@ import {
   MoreVertical,
   Star,
   StarOff,
+  RotateCcw,
 } from "lucide-react";
 import {
   DropdownMenu,
@@ -34,6 +35,7 @@ interface CategoryCardProps {
   onDelete: (categoryId: string) => void;
   onViewTasks: (category: Category) => void;
   onTogglePinned: (categoryId: string, pinned: boolean) => void;
+  onReset: (categoryId: string) => void;
 }
 
 const CategoryCard: React.FC<CategoryCardProps> = ({
@@ -43,6 +45,7 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
   onDelete,
   onViewTasks,
   onTogglePinned,
+  onReset,
 }) => {
   const { t } = useTranslation();
   const { colorPalette, theme } = useSettings();
@@ -146,6 +149,17 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
             >
               <Edit className="h-4 w-4" />
             </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                onReset(category.id);
+              }}
+              className="h-8 w-8 p-0"
+            >
+              <RotateCcw className="h-4 w-4" />
+            </Button>
             {category.id !== "default" && (
               <Button
                 variant="ghost"
@@ -197,6 +211,10 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
                 <DropdownMenuItem onClick={() => onEdit(category)}>
                   <Edit className="h-4 w-4 mr-2" />
                   {t("common.edit")}
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => onReset(category.id)}>
+                  <RotateCcw className="h-4 w-4 mr-2" />
+                  {t("categoryCard.resetTasks")}
                 </DropdownMenuItem>
                 {category.id !== "default" && (
                   <DropdownMenuItem

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -121,6 +121,8 @@ const Dashboard: React.FC = () => {
     reorderCategories,
     reorderTasks,
     undoDeleteCategory,
+    resetTask,
+    resetCategoryTasks,
   } = useTaskStore();
 
   const { toast } = useToast();
@@ -385,6 +387,15 @@ const Dashboard: React.FC = () => {
     }
   };
 
+  const handleResetTask = (taskId: string) => {
+    resetTask(taskId);
+    const task = findTaskById(taskId);
+    toast({
+      title: t("dashboard.taskReset"),
+      description: t("dashboard.taskResetDesc", { title: task?.title }),
+    });
+  };
+
   const handleCreateCategory = (categoryData: CategoryFormData) => {
     addCategory(categoryData);
     toast({
@@ -414,6 +425,15 @@ const Dashboard: React.FC = () => {
 
   const handleToggleCategoryPinned = (id: string, pinned: boolean) => {
     updateCategory(id, { pinned });
+  };
+
+  const handleResetCategory = (id: string) => {
+    resetCategoryTasks(id);
+    const cat = categories.find((c) => c.id === id);
+    toast({
+      title: t("dashboard.categoryTasksReset"),
+      description: t("dashboard.categoryTasksResetDesc", { name: cat?.name }),
+    });
   };
 
   const handleViewCategoryTasks = (category: Category) => {
@@ -634,6 +654,7 @@ const Dashboard: React.FC = () => {
                           onDelete={handleDeleteCategory}
                           onViewTasks={handleViewCategoryTasks}
                           onTogglePinned={handleToggleCategoryPinned}
+                          onReset={handleResetCategory}
                         />
                       </SortableCategory>
                     ))}
@@ -739,6 +760,7 @@ const Dashboard: React.FC = () => {
                           onAddSubtask={handleAddSubtask}
                           onToggleComplete={handleToggleTaskComplete}
                           onViewDetails={handleViewTaskDetails}
+                          onReset={handleResetTask}
                           isGrid={taskLayout === "grid"}
                         />
                       </SortableTask>

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -28,6 +28,7 @@ import {
   Star,
   StarOff,
   Calendar as CalendarIcon,
+  RotateCcw,
   Eye,
   EyeOff,
 } from "lucide-react";
@@ -46,6 +47,7 @@ interface TaskCardProps {
   onAddSubtask: (parentTask: Task) => void;
   onToggleComplete: (taskId: string, completed: boolean) => void;
   onViewDetails: (task: Task) => void;
+  onReset: (taskId: string) => void;
   depth?: number;
   /** Titles of all parent tasks from root to immediate parent */
   parentPathTitles?: string[];
@@ -62,6 +64,7 @@ const TaskCard: React.FC<TaskCardProps> = ({
   onAddSubtask,
   onToggleComplete,
   onViewDetails,
+  onReset,
   depth = 0,
   parentPathTitles = [],
   showSubtasks = true,
@@ -195,6 +198,10 @@ const TaskCard: React.FC<TaskCardProps> = ({
                 <Edit className="h-4 w-4 mr-2" />
                 {t("common.edit")}
               </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onReset(st.id)}>
+                <RotateCcw className="h-4 w-4 mr-2" />
+                {t("taskCard.reset")}
+              </DropdownMenuItem>
               <DropdownMenuItem
                 onClick={() =>
                   updateTask(st.id, { visible: !(st.visible !== false) })
@@ -304,6 +311,10 @@ const TaskCard: React.FC<TaskCardProps> = ({
             <DropdownMenuItem onClick={() => onEdit(task)}>
               <Edit className="h-4 w-4 mr-2" />
               {t("common.edit")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onReset(task.id)}>
+              <RotateCcw className="h-4 w-4 mr-2" />
+              {t("taskCard.reset")}
             </DropdownMenuItem>
             <DropdownMenuItem
               onClick={() =>

--- a/src/hooks/useTaskStore.tsx
+++ b/src/hooks/useTaskStore.tsx
@@ -523,7 +523,6 @@ const useTaskStoreImpl = () => {
     );
   };
 
-
   const deleteRecurringTask = (id: string) => {
     setRecurring((prev) => prev.filter((t) => t.id !== id));
     setTasks((prev) =>
@@ -853,6 +852,43 @@ const useTaskStoreImpl = () => {
     });
   };
 
+  const resetTaskRecursive = (t: Task): Task => ({
+    ...t,
+    completed: false,
+    status: "todo",
+    visible: true,
+    subtasks: t.subtasks.map((st) => resetTaskRecursive(st)),
+  });
+
+  const resetTask = (taskId: string) => {
+    const update = (list: Task[]): Task[] =>
+      list.map((task) => {
+        if (task.id === taskId) {
+          return resetTaskRecursive(task);
+        }
+        if (task.subtasks.length > 0) {
+          return { ...task, subtasks: update(task.subtasks) };
+        }
+        return task;
+      });
+    setTasks((prev) => update(prev));
+  };
+
+  const resetCategoryTasks = (categoryId: string) => {
+    const update = (list: Task[]): Task[] =>
+      list.map((task) => {
+        const subs = update(task.subtasks);
+        if (task.categoryId === categoryId) {
+          return resetTaskRecursive({ ...task, subtasks: subs });
+        }
+        if (subs !== task.subtasks) {
+          return { ...task, subtasks: subs };
+        }
+        return task;
+      });
+    setTasks((prev) => update(prev));
+  };
+
   const getTasksByCategory = (categoryId: string): Task[] => {
     return tasks
       .filter(
@@ -904,6 +940,8 @@ const useTaskStoreImpl = () => {
     updateNote,
     deleteNote,
     reorderNotes,
+    resetTask,
+    resetCategoryTasks,
     recurring,
     addRecurringTask,
     updateRecurringTask,

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -511,6 +511,7 @@
     "deleted": "Task gelöscht",
     "completed": "Task abgeschlossen",
     "reactivated": "Task reaktiviert",
+    "reset": "Task zurückgesetzt",
     "deleteConfirm": "Sind Sie sicher, dass Sie \"{{title}}\" löschen möchten?",
     "search": "Suchen...",
     "moreFilters": "Mehr Filter",
@@ -661,6 +662,8 @@
     "taskCompletedDesc": "\"{{title}}\" wurde als erledigt markiert.",
     "taskReactivated": "Task reaktiviert",
     "taskReactivatedDesc": "\"{{title}}\" wurde reaktiviert.",
+    "taskReset": "Task zurückgesetzt",
+    "taskResetDesc": "\"{{title}}\" wurde zurückgesetzt.",
     "taskDeleteConfirm": "Sind Sie sicher, dass Sie \"{{title}}\" löschen möchten?",
     "categoryCreated": "Kategorie erstellt",
     "categoryCreatedDesc": "\"{{name}}\" wurde erfolgreich erstellt.",
@@ -670,13 +673,16 @@
     "categoryDeletedDesc": "Die Kategorie wurde erfolgreich gelöscht.",
     "categoryDeleteConfirm": "Sind Sie sicher, dass Sie \"{{name}}\" löschen möchten?",
     "categoryDeleteLastConfirm": "Sie sind dabei, die letzte verbleibende Kategorie zu löschen. \"{{name}}\" wirklich löschen?",
+    "categoryTasksReset": "Aufgaben zurückgesetzt",
+    "categoryTasksResetDesc": "Alle Aufgaben in \"{{name}}\" wurden zurückgesetzt.",
     "undo": "Rückgängig"
   },
   "categoryCard": {
     "deleteTooltip": "Löschen (rückgängig möglich)",
     "deleteMenu": "Löschen (Undo möglich)",
     "percentDone": "{{percent}}% erledigt",
-    "completedOfTotal": "{{completed}} von {{total}} abgeschlossen"
+    "completedOfTotal": "{{completed}} von {{total}} abgeschlossen",
+    "resetTasks": "Aufgaben zurücksetzen"
   },
   "taskCard": {
     "viewDetails": "Details anzeigen",
@@ -685,7 +691,8 @@
     "recurring": "Wiederholt",
     "due": "Fällig am {{date}}",
     "hide": "Verstecken",
-    "unhide": "Einblenden"
+    "unhide": "Einblenden",
+    "reset": "Zurücksetzen"
   },
   "taskDetail": {
     "noSubtasks": "Keine Unteraufgaben vorhanden.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -511,6 +511,7 @@
     "deleted": "Task deleted",
     "completed": "Task completed",
     "reactivated": "Task reactivated",
+    "reset": "Task reset",
     "deleteConfirm": "Are you sure you want to delete \"{{title}}\"?",
     "search": "Search...",
     "moreFilters": "More Filters",
@@ -661,6 +662,8 @@
     "taskCompletedDesc": "\"{{title}}\" was marked as completed.",
     "taskReactivated": "Task reactivated",
     "taskReactivatedDesc": "\"{{title}}\" was reactivated.",
+    "taskReset": "Task reset",
+    "taskResetDesc": "\"{{title}}\" was reset.",
     "taskDeleteConfirm": "Are you sure you want to delete \"{{title}}\"?",
     "categoryCreated": "Category created",
     "categoryCreatedDesc": "\"{{name}}\" was successfully created.",
@@ -670,13 +673,16 @@
     "categoryDeletedDesc": "The category was successfully deleted.",
     "categoryDeleteConfirm": "Are you sure you want to delete \"{{name}}\"?",
     "categoryDeleteLastConfirm": "You are about to delete the last remaining category. Delete \"{{name}}\"?",
+    "categoryTasksReset": "Tasks reset",
+    "categoryTasksResetDesc": "All tasks in \"{{name}}\" were reset.",
     "undo": "Undo"
   },
   "categoryCard": {
     "deleteTooltip": "Delete (undo possible)",
     "deleteMenu": "Delete (undo possible)",
     "percentDone": "{{percent}}% done",
-    "completedOfTotal": "{{completed}} of {{total}} completed"
+    "completedOfTotal": "{{completed}} of {{total}} completed",
+    "resetTasks": "Reset tasks"
   },
   "taskCard": {
     "viewDetails": "View details",
@@ -685,7 +691,8 @@
     "recurring": "Recurring",
     "due": "Due on {{date}}",
     "hide": "Hide",
-    "unhide": "Unhide"
+    "unhide": "Unhide",
+    "reset": "Reset"
   },
   "taskDetail": {
     "noSubtasks": "No subtasks available.",

--- a/src/pages/Kanban.tsx
+++ b/src/pages/Kanban.tsx
@@ -84,8 +84,15 @@ const KanbanColumn: React.FC<KanbanColumnProps> = ({ id, children }) => {
 };
 
 const Kanban: React.FC = () => {
-  const { tasks, categories, addTask, updateTask, deleteTask, findTaskById } =
-    useTaskStore();
+  const {
+    tasks,
+    categories,
+    addTask,
+    updateTask,
+    deleteTask,
+    findTaskById,
+    resetTask,
+  } = useTaskStore();
   const { toast } = useToast();
   const { t } = useTranslation();
 
@@ -165,6 +172,15 @@ const Kanban: React.FC = () => {
     toast({
       title: completed ? t("kanban.completed") : t("kanban.reactivated"),
       description: `"${task?.title}" ${completed ? t("kanban.completed") : t("kanban.reactivated")}`,
+    });
+  };
+
+  const handleResetTask = (taskId: string) => {
+    resetTask(taskId);
+    const task = findTaskById(taskId);
+    toast({
+      title: t("kanban.reset"),
+      description: `"${task?.title}" ${t("kanban.reset")}`,
     });
   };
 
@@ -346,6 +362,7 @@ const Kanban: React.FC = () => {
                         onAddSubtask={handleAddSubtask}
                         onToggleComplete={handleToggleTaskComplete}
                         onViewDetails={handleViewTaskDetails}
+                        onReset={handleResetTask}
                       />
                     </SortableKanbanTask>
                   ))}


### PR DESCRIPTION
## Summary
- enable recursive resetting of task status and kanban state
- support resetting tasks of an entire category
- add quick-menu actions in TaskCard and CategoryCard
- update German and English translations

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687bba0d7e2c832a95a4995f80a795cc