### PR TITLE
Fix SSE race when toggling task completion

### DIFF
--- a/src/hooks/useTaskStore.tsx
+++ b/src/hooks/useTaskStore.tsx
@@ -204,7 +204,7 @@ const useTaskStoreImpl = () => {
   useEffect(() => {
     const es = new EventSource("/api/updates");
     es.onmessage = () => {
-      if (Date.now() - lastSaveTimeRef.current > 1000) {
+      if (Date.now() - lastSaveTimeRef.current > 3000) {
         fetchData(false);
       }
     };


### PR DESCRIPTION
## Summary
- increase debounce for SSE updates in `useTaskStore`

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_687bc9451ca4832a9c6985d13ec9d34c