### PR TITLE
refactor: centralize router registration

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -1,28 +1,7 @@
 import express from "express";
 import path from "path";
 import { fileURLToPath } from "url";
-import updatesController from "./controllers/updates.js";
-import dataController from "./controllers/data.js";
-import flashcardsController from "./controllers/flashcards.js";
-import decksController from "./controllers/decks.js";
-import recurringController from "./controllers/recurring.js";
-import habitsController from "./controllers/habits.js";
-import notesController from "./controllers/notes.js";
-import inventoryController from "./controllers/inventory.js";
-import allController from "./controllers/all.js";
-import settingsController from "./controllers/settings.js";
-import pomodoroController from "./controllers/pomodoro.js";
-import timersController from "./controllers/timers.js";
-import tripsController from "./controllers/trips.js";
-import workdaysController from "./controllers/workdays.js";
-import commutesController from "./controllers/commutes.js";
-import syncController from "./controllers/sync.js";
-import syncLogController from "./controllers/syncLog.js";
-import serverInfoController from "./controllers/serverInfo.js";
-import syncStatusController from "./controllers/syncStatus.js";
-import llmController from "./controllers/llm.js";
-import healthController from "./controllers/health.js";
-import frontendController from "./controllers/frontend.js";
+import routers, { frontendController } from "./controllers/index.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -31,27 +10,13 @@ const DIST_DIR = path.join(__dirname, "..", "dist");
 export const app = express();
 app.use(express.json());
 
-app.use("/api/updates", updatesController);
-app.use("/api/data", dataController);
-app.use("/api/flashcards", flashcardsController);
-app.use("/api/decks", decksController);
-app.use("/api/recurring", recurringController);
-app.use("/api/habits", habitsController);
-app.use("/api/notes", notesController);
-app.use("/api/inventory", inventoryController);
-app.use("/api/all", allController);
-app.use("/api/settings", settingsController);
-app.use("/api/pomodoro-sessions", pomodoroController);
-app.use("/api/timers", timersController);
-app.use("/api/trips", tripsController);
-app.use("/api/workdays", workdaysController);
-app.use("/api/commutes", commutesController);
-app.use("/api/sync", syncController);
-app.use("/api/sync-log", syncLogController);
-app.use("/api/serverInfo", serverInfoController);
-app.use("/api/sync-status", syncStatusController);
-app.use("/api/llm", llmController);
-app.use(healthController);
+for (const [route, router] of Object.entries(routers)) {
+  if (route === "/") {
+    app.use(router);
+  } else {
+    app.use(route, router);
+  }
+}
 
 // Serve static files first (with correct MIME types)
 app.use(

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -1,0 +1,49 @@
+import allController from "./all.js";
+import commutesController from "./commutes.js";
+import dataController from "./data.js";
+import decksController from "./decks.js";
+import flashcardsController from "./flashcards.js";
+import frontendController from "./frontend.js";
+import habitsController from "./habits.js";
+import healthController from "./health.js";
+import inventoryController from "./inventory.js";
+import llmController from "./llm.js";
+import notesController from "./notes.js";
+import pomodoroController from "./pomodoro.js";
+import recurringController from "./recurring.js";
+import serverInfoController from "./serverInfo.js";
+import settingsController from "./settings.js";
+import syncController from "./sync.js";
+import syncLogController from "./syncLog.js";
+import syncStatusController from "./syncStatus.js";
+import timersController from "./timers.js";
+import tripsController from "./trips.js";
+import updatesController from "./updates.js";
+import workdaysController from "./workdays.js";
+
+export const routers = {
+  "/api/updates": updatesController,
+  "/api/data": dataController,
+  "/api/flashcards": flashcardsController,
+  "/api/decks": decksController,
+  "/api/recurring": recurringController,
+  "/api/habits": habitsController,
+  "/api/notes": notesController,
+  "/api/inventory": inventoryController,
+  "/api/all": allController,
+  "/api/settings": settingsController,
+  "/api/pomodoro-sessions": pomodoroController,
+  "/api/timers": timersController,
+  "/api/trips": tripsController,
+  "/api/workdays": workdaysController,
+  "/api/commutes": commutesController,
+  "/api/sync": syncController,
+  "/api/sync-log": syncLogController,
+  "/api/serverInfo": serverInfoController,
+  "/api/sync-status": syncStatusController,
+  "/api/llm": llmController,
+  "/": healthController,
+};
+
+export { frontendController };
+export default routers;


### PR DESCRIPTION
## Summary
- add controllers index exporting all routers
- register controllers dynamically in app setup

## Testing
- `npm run format`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aee37f5a14832a9c20b39d6941e951