### PR TITLE
chore: format server TypeScript files

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -54,15 +54,17 @@ app.use("/api/llm", llmController);
 app.use(healthController);
 
 // Serve static files first (with correct MIME types)
-app.use(express.static(DIST_DIR, {
-  setHeaders: (res, path) => {
-    if (path.endsWith('.js')) {
-      res.setHeader('Content-Type', 'application/javascript');
-    } else if (path.endsWith('.webmanifest')) {
-      res.setHeader('Content-Type', 'application/manifest+json');
-    }
-  }
-}));
+app.use(
+  express.static(DIST_DIR, {
+    setHeaders: (res, path) => {
+      if (path.endsWith(".js")) {
+        res.setHeader("Content-Type", "application/javascript");
+      } else if (path.endsWith(".webmanifest")) {
+        res.setHeader("Content-Type", "application/manifest+json");
+      }
+    },
+  }),
+);
 
 // Frontend controller as fallback (only for routes without file extensions)
 app.use(frontendController);

--- a/server/controllers/frontend.ts
+++ b/server/controllers/frontend.ts
@@ -12,12 +12,14 @@ const DIST_DIR = path.join(__dirname, "..", "..");
 // Only serve index.html for routes that don't match static files
 router.get("*", (req, res) => {
   // Skip API routes, docs, and static files like .js, .css, .webmanifest, etc.
-  if (req.path.startsWith('/api') || 
-      req.path.startsWith('/docs') ||
-      req.path.includes('.')) {
-    return res.status(404).send('Not Found');
+  if (
+    req.path.startsWith("/api") ||
+    req.path.startsWith("/docs") ||
+    req.path.includes(".")
+  ) {
+    return res.status(404).send("Not Found");
   }
-  
+
   res.sendFile(path.join(DIST_DIR, "index.html"));
 });
 


### PR DESCRIPTION
## Summary
- format server Express app and frontend controller with Prettier

## Testing
- `npm run format:check`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ab4914466c832aa5fcc336cf33ab28