### PR TITLE
Fix immediate workday deletion

### DIFF
--- a/src/hooks/useWorklog.tsx
+++ b/src/hooks/useWorklog.tsx
@@ -121,7 +121,16 @@ const useWorklogImpl = () => {
   };
 
   const deleteWorkDay = (id: string) => {
-    setWorkDays((prev) => prev.filter((d) => d.id !== id));
+    const updated = workDays.filter((d) => d.id !== id);
+    setWorkDays(updated);
+    updateOfflineData({ workDays: updated.map(normalizeDay) });
+    if (navigator.onLine) {
+      fetch(API_WORKDAYS, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(updated.map(normalizeDay)),
+      }).catch((err) => console.error("Error deleting workday", err));
+    }
   };
 
   return {


### PR DESCRIPTION
## Summary
- ensure deleting a workday updates offline storage immediately
- push updated list to API right away

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e3f704ee8832ab78f8fad225cf6e4