### PR TITLE
Refactor backend modules

### DIFF
--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -1,0 +1,88 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import Database from "better-sqlite3";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const DATA_DIR = path.join(__dirname, "..", "data");
+const DB_FILE = path.join(DATA_DIR, "data.db");
+
+fs.mkdirSync(DATA_DIR, { recursive: true });
+const db = new Database(DB_FILE);
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS tasks (
+    id TEXT PRIMARY KEY,
+    data TEXT NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS categories (
+    id TEXT PRIMARY KEY,
+    data TEXT NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS notes (
+    id TEXT PRIMARY KEY,
+    data TEXT NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS recurring (
+    id TEXT PRIMARY KEY,
+    data TEXT NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS habits (
+    id TEXT PRIMARY KEY,
+    data TEXT NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS flashcards (
+    id TEXT PRIMARY KEY,
+    data TEXT NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS decks (
+    id TEXT PRIMARY KEY,
+    data TEXT NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS pomodoro_sessions (
+    start INTEGER NOT NULL,
+    end INTEGER NOT NULL,
+    breakEnd INTEGER
+  );
+  CREATE TABLE IF NOT EXISTS timers (
+    id TEXT PRIMARY KEY,
+    data TEXT NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS trips (
+    id TEXT PRIMARY KEY,
+    data TEXT NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS workdays (
+    id TEXT PRIMARY KEY,
+    data TEXT NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS inventory_items (
+    id TEXT PRIMARY KEY,
+    data TEXT NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS inventory_categories (
+    id TEXT PRIMARY KEY,
+    data TEXT NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS inventory_tags (
+    id TEXT PRIMARY KEY,
+    data TEXT NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS deletions (
+    type TEXT NOT NULL,
+    id TEXT NOT NULL,
+    deletedAt TEXT NOT NULL,
+    PRIMARY KEY (type, id)
+  );
+`);
+try {
+  db.prepare("ALTER TABLE pomodoro_sessions ADD COLUMN breakEnd INTEGER").run();
+} catch {}
+
+export default db;

--- a/server/lib/sse.js
+++ b/server/lib/sse.js
@@ -1,0 +1,14 @@
+const clients = [];
+
+export function registerClient(req, res) {
+  clients.push(res);
+  req.on("close", () => {
+    const idx = clients.indexOf(res);
+    if (idx !== -1) clients.splice(idx, 1);
+  });
+}
+
+export function notifyClients() {
+  const msg = "data: update\n\n";
+  clients.forEach((res) => res.write(msg));
+}

--- a/server/lib/sync.js
+++ b/server/lib/sync.js
@@ -1,0 +1,125 @@
+let syncRole = "client";
+let syncServerUrl = "";
+let syncInterval = 5;
+let syncEnabled = true;
+let llmUrl = "";
+let llmToken = "";
+let llmModel = "gpt-3.5-turbo";
+let syncTimer = null;
+let lastSyncTime = 0;
+let lastSyncError = null;
+export const syncLogs = [];
+
+let loadAllData = () => ({});
+let saveAllData = () => {};
+
+function log(...args) {
+  console.log(new Date().toISOString(), ...args);
+}
+
+export function initSync({ loadAllData: l, saveAllData: s }) {
+  loadAllData = l;
+  saveAllData = s;
+}
+
+export function getSyncRole() {
+  return syncRole;
+}
+
+export function getSyncStatus() {
+  return { last: lastSyncTime, error: lastSyncError, enabled: syncEnabled };
+}
+
+export function getLlmConfig() {
+  return { llmUrl, llmToken, llmModel };
+}
+
+async function performSync() {
+  if (syncRole !== "client" || !syncServerUrl) return;
+  const url = `${syncServerUrl.replace(/\/$/, "")}/api/sync`;
+  try {
+    log("Starting sync with", url);
+    const data = loadAllData();
+    if (data.settings) {
+      delete data.settings.syncServerUrl;
+      delete data.settings.syncRole;
+      delete data.settings.syncEnabled;
+      delete data.settings.llmToken;
+    }
+    const post = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data, (k, v) => (v instanceof Date ? v.toISOString() : v)),
+    });
+    if (!post.ok) throw new Error(`HTTP ${post.status}`);
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const incoming = await res.json();
+    saveAllData(incoming);
+    lastSyncTime = Date.now();
+    lastSyncError = null;
+    log("Sync successful");
+  } catch (err) {
+    console.error("Sync error", err);
+    lastSyncTime = Date.now();
+    lastSyncError = err.message || String(err);
+  }
+}
+
+export function startSyncTimer() {
+  if (syncTimer) clearInterval(syncTimer);
+  syncTimer = null;
+  if (syncEnabled && syncRole === "client" && syncServerUrl && syncInterval > 0) {
+    log("Sync timer started with interval", syncInterval, "minutes");
+    performSync();
+    syncTimer = setInterval(performSync, syncInterval * 60 * 1000);
+  }
+}
+
+export function setSyncRole(role) {
+  const newRole = role === "server" ? "server" : "client";
+  if (newRole === syncRole) return;
+  syncRole = newRole;
+  log("Sync role set to", syncRole);
+  startSyncTimer();
+}
+
+export function setSyncServerUrl(url) {
+  if (url && !/^https?:\/\//i.test(url)) {
+    url = "http://" + url;
+  }
+  const normalized = url ? url.replace(/\/$/, "") : "";
+  if (normalized === syncServerUrl) return;
+  syncServerUrl = normalized;
+  log("Sync server URL set to", syncServerUrl || "(none)");
+  startSyncTimer();
+}
+
+export function setSyncInterval(minutes) {
+  const val = Number(minutes) || 0;
+  if (val === syncInterval) return;
+  syncInterval = val;
+  log("Sync interval set to", syncInterval);
+  startSyncTimer();
+}
+
+export function setSyncEnabled(val) {
+  const enabled = Boolean(val);
+  if (enabled === syncEnabled) return;
+  syncEnabled = enabled;
+  log("Sync enabled set to", syncEnabled);
+  startSyncTimer();
+}
+
+export function setLlmUrl(url) {
+  llmUrl = url || "";
+  log("LLM URL set to", llmUrl || "(none)");
+}
+
+export function setLlmToken(token) {
+  llmToken = token || "";
+}
+
+export function setLlmModel(model) {
+  llmModel = model || "gpt-3.5-turbo";
+}


### PR DESCRIPTION
## Summary
- move DB initialization into `lib/db.js`
- extract sync logic to `lib/sync.js`
- manage SSE clients in `lib/sse.js`
- simplify `app.js` to configure routes and use new helpers

## Testing
- `npm install`
- `npm test` *(no tests present)*

------
https://chatgpt.com/codex/tasks/task_e_6883440d15c0832a810c4254a72b08b4