### PR TITLE
Fix worklog CSV date parsing

### DIFF
--- a/src/pages/Worklog.tsx
+++ b/src/pages/Worklog.tsx
@@ -107,9 +107,12 @@ const WorklogPage: React.FC = () => {
     const text = await file.text();
     const lines = text.trim().split(/\r?\n/).slice(1);
     for (const line of lines) {
-      const [start, end] = line.split(',');
-      if (start && end)
+      const [rawStart, rawEnd] = line.split(',');
+      if (rawStart && rawEnd) {
+        const start = format(new Date(rawStart), 'yyyy-MM-dd HH:mm');
+        const end = format(new Date(rawEnd), 'yyyy-MM-dd HH:mm');
         addWorkDay({ start, end, tripId: importTripId });
+      }
     }
     e.target.value = '';
   };


### PR DESCRIPTION
## Summary
- normalize dates during CSV import by formatting them as `yyyy-MM-dd HH:mm`

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687e226993a8832aaa66974f505e1f37