### PR TITLE
feat: centralize data update events

### DIFF
--- a/server/lib/events.ts
+++ b/server/lib/events.ts
@@ -1,0 +1,5 @@
+import { EventEmitter } from "node:events";
+
+const events = new EventEmitter();
+
+export default events;

--- a/server/lib/sse.ts
+++ b/server/lib/sse.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from "express";
+import events from "./events.js";
 
 const clients: Response[] = [];
 
@@ -14,3 +15,5 @@ export function notifyClients(): void {
   const msg = "data: update\n\n";
   clients.forEach((res) => res.write(msg));
 }
+
+events.on("data:updated", notifyClients);

--- a/server/services/dataService.ts
+++ b/server/services/dataService.ts
@@ -70,7 +70,7 @@ import {
   saveAllData as repoSaveAllData,
   dateReviver,
 } from "../repositories/dataRepository.js";
-import { notifyClients } from "../lib/sse.js";
+import events from "../lib/events.js";
 
 export {
   loadTasks,
@@ -95,75 +95,79 @@ export {
   dateReviver,
 };
 
+function emitUpdate(): void {
+  events.emit("data:updated");
+}
+
 export function saveTasks(tasks) {
   repoSaveTasks(tasks);
-  notifyClients();
+  emitUpdate();
 }
 export function saveCategories(categories) {
   repoSaveCategories(categories);
-  notifyClients();
+  emitUpdate();
 }
 export function saveNotes(notes) {
   repoSaveNotes(notes);
-  notifyClients();
+  emitUpdate();
 }
 export function saveRecurring(list) {
   repoSaveRecurring(list);
-  notifyClients();
+  emitUpdate();
 }
 export function saveHabits(list) {
   repoSaveHabits(list);
-  notifyClients();
+  emitUpdate();
 }
 export function saveData(data) {
   repoSaveData(data);
-  notifyClients();
+  emitUpdate();
 }
 export function saveFlashcards(cards) {
   repoSaveFlashcards(cards);
-  notifyClients();
+  emitUpdate();
 }
 export function saveDecks(decks) {
   repoSaveDecks(decks);
-  notifyClients();
+  emitUpdate();
 }
 export function saveSettings(settings) {
   repoSaveSettings(settings);
-  notifyClients();
+  emitUpdate();
 }
 export function savePomodoroSessions(list) {
   repoSavePomodoroSessions(list);
-  notifyClients();
+  emitUpdate();
 }
 export function saveTimers(list) {
   repoSaveTimers(list);
-  notifyClients();
+  emitUpdate();
 }
 export function saveTrips(list) {
   repoSaveTrips(list);
-  notifyClients();
+  emitUpdate();
 }
 export function saveWorkDays(list) {
   repoSaveWorkDays(list);
-  notifyClients();
+  emitUpdate();
 }
 export function saveCommutes(list) {
   repoSaveCommutes(list);
-  notifyClients();
+  emitUpdate();
 }
 export function saveItems(list) {
   repoSaveItems(list);
-  notifyClients();
+  emitUpdate();
 }
 export function saveItemCategories(list) {
   repoSaveItemCategories(list);
-  notifyClients();
+  emitUpdate();
 }
 export function saveItemTags(list) {
   repoSaveItemTags(list);
-  notifyClients();
+  emitUpdate();
 }
 export function saveAllData(data) {
   repoSaveAllData(data);
-  notifyClients();
+  emitUpdate();
 }

--- a/server/services/taskService.ts
+++ b/server/services/taskService.ts
@@ -13,8 +13,7 @@ import {
   UpdateTaskSchema,
   validateSchema,
 } from "../schemas/index.js";
-import { loadTasks, saveTasks } from "../repositories/tasksRepository.js";
-import { notifyClients } from "../lib/sse.js";
+import { loadTasks, saveTasks } from "./dataService.js";
 
 // Service error classes
 export class TaskServiceError extends Error {
@@ -227,9 +226,6 @@ export class TaskService {
 
       saveTasks(tasks);
 
-      // Notify clients
-      notifyClients();
-
       return newTask;
     } catch (error) {
       if (error instanceof TaskServiceError) {
@@ -300,9 +296,6 @@ export class TaskService {
       this.updateTaskRecursive(tasks, taskId, updatedTask);
       saveTasks(tasks);
 
-      // Notify clients
-      notifyClients();
-
       return updatedTask;
     } catch (error) {
       if (error instanceof TaskServiceError) {
@@ -327,9 +320,6 @@ export class TaskService {
       const tasks = loadTasks();
       const filtered = this.removeTaskRecursive(tasks, taskId);
       saveTasks(filtered);
-
-      // Notify clients
-      notifyClients();
     } catch (error) {
       if (error instanceof TaskServiceError) {
         throw error;


### PR DESCRIPTION
## Summary
- add shared EventEmitter for server components
- emit `data:updated` events from data and task services instead of direct SSE calls
- notify SSE clients when `data:updated` is emitted
- route task service writes through data service to reuse event emitter

## Testing
- `npm run format`
- `npm run format:check`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b0164c4540832a985c36402af3c166