### PR TITLE
fix task modal input reset

### DIFF
--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -101,6 +101,15 @@ const TaskModal: React.FC<TaskModalProps> = ({
 
   const colorOptions = colorPalette;
 
+  const defaultCategory = React.useMemo(
+    () =>
+      defaultCategoryId ||
+      parentTask?.categoryId ||
+      categories[0]?.id ||
+      "",
+    [defaultCategoryId, parentTask?.categoryId, categories],
+  );
+
   useEffect(() => {
     if (!isOpen) return;
 
@@ -133,11 +142,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
         description: "",
         priority: defaultTaskPriority,
         color: defaultTaskColor,
-        categoryId:
-          defaultCategoryId ||
-          parentTask?.categoryId ||
-          categories[0]?.id ||
-          "",
+        categoryId: defaultCategory,
         parentId: parentTask?.id,
         dueDate: defaultDueDate,
         isRecurring: allowRecurring ? defaultIsRecurring : false,
@@ -158,16 +163,15 @@ const TaskModal: React.FC<TaskModalProps> = ({
   }, [
     isOpen,
     task,
-    categories,
-    parentTask,
-    defaultCategoryId,
+    parentTask?.id,
+    defaultCategory,
     defaultDueDate,
     defaultTaskPriority,
+    defaultTaskColor,
     defaultIsRecurring,
     allowRecurring,
     defaultStartTime,
     defaultEndTime,
-    colorPalette,
   ]);
 
   const handleSubmit = (e: React.FormEvent) => {


### PR DESCRIPTION
## Summary
- prevent TaskModal form from resetting on every change

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a33295ab58832a8ec31d9e1b673fc4