### PR TITLE
feat(server): load controllers dynamically

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -1,28 +1,7 @@
 import express from "express";
 import path from "path";
 import { fileURLToPath } from "url";
-import updatesController from "./controllers/updates.js";
-import dataController from "./controllers/data.js";
-import flashcardsController from "./controllers/flashcards.js";
-import decksController from "./controllers/decks.js";
-import recurringController from "./controllers/recurring.js";
-import habitsController from "./controllers/habits.js";
-import notesController from "./controllers/notes.js";
-import inventoryController from "./controllers/inventory.js";
-import allController from "./controllers/all.js";
-import settingsController from "./controllers/settings.js";
-import pomodoroController from "./controllers/pomodoro.js";
-import timersController from "./controllers/timers.js";
-import tripsController from "./controllers/trips.js";
-import workdaysController from "./controllers/workdays.js";
-import commutesController from "./controllers/commutes.js";
-import syncController from "./controllers/sync.js";
-import syncLogController from "./controllers/syncLog.js";
-import serverInfoController from "./controllers/serverInfo.js";
-import syncStatusController from "./controllers/syncStatus.js";
-import llmController from "./controllers/llm.js";
-import healthController from "./controllers/health.js";
-import frontendController from "./controllers/frontend.js";
+import controllers from "./controllers/index.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -31,27 +10,11 @@ const DIST_DIR = path.join(__dirname, "..", "dist");
 export const app = express();
 app.use(express.json());
 
-app.use("/api/updates", updatesController);
-app.use("/api/data", dataController);
-app.use("/api/flashcards", flashcardsController);
-app.use("/api/decks", decksController);
-app.use("/api/recurring", recurringController);
-app.use("/api/habits", habitsController);
-app.use("/api/notes", notesController);
-app.use("/api/inventory", inventoryController);
-app.use("/api/all", allController);
-app.use("/api/settings", settingsController);
-app.use("/api/pomodoro-sessions", pomodoroController);
-app.use("/api/timers", timersController);
-app.use("/api/trips", tripsController);
-app.use("/api/workdays", workdaysController);
-app.use("/api/commutes", commutesController);
-app.use("/api/sync", syncController);
-app.use("/api/sync-log", syncLogController);
-app.use("/api/serverInfo", serverInfoController);
-app.use("/api/sync-status", syncStatusController);
-app.use("/api/llm", llmController);
-app.use(healthController);
+const { frontend, ...routers } = controllers;
+
+for (const [route, router] of Object.entries(routers)) {
+  app.use(route, router);
+}
 
 // Serve static files first (with correct MIME types)
 app.use(
@@ -67,4 +30,4 @@ app.use(
 );
 
 // Frontend controller as fallback (only for routes without file extensions)
-app.use(frontendController);
+app.use(frontend);

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -1,0 +1,47 @@
+import updates from "./updates.js";
+import data from "./data.js";
+import flashcards from "./flashcards.js";
+import decks from "./decks.js";
+import recurring from "./recurring.js";
+import habits from "./habits.js";
+import notes from "./notes.js";
+import inventory from "./inventory.js";
+import all from "./all.js";
+import settings from "./settings.js";
+import pomodoro from "./pomodoro.js";
+import timers from "./timers.js";
+import trips from "./trips.js";
+import workdays from "./workdays.js";
+import commutes from "./commutes.js";
+import sync from "./sync.js";
+import syncLog from "./syncLog.js";
+import serverInfo from "./serverInfo.js";
+import syncStatus from "./syncStatus.js";
+import llm from "./llm.js";
+import health from "./health.js";
+import frontend from "./frontend.js";
+
+export default {
+  "/api/updates": updates,
+  "/api/data": data,
+  "/api/flashcards": flashcards,
+  "/api/decks": decks,
+  "/api/recurring": recurring,
+  "/api/habits": habits,
+  "/api/notes": notes,
+  "/api/inventory": inventory,
+  "/api/all": all,
+  "/api/settings": settings,
+  "/api/pomodoro-sessions": pomodoro,
+  "/api/timers": timers,
+  "/api/trips": trips,
+  "/api/workdays": workdays,
+  "/api/commutes": commutes,
+  "/api/sync": sync,
+  "/api/sync-log": syncLog,
+  "/api/serverInfo": serverInfo,
+  "/api/sync-status": syncStatus,
+  "/api/llm": llm,
+  "": health,
+  frontend,
+};


### PR DESCRIPTION
## Summary
- centralize controller exports with `server/controllers/index.ts`
- dynamically register API routers in `server/app.ts`

## Testing
- `npm run format`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aee37f5a14832a9c20b39d6941e951