### PR TITLE
Fix worklog day ordering

### DIFF
--- a/src/pages/Worklog.tsx
+++ b/src/pages/Worklog.tsx
@@ -215,6 +215,11 @@ const WorklogPage: React.FC = () => {
                 <TableBody>
                   {workDays
                     .filter((d) => d.tripId === trip.id)
+                    .sort(
+                      (a, b) =>
+                        new Date(a.start).getTime() -
+                        new Date(b.start).getTime(),
+                    )
                     .map((d) => {
                       const dur = duration(d.start, d.end);
                       return (
@@ -385,6 +390,11 @@ const WorklogPage: React.FC = () => {
                 <TableBody>
                   {workDays
                     .filter((d) => !d.tripId)
+                    .sort(
+                      (a, b) =>
+                        new Date(a.start).getTime() -
+                        new Date(b.start).getTime(),
+                    )
                     .map((d) => {
                       const dur = duration(d.start, d.end);
                       return (

--- a/src/pages/WorklogDetail.tsx
+++ b/src/pages/WorklogDetail.tsx
@@ -30,9 +30,12 @@ const WorklogDetailPage: React.FC = () => {
   const trip = id === "default" ? null : trips.find((tr) => tr.id === id);
   const notFound = id !== "default" && !trip;
 
-  const days = workDays.filter((d) =>
-    id === "default" ? !d.tripId : d.tripId === id,
-  );
+  const days = workDays
+    .filter((d) => (id === "default" ? !d.tripId : d.tripId === id))
+    .sort(
+      (a, b) =>
+        new Date(a.start).getTime() - new Date(b.start).getTime(),
+    );
   const totalMinutes = days.reduce(
     (sum, d) =>
       sum + (new Date(d.end).getTime() - new Date(d.start).getTime()) / 60000,


### PR DESCRIPTION
## Summary
- ensure work days are displayed from oldest to newest on overview and detail pages

## Testing
- `npm test -- -t ''`
- `npm run format:check` *(fails: Code style issues found in 30 files)*

------
https://chatgpt.com/codex/tasks/task_e_687e45eb3398832aaf2f4f55fd12b110